### PR TITLE
Reintroduce rtk token-optimization guidance into the AI corpus

### DIFF
--- a/.ai/hooks/pre-commit.md
+++ b/.ai/hooks/pre-commit.md
@@ -4,17 +4,17 @@ lifecycle: pre-commit
 
 # Pre-commit — Run Specs
 
-> **This is lifecycle guidance, not a wired tool hook.** To *enforce* it, wire it per tool — Claude Code: a `PreToolUse` hook in `.claude/settings.json` with a matcher on `Bash` (or your terminal tool) gating `git commit`; GitHub Copilot: a hook in a `.github/hooks/*.json` file. The steps below are what that hook (or the agent) should do.
+> **This is lifecycle guidance, not a wired tool hook.** To *enforce* it, wire it per tool — Claude Code: a `PreToolUse` hook in `.claude/settings.json` with a matcher on `Bash` (or your terminal tool) gating `git commit` (and its rtk-rewritten `rtk git commit` form — see [rtk](../rules/rtk.md)); GitHub Copilot: a hook in a `.github/hooks/*.json` file. The steps below are what that hook (or the agent) should do.
 
 Before executing any `git commit` terminal command, automatically run the specs for every affected project to ensure nothing is broken before changes are recorded in version control.
 
 ## When this hook applies
 
-This guidance applies before any `git commit` (including `git commit -m`, `git commit --amend`, etc.). If the command being run is not a commit, do nothing and proceed.
+This guidance applies before any `git commit` (including `git commit -m`, `git commit --amend`, etc.) — and equally to the rtk-rewritten `rtk git commit ...`, since the rtk hook prefixes terminal commands. If the command being run is not a commit, do nothing and proceed.
 
 ## Steps
 
