### PR TITLE
Consume Chronicle 16.19.3 — connection strings log redacted

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,12 +14,12 @@
     <PackageVersion Include="Cratis.Arc.OpenApi" Version="21.0.4" />
     <PackageVersion Include="Cratis.Arc.MongoDB" Version="21.0.4" />
     <PackageVersion Include="Cratis.Arc.Core" Version="21.0.4" />
-    <PackageVersion Include="Cratis.Chronicle" Version="16.19.2" />
-    <PackageVersion Include="Cratis.Chronicle.Aspire" Version="16.19.2" />
-    <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="16.19.2" />
-    <PackageVersion Include="Cratis.Chronicle.Contracts" Version="16.19.2" />
-    <PackageVersion Include="Cratis.Chronicle.Testing" Version="16.19.2" />
-    <PackageVersion Include="Cratis.Chronicle.XUnit.Integration" Version="16.19.2" />
+    <PackageVersion Include="Cratis.Chronicle" Version="16.19.3" />
+    <PackageVersion Include="Cratis.Chronicle.Aspire" Version="16.19.3" />
+    <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="16.19.3" />
+    <PackageVersion Include="Cratis.Chronicle.Contracts" Version="16.19.3" />
+    <PackageVersion Include="Cratis.Chronicle.Testing" Version="16.19.3" />
+    <PackageVersion Include="Cratis.Chronicle.XUnit.Integration" Version="16.19.3" />
     <!-- Microsoft Orleans -->
     <!--
       Orleans.Providers.MongoDB has no Orleans 10 release - 9.5.0 is the newest - and it pulls in


### PR DESCRIPTION
## Security

- Chronicle client **16.19.3**: connection strings are logged with credentials masked. The Planner previously wrote its Chronicle client secret to the production log pipeline at Information level on every connect and reconnect.

Verified: Release build zero warnings/errors, 200 specs pass.