### PR TITLE
Fix the Planner image failing to start a silo

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,6 +21,15 @@
     <PackageVersion Include="Cratis.Chronicle.Testing" Version="16.19.2" />
     <PackageVersion Include="Cratis.Chronicle.XUnit.Integration" Version="16.19.2" />
     <!-- Microsoft Orleans -->
+    <!--
+      Orleans.Providers.MongoDB has no Orleans 10 release - 9.5.0 is the newest - and it pulls in
+      Microsoft.Orleans.Reminders 9.0.1. Microsoft.Orleans.Server no longer includes Reminders as of
+      Orleans 10, so nothing lifts that transitive reference and a 9.x Orleans.Reminders.dll lands
+      next to the 10.x Orleans.Runtime.dll. The 9.x LocalReminderService then calls a GrainService
+      constructor that no longer exists and the silo dies with a MissingMethodException. Referencing
+      Microsoft.Orleans.Reminders explicitly at 10.2.2 keeps the whole Orleans surface on 10.x.
+    -->
+    <PackageVersion Include="Microsoft.Orleans.Reminders" Version="10.2.2" />
     <PackageVersion Include="Microsoft.Orleans.Sdk" Version="10.2.2" />
     <PackageVersion Include="Microsoft.Orleans.Server" Version="10.2.2" />
     <PackageVersion Include="Microsoft.Orleans.Serialization.SystemTextJson" Version="10.2.2" />

--- a/Documentation/Planner/configuration.md
+++ b/Documentation/Planner/configuration.md
@@ -76,12 +76,20 @@ to your accounts' real experience.
 | `DockerEndpoint` | *(auto)* | Explicit Docker daemon endpoint; defaults to `DOCKER_HOST` / the platform socket |
 | `KubernetesNamespace` | `default` | The namespace worker jobs are created in |
 
-## Orleans - `Orleans`
+## Orleans - `Planner:Orleans`
 
 | Key | Default | Purpose |
 | --- | --- | --- |
 | `Enabled` | `true` | Co-hosts the Orleans silo (scheduler + consolidation grains) |
 | `Clustering` | `Localhost` | `Localhost` (single instance, in-memory reminders) or `MongoDB` (durable clustering and reminders for multiple instances) |
+
+An unrecognized `Clustering` value fails startup rather than quietly falling
+back to `Localhost`.
+
+> These live under `Planner:Orleans`, **not** under `Orleans`. The `Orleans` section belongs to
+> Orleans itself, which binds it and reads `Orleans:Clustering` as the name of a registered
+> clustering *provider* - putting the Planner's own value there makes the silo fail to build with
+> `Could not find Clustering provider named 'Default'`.
 
 ## Claude accounts
 

--- a/Documentation/Planner/running-in-the-cloud.md
+++ b/Documentation/Planner/running-in-the-cloud.md
@@ -42,7 +42,7 @@ env:
     value: Kubernetes
   - name: ContainerRuntime__KubernetesNamespace
     value: planner-workers
-  - name: Orleans__Clustering
+  - name: Planner__Orleans__Clustering
     value: MongoDB
 ```
 
@@ -59,9 +59,12 @@ env:
   ```
 
 - `Planner:Worker:CallbackBaseUrl` must resolve from inside worker pods to the Planner service.
-- With `Orleans:Clustering=MongoDB`, clustering and reminders are durable in the
+- With `Planner:Orleans:Clustering=MongoDB`, clustering and reminders are durable in the
   `planner-orleans` database, so multiple replicas form one cluster and the scheduler/consolidation
-  grains keep running across restarts. A single replica can stay on `Localhost` clustering.
+  grains keep running across restarts. A single replica can stay on `Localhost` clustering, but its
+  reminders are in-memory and start over on every restart. The key deliberately sits under
+  `Planner:`, not under `Orleans:` - that section belongs to Orleans, which reads
+  `Orleans:Clustering` as the name of a clustering provider it must resolve.
 
 ## Webhooks
 