-1. **Detect a git commit command** — inspect the terminal command string for `git commit ...`. If it does not match, skip all steps below and proceed normally.
+1. **Detect a git commit command** — inspect the terminal command string for `git commit ...` (treat the rtk-rewritten `rtk git commit ...` as the same thing, since the rtk hook prefixes commands). If it does not match, skip all steps below and proceed normally.
 
 2. **Identify affected projects** from the staged changes:
    ```

--- a/.ai/hooks/scripts/validate-ai-setup.sh
+++ b/.ai/hooks/scripts/validate-ai-setup.sh
@@ -142,9 +142,6 @@ fi
 if grep -rniE 'custom exception to signal|framework converts it to (an? )?(error|failed)' .ai/rules .ai/skills .ai/prompts 2>/dev/null | grep -q .; then
     warn "stale business-rule guidance — return ValidationResult/Result<,>, not a thrown exception"
 fi
-if grep -rniE '\brtk\b' .ai/rules .ai/skills .ai/agents .ai/prompts 2>/dev/null | grep -q .; then
-    warn "rtk reference found — rtk was dropped from this corpus"
-fi
 
 if [[ "$failed" -ne 0 ]]; then
     printf 'AI corpus validation FAILED.\n' >&2

--- a/.ai/rules/rtk.md
+++ b/.ai/rules/rtk.md
@@ -1,0 +1,37 @@
+---
+applyTo: "**/*"
+description: "Use when running any shell command, reading files, or searching code. Route every command rtk supports through rtk (a hook auto-rewrites Bash commands); call rtk read/grep/find directly because the built-in Read/Grep/Glob tools bypass that hook."
+---
+
+# Using rtk (Token-Optimized Commands)
+
+[rtk](https://github.com/rtk-ai/rtk) (Rust Token Killer) is a CLI proxy that filters and compresses command output *before it reaches the model* — typically **60–90% fewer tokens** on common dev commands, with no loss of the signal you actually need. The default in this corpus is to **run every command rtk supports through rtk**. The savings are real and compound across a session: build, test, lint, git, search, and file-read output are exactly the high-volume, low-signal outputs rtk trims.
+
+## How it works — let the hook do its job
+
+A `PreToolUse` hook **auto-rewrites Bash commands** to their `rtk` equivalent transparently and at zero token overhead (`git status` → `rtk git status`). For any supported command you do **nothing special** — run it normally and the hook wraps it.
+
+- **Never bypass it.** Don't disable the hook, and reserve `rtk proxy <cmd>` for the rare case where you genuinely need the raw, unfiltered output (e.g. debugging what a filter dropped).
+- **Audit coverage** with `rtk gain` (savings so far) and `rtk discover` (commands that slipped past rtk — missed opportunities to close).
+
+## What rtk supports (route these through rtk)
+
+- **Files** — `ls`, `tree`, `read`, `find`, `grep`, `diff`
+- **Git & GitHub** — `git status/log/diff/add/commit/push/pull`, `gh pr/issue/run …`
+- **Tests** — `dotnet test`, Jest, Vitest, Playwright, pytest, Go, Cargo, RSpec
+- **Build & lint** — `dotnet build`, `tsc`, ESLint, Biome, Prettier, Cargo Clippy, Ruff, golangci-lint, Rubocop
+- **Package managers** — pnpm/npm/yarn, pip, Bundler, Prisma
+- **Cloud & containers** — AWS CLI, Docker, Kubernetes, OpenShift
+
+In practice this means the Cratis **quality-gate commands** — `dotnet build`, `dotnet test`, `yarn lint`, `npx tsc -b`, `git`, `gh` — all flow through rtk automatically. Just run them.
+
+## The one gap — built-in tools bypass the hook
+
+The hook only sees **Bash** commands. Claude Code's built-in `Read`, `Grep`, and `Glob` tools (and the Copilot equivalents) do **not** pass through it, so they are **not** auto-rewritten — and those are some of the most token-heavy operations in a session.
+
+- For **bulk reads and broad searches** where output volume is large, call **`rtk read` / `rtk grep` / `rtk find`** from the terminal so the savings are captured. This is a deliberate override of the usual "prefer the built-in file tools" default.
+- Keep the **built-in** `Read`/`Grep`/`Glob` for **small, targeted reads** and when you need exact line references for an edit — rtk filters output, so it serves exploration and volume, not the precise content an `Edit` must match verbatim.
+
+## Availability
+
+This assumes the `rtk` binary is installed and the hook configured (`rtk init -g`). If `rtk` is **not** on `PATH`, ignore this rule and use the normal tools — never block work on rtk being present.

--- a/.claude/rules/rtk.md
+++ b/.claude/rules/rtk.md
@@ -1,0 +1,1 @@
+../../.ai/rules/rtk.md

--- a/.github/instructions/rtk.instructions.md
+++ b/.github/instructions/rtk.instructions.md
@@ -1,0 +1,1 @@
+../../.ai/rules/rtk.md

--- a/Documentation/instructions.md
+++ b/Documentation/instructions.md
@@ -105,7 +105,7 @@ Currently guarded files:
 | `orleans.instructions.md` | `"**/*.cs"` ⚠️ Orleans only | Orleans grain, storage provider, clustering conventions |
 | `pull-requests.instructions.md` | `"**/*"` | PR description and label conventions |
 | `git-commits.instructions.md` | `"**/*"` | Commit message format and staging discipline |
-| `terminal-commands.instructions.md` | `"**/*"` | RTK token-optimized terminal commands |
+| `rtk.instructions.md` | `"**/*"` | Using rtk for token-optimized commands |
 | `web-fetching.instructions.md` | `"**/*"` | Prefer `curl` for raw remote content |
 
 ---


### PR DESCRIPTION
# Summary

Reintroduces rtk (Rust Token Killer) guidance into the shared AI corpus. rtk is a CLI proxy that filters and compresses command output before it reaches the model, cutting roughly 60–90% of tokens on common dev commands. A PreToolUse hook auto-rewrites Bash commands transparently; the rule additionally directs agents to reach for `rtk read`/`rtk grep`/`rtk find` for the file and search operations that bypass that hook through the built-in tools. It degrades gracefully when rtk is not installed.

## Added

- rtk rule covering token-optimized command usage, wired to GitHub Copilot and Claude Code.

## Changed

- Pre-commit hook guidance now recognizes the rtk-rewritten `rtk git commit`, so the spec-run gate keeps firing.
- Instruction inventory references the rtk rule in place of the removed terminal-commands entry.

## Removed

- Validator drift guard that flagged any rtk reference as "dropped from this corpus".
