### PR TITLE
Reference Cratis.Chronicle directly so the central pin applies

### DIFF
--- a/Source/Planner/Planner.csproj
+++ b/Source/Planner/Planner.csproj
@@ -18,6 +18,10 @@
         <PackageReference Include="Cratis" />
         <PackageReference Include="Cratis.Arc.Core" />
         <PackageReference Include="Cratis.Arc.MongoDB" />
+        <!-- Direct reference so the central Cratis.Chronicle pin actually applies: without it the
+             client resolves transitively through Cratis.Arc.Chronicle and central package management
+             does not pin transitives, which quietly held the client at whatever Arc referenced. -->
+        <PackageReference Include="Cratis.Chronicle" />
         <PackageReference Include="Docker.DotNet.Enhanced" />
         <PackageReference Include="KubernetesClient" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" />


### PR DESCRIPTION
## Security

- The 16.19.3 bump in #39 never reached the shipped image: `Cratis.Chronicle` resolved transitively through `Cratis.Arc.Chronicle`, and central package management does not pin transitives — so `0.0.4` still carried 16.19.2 and still logged the client secret. A direct reference makes the central pin the resolved version, **verified in the publish output's `deps.json`** (16.19.3), which is what actually ships.