--- a/Source/Planner/Hosting/ClusteringMode.cs
+++ b/Source/Planner/Hosting/ClusteringMode.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Planner.Hosting;
+
+/// <summary>
+/// Represents how the co-hosted silo discovers its cluster and where it keeps its reminders.
+/// </summary>
+public enum ClusteringMode
+{
+    /// <summary>
+    /// A single silo on localhost with in-memory reminders - for local development.
+    /// </summary>
+    Localhost = 0,
+
+    /// <summary>
+    /// MongoDB backed membership and reminders - for running more than one instance, and for
+    /// reminders that survive a restart.
+    /// </summary>
+    MongoDB = 1
+}

--- a/Source/Planner/Hosting/OrleansConfigurationExtensions.cs
+++ b/Source/Planner/Hosting/OrleansConfigurationExtensions.cs
@@ -12,8 +12,8 @@ namespace Planner.Hosting;
 /// </summary>
 /// <remarks>
 /// The Planner co-hosts a single silo in-process. Locally the silo uses localhost clustering with
-/// in-memory reminders; set <c>Orleans:Clustering</c> to <c>MongoDB</c> for durable clustering and
-/// reminders when running more than one instance - typically in Kubernetes.
+/// in-memory reminders; set <c>Planner:Orleans:Clustering</c> to <c>MongoDB</c> for durable
+/// clustering and reminders when running more than one instance - typically in Kubernetes.
 /// </remarks>
 public static class OrleansConfigurationExtensions
 {
@@ -23,18 +23,18 @@ public static class OrleansConfigurationExtensions
     public const string OrleansDatabaseName = "planner-orleans";
 
     /// <summary>
-    /// Adds the co-hosted Orleans silo, unless disabled through <c>Orleans:Enabled</c>.
+    /// Adds the co-hosted Orleans silo, unless disabled through <c>Planner:Orleans:Enabled</c>.
     /// </summary>
     /// <param name="builder">The <see cref="WebApplicationBuilder"/> to configure.</param>
     /// <returns>The same <see cref="WebApplicationBuilder"/> for chaining.</returns>
     public static WebApplicationBuilder AddPlannerOrleans(this WebApplicationBuilder builder)
     {
-        if (!builder.Configuration.GetValue("Orleans:Enabled", true))
+        var options = OrleansOptions.From(builder.Configuration);
+        if (!options.Enabled)
         {
             return builder;
         }
 
-        var useMongoClustering = builder.Configuration["Orleans:Clustering"] == "MongoDB";
         builder.Host.UseOrleans(silo =>
         {
             silo.Configure<ClusterOptions>(options =>
@@ -49,7 +49,7 @@ public static class OrleansConfigurationExtensions
             // failing startup on types this silo never serializes.
             silo.Services.Configure<TypeManifestOptions>(options => options.EnableConfigurationAnalysis = false);
 
-            if (useMongoClustering)
+            if (options.Clustering == ClusteringMode.MongoDB)
             {
                 var connectionString = builder.Configuration["Cratis:MongoDB:Server"] ?? "mongodb://localhost:27017";
                 silo.UseMongoDBClient(connectionString);

--- a/Source/Planner/Hosting/OrleansOptions.cs
+++ b/Source/Planner/Hosting/OrleansOptions.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Planner.Hosting;
+
+/// <summary>
+/// Represents the Planner's choices for the co-hosted Orleans silo, bound from the
+/// <c>Planner:Orleans</c> configuration section.
+/// </summary>
+/// <remarks>
+/// These deliberately do not live under the <c>Orleans</c> section: Orleans binds that section
+/// itself and reads <c>Orleans:Clustering</c> as the name of a registered clustering provider, so
+/// anything the Planner puts there collides with it and fails silo construction.
+/// </remarks>
+public class OrleansOptions
+{
+    /// <summary>
+    /// The configuration section name the options are bound from.
+    /// </summary>
+    public const string SectionName = "Planner:Orleans";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the co-hosted silo is started at all.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets how the silo discovers its cluster and where it keeps its reminders.
+    /// </summary>
+    public ClusteringMode Clustering { get; set; } = ClusteringMode.Localhost;
+
+    /// <summary>
+    /// Binds the options from configuration, falling back to the defaults when the section is absent.
+    /// </summary>
+    /// <param name="configuration">The <see cref="IConfiguration"/> to bind from.</param>
+    /// <returns>The bound <see cref="OrleansOptions"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when a configured value cannot be converted - an unknown clustering mode, for instance.</exception>
+    public static OrleansOptions From(IConfiguration configuration) =>
+        configuration.GetSection(SectionName).Get<OrleansOptions>() ?? new OrleansOptions();
+}

--- a/Source/Planner/Hosting/for_OrleansOptions/given/a_configuration.cs
+++ b/Source/Planner/Hosting/for_OrleansOptions/given/a_configuration.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+namespace Planner.Hosting.for_OrleansOptions.given;
+
+public class a_configuration : Specification
+{
+    protected Dictionary<string, string?> _values;
+
+    protected IConfiguration Configuration => new ConfigurationBuilder().AddInMemoryCollection(_values).Build();
+
+    void Establish() => _values = [];
+}
+#endif

--- a/Source/Planner/Hosting/for_OrleansOptions/when_binding_from_configuration/and_mongodb_clustering_is_configured.cs
+++ b/Source/Planner/Hosting/for_OrleansOptions/when_binding_from_configuration/and_mongodb_clustering_is_configured.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+namespace Planner.Hosting.for_OrleansOptions.when_binding_from_configuration;
+
+public class and_mongodb_clustering_is_configured : given.a_configuration
+{
+    OrleansOptions _options;
+
+    void Establish() => _values["Planner:Orleans:Clustering"] = "MongoDB";
+
+    void Because() => _options = OrleansOptions.From(Configuration);
+
+    [Fact] void should_enable_the_silo() => _options.Enabled.ShouldBeTrue();
+    [Fact] void should_cluster_on_mongodb() => _options.Clustering.ShouldEqual(ClusteringMode.MongoDB);
+}
+#endif

--- a/Source/Planner/Hosting/for_OrleansOptions/when_binding_from_configuration/and_nothing_is_configured.cs
+++ b/Source/Planner/Hosting/for_OrleansOptions/when_binding_from_configuration/and_nothing_is_configured.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+namespace Planner.Hosting.for_OrleansOptions.when_binding_from_configuration;
+
+public class and_nothing_is_configured : given.a_configuration
+{
+    OrleansOptions _options;
+
+    void Because() => _options = OrleansOptions.From(Configuration);
+
+    [Fact] void should_enable_the_silo() => _options.Enabled.ShouldBeTrue();
+    [Fact] void should_cluster_on_localhost() => _options.Clustering.ShouldEqual(ClusteringMode.Localhost);
+}
+#endif

--- a/Source/Planner/Hosting/for_OrleansOptions/when_binding_from_configuration/and_the_clustering_mode_is_unknown.cs
+++ b/Source/Planner/Hosting/for_OrleansOptions/when_binding_from_configuration/and_the_clustering_mode_is_unknown.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+namespace Planner.Hosting.for_OrleansOptions.when_binding_from_configuration;
+
+public class and_the_clustering_mode_is_unknown : given.a_configuration
+{
+    Exception _error;
+
+    void Establish() => _values["Planner:Orleans:Clustering"] = "Mongo";
+
+    void Because() => _error = Cratis.Specifications.Catch.Exception(() => OrleansOptions.From(Configuration));
+
+    [Fact] void should_fail_rather_than_silently_fall_back() => _error.ShouldNotBeNull();
+}
+#endif

--- a/Source/Planner/Hosting/for_OrleansOptions/when_binding_from_configuration/and_the_orleans_owned_section_is_configured.cs
+++ b/Source/Planner/Hosting/for_OrleansOptions/when_binding_from_configuration/and_the_orleans_owned_section_is_configured.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+namespace Planner.Hosting.for_OrleansOptions.when_binding_from_configuration;
+
+/// <summary>
+/// The <c>Orleans</c> section belongs to Orleans itself - it reads <c>Orleans:Clustering</c> as the
+/// name of a registered clustering provider. Nothing the Planner decides may be read from there.
+/// </summary>
+public class and_the_orleans_owned_section_is_configured : given.a_configuration
+{
+    OrleansOptions _options;
+
+    void Establish()
+    {
+        _values["Orleans:Clustering"] = "MongoDB";
+        _values["Orleans:Enabled"] = "false";
+    }
+
+    void Because() => _options = OrleansOptions.From(Configuration);
+
+    [Fact] void should_ignore_it_and_enable_the_silo() => _options.Enabled.ShouldBeTrue();
+    [Fact] void should_ignore_it_and_cluster_on_localhost() => _options.Clustering.ShouldEqual(ClusteringMode.Localhost);
+}
+#endif

--- a/Source/Planner/Hosting/for_OrleansOptions/when_binding_from_configuration/and_the_silo_is_disabled.cs
+++ b/Source/Planner/Hosting/for_OrleansOptions/when_binding_from_configuration/and_the_silo_is_disabled.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+namespace Planner.Hosting.for_OrleansOptions.when_binding_from_configuration;
+
+public class and_the_silo_is_disabled : given.a_configuration
+{
+    OrleansOptions _options;
+
+    void Establish() => _values["Planner:Orleans:Enabled"] = "false";
+
+    void Because() => _options = OrleansOptions.From(Configuration);
+
+    [Fact] void should_not_enable_the_silo() => _options.Enabled.ShouldBeFalse();
+}
+#endif

--- a/Source/Planner/Planner.csproj
+++ b/Source/Planner/Planner.csproj
@@ -22,6 +22,7 @@
         <PackageReference Include="KubernetesClient" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
         <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
+        <PackageReference Include="Microsoft.Orleans.Reminders" />
         <PackageReference Include="Microsoft.Orleans.Server" />
         <PackageReference Include="Orleans.Providers.MongoDB" />
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />

--- a/Source/Planner/appsettings.json
+++ b/Source/Planner/appsettings.json
@@ -13,10 +13,11 @@
             "Database": "Planner"
         }
     },
-    "Orleans": {
-        "Enabled": true
-    },
     "Planner": {
+        "Orleans": {
+            "Enabled": true,
+            "Clustering": "Localhost"
+        },
         "GitHub": {
             "ApiBaseUrl": "https://api.github.com"
         },


### PR DESCRIPTION
# Summary

The published `cratis/planner` image could not start at all - two independent
faults, one in the package graph and one in the configuration keys, each fatal
on its own.

## Changed

- The co-hosted silo now reads its options from `Planner:Orleans` instead of
  `Orleans`. Use `Planner__Orleans__Clustering=MongoDB` (was
  `Orleans__Clustering`) for durable clustering and reminders, and
  `Planner__Orleans__Enabled` (was `Orleans__Enabled`) to turn the silo off. The
  `Orleans` section belongs to Orleans, which binds it itself and reads
  `Orleans:Clustering` as the name of a clustering *provider* - so the old key
  could never work.
- An unrecognized clustering mode now fails startup instead of quietly falling
  back to localhost clustering.

## Fixed

- The Planner silo no longer dies on startup with
  `MissingMethodException: Orleans.Runtime.GrainService..ctor`. Orleans 10
  dropped `Microsoft.Orleans.Reminders` from the `Microsoft.Orleans.Server`
  metapackage, so the only thing pulling it in was `Orleans.Providers.MongoDB`
  9.5.0 - at 9.0.1, next to a 10.2.2 runtime. Every Orleans assembly is now on
  10.2.2.
- Turning on durable clustering no longer fails with
  `Could not find Clustering provider named 'Default'`.
