### PR TITLE
Stop the Planner's reminders from going through the 9.x MongoDB Orleans provider

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,6 +33,11 @@
     <PackageVersion Include="Microsoft.Orleans.Sdk" Version="10.2.2" />
     <PackageVersion Include="Microsoft.Orleans.Server" Version="10.2.2" />
     <PackageVersion Include="Microsoft.Orleans.Serialization.SystemTextJson" Version="10.2.2" />
+    <!--
+      Used for cluster membership only. Its reminder table is a 9.x binary the 10.x reminder service
+      hangs on - see Planner.Hosting.OrleansConfigurationExtensions. Cratis Studio runs this same
+      package pair in production, membership-only, which is the arrangement proven to be stable.
+    -->
     <PackageVersion Include="Orleans.Providers.MongoDB" Version="9.5.0" />
     <!-- Containers -->
     <PackageVersion Include="Docker.DotNet.Enhanced" Version="4.3.3" />

--- a/Documentation/Planner/configuration.md
+++ b/Documentation/Planner/configuration.md
@@ -81,10 +81,16 @@ to your accounts' real experience.
 | Key | Default | Purpose |
 | --- | --- | --- |
 | `Enabled` | `true` | Co-hosts the Orleans silo (scheduler + consolidation grains) |
-| `Clustering` | `Localhost` | `Localhost` (single instance, in-memory reminders) or `MongoDB` (durable clustering and reminders for multiple instances) |
+| `Clustering` | `Localhost` | `Localhost` (single instance) or `MongoDB` (shared cluster membership for multiple instances) |
 
 An unrecognized `Clustering` value fails startup rather than quietly falling
 back to `Localhost`.
+
+`Clustering` picks the **membership** provider only. Reminders always come from Orleans' in-memory
+reminder service, in both modes: the MongoDB provider is a 9.x binary and its reminder table hangs
+the 10.x reminder service outright, so the Planner uses it for membership and nothing else. The
+practical consequence is that reminders do not survive a full cluster restart - which costs nothing,
+because the Planner re-registers both recurring reminders on every start.
 
 > These live under `Planner:Orleans`, **not** under `Orleans`. The `Orleans` section belongs to
 > Orleans itself, which binds it and reads `Orleans:Clustering` as the name of a registered

--- a/Documentation/Planner/github-app-setup.md
+++ b/Documentation/Planner/github-app-setup.md
@@ -28,6 +28,12 @@ deliveries.
    [Running in the cloud](./running-in-the-cloud.md)) - then restart the Planner. Credentials are
    shown once; if you lose them, delete the App on GitHub and register a new one.
 
+Every URL in the manifest - the redirect back to `/github-app/created`, the setup URL, and the
+webhook - is built from the origin **your browser** reached `/github-app/start` on. Behind a reverse
+proxy that origin comes from `X-Forwarded-Proto` and `X-Forwarded-Host`, so the ingress has to
+forward them; without them GitHub gets the Planner's internal address and sends you somewhere your
+browser cannot go.
+
 The manifest requests exactly what the Planner needs and nothing more:
 
 | Permission | Access | Used for |

--- a/Documentation/Planner/running-in-the-cloud.md
+++ b/Documentation/Planner/running-in-the-cloud.md
@@ -58,13 +58,20 @@ env:
       verbs: ["create"]
   ```
 
-- `Planner:Worker:CallbackBaseUrl` must resolve from inside worker pods to the Planner service.
-- With `Planner:Orleans:Clustering=MongoDB`, clustering and reminders are durable in the
-  `planner-orleans` database, so multiple replicas form one cluster and the scheduler/consolidation
-  grains keep running across restarts. A single replica can stay on `Localhost` clustering, but its
-  reminders are in-memory and start over on every restart. The key deliberately sits under
-  `Planner:`, not under `Orleans:` - that section belongs to Orleans, which reads
-  `Orleans:Clustering` as the name of a clustering provider it must resolve.
+- `Planner:Worker:CallbackBaseUrl` must resolve from inside worker pods to the Planner service. It is
+  an in-cluster address and is used for worker callbacks only - never for anything a browser has to
+  reach. The GitHub App manifest, for instance, derives its URLs from the request the operator's
+  browser arrived on (honoring `X-Forwarded-Proto` / `X-Forwarded-Host`), so the ingress must forward
+  those headers.
+- With `Planner:Orleans:Clustering=MongoDB`, cluster membership is durable in the `planner-orleans`
+  database, so multiple replicas form one cluster. Reminders are in-memory in both modes and are
+  re-registered on every start (see [Configuration](./configuration.md#orleans---plannerorleans)).
+  The key deliberately sits under `Planner:`, not under `Orleans:` - that section belongs to Orleans,
+  which reads `Orleans:Clustering` as the name of a clustering provider it must resolve.
+- Set `DOTNET_DbgEnableMiniDump=1` (and `DOTNET_DbgMiniDumpType=4`, with `DOTNET_DbgMiniDumpName`
+  pointing at a mounted path) when investigating a silent native crash. A container that dies with
+  exit 139 and no log output leaves nothing to attach a stack to otherwise; the dump is the only
+  artifact that turns one into a diagnosable failure.
 
 ## Webhooks
 

--- a/Source/Planner/GitHub/App/GitHubAppEndpoints.cs
+++ b/Source/Planner/GitHub/App/GitHubAppEndpoints.cs
@@ -3,9 +3,7 @@
 
 using System.Net;
 using System.Text.Json.Nodes;
-using Microsoft.Extensions.Options;
 using Planner.GitHub.App.Installations;
-using Planner.Work.Workers;
 
 namespace Planner.GitHub.App;
 
@@ -22,9 +20,12 @@ public static class GitHubAppEndpoints
     /// <returns>The same <see cref="WebApplication"/> for chaining.</returns>
     public static WebApplication MapGitHubAppEndpoints(this WebApplication app)
     {
-        app.MapGet("/github-app/start", (IOptions<WorkerOptions> workerOptions) =>
+        // The manifest is built from the origin this request came in on, never from a configured
+        // address: every URL in it is one GitHub sends the operator's browser to, and the Planner's
+        // configured worker callback URL is an in-cluster name no browser can resolve.
+        app.MapGet("/github-app/start", (HttpRequest request) =>
         {
-            var manifest = GitHubAppManifest.Build(workerOptions.Value.CallbackBaseUrl);
+            var manifest = GitHubAppManifest.Build(RequestOrigin.From(request));
             return Results.Content(SelfSubmittingManifestForm(manifest), "text/html");
         });
 

--- a/Source/Planner/GitHub/App/GitHubAppManifest.cs
+++ b/Source/Planner/GitHub/App/GitHubAppManifest.cs
@@ -27,11 +27,16 @@ public static class GitHubAppManifest
     /// <summary>
     /// Builds the manifest JSON for registering the Planner as a GitHub App.
     /// </summary>
-    /// <param name="callbackBaseUrl">The Planner's own publicly reachable base URL.</param>
+    /// <param name="publicBaseUrl">
+    /// The Planner's publicly reachable base URL - resolve it from the incoming request with
+    /// <see cref="RequestOrigin.From(HttpRequest)"/>. GitHub redirects the operator's browser to the
+    /// registration and setup URLs built from it, and delivers webhooks to the hook URL, so an
+    /// address only reachable from inside the cluster breaks the whole flow.
+    /// </param>
     /// <returns>The manifest as a JSON string.</returns>
-    public static string Build(string callbackBaseUrl)
+    public static string Build(string publicBaseUrl)
     {
-        var baseUrl = callbackBaseUrl.TrimEnd('/');
+        var baseUrl = publicBaseUrl.TrimEnd('/');
         var manifest = new JsonObject
         {
             ["name"] = "Cratis Planner",

--- a/Source/Planner/GitHub/App/RequestOrigin.cs
+++ b/Source/Planner/GitHub/App/RequestOrigin.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Primitives;
+
+namespace Planner.GitHub.App;
+
+/// <summary>
+/// Resolves the publicly reachable origin a request actually arrived on.
+/// </summary>
+/// <remarks>
+/// GitHub sends the operator's browser to whatever URLs the App manifest carries, so those have to be
+/// addresses a browser outside the cluster can reach. The Planner's own configured addresses are not:
+/// the worker callback URL is an in-cluster service name (<c>http://planner</c>), and behind a reverse
+/// proxy the request's own scheme and host are the internal ones too. What the browser asked for is
+/// recorded by the proxy in <c>X-Forwarded-Proto</c> and <c>X-Forwarded-Host</c>, so those win when
+/// present and the request's own values are the fallback for a direct hit.
+/// </remarks>
+public static class RequestOrigin
+{
+    /// <summary>
+    /// The header a reverse proxy records the client's scheme in.
+    /// </summary>
+    public const string ForwardedProtoHeader = "X-Forwarded-Proto";
+
+    /// <summary>
+    /// The header a reverse proxy records the client's host in.
+    /// </summary>
+    public const string ForwardedHostHeader = "X-Forwarded-Host";
+
+    /// <summary>
+    /// Resolves the scheme and host the client reached the Planner on.
+    /// </summary>
+    /// <param name="request">The <see cref="HttpRequest"/> to resolve from.</param>
+    /// <returns>The origin as <c>scheme://host</c>, with no trailing slash.</returns>
+    public static string From(HttpRequest request)
+    {
+        var scheme = Forwarded(request.Headers[ForwardedProtoHeader]) ?? request.Scheme;
+        var host = Forwarded(request.Headers[ForwardedHostHeader]) ?? request.Host.Value;
+
+        return $"{scheme}://{host}";
+    }
+
+    /// <summary>
+    /// Reads the client-facing value out of a forwarding header. A request that passed through several
+    /// proxies carries one entry per hop, oldest first - the client's own value is the first one.
+    /// </summary>
+    /// <param name="values">The header values to read.</param>
+    /// <returns>The client-facing value, or <see langword="null"/> when the header carries nothing usable.</returns>
+    static string? Forwarded(StringValues values)
+    {
+        var header = values.ToString();
+        if (string.IsNullOrWhiteSpace(header))
+        {
+            return null;
+        }
+
+        var first = header.Split(',')[0].Trim();
+
+        return string.IsNullOrEmpty(first) ? null : first;
+    }
+}

--- a/Source/Planner/GitHub/App/for_GitHubAppManifest/when_building_the_manifest/and_the_url_comes_from_a_proxied_request.cs
+++ b/Source/Planner/GitHub/App/for_GitHubAppManifest/when_building_the_manifest/and_the_url_comes_from_a_proxied_request.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using System.Text.Json.Nodes;
+using Microsoft.AspNetCore.Http;
+
+namespace Planner.GitHub.App.for_GitHubAppManifest.when_building_the_manifest;
+
+/// <summary>
+/// Every URL in the manifest is one GitHub sends the operator's browser to, so they have to carry the
+/// origin the browser actually used - not the in-cluster address the Planner is reached on internally.
+/// </summary>
+public class and_the_url_comes_from_a_proxied_request : Specification
+{
+    JsonObject _manifest;
+
+    void Because()
+    {
+        var request = new DefaultHttpContext().Request;
+        request.Scheme = "http";
+        request.Host = new HostString("planner");
+        request.Headers[RequestOrigin.ForwardedProtoHeader] = "https";
+        request.Headers[RequestOrigin.ForwardedHostHeader] = "planner.cratis.io";
+
+        _manifest = JsonNode.Parse(GitHubAppManifest.Build(RequestOrigin.From(request))) as JsonObject;
+    }
+
+    [Fact]
+    void should_redirect_the_browser_back_to_the_public_origin() =>
+        _manifest["redirect_url"]!.GetValue<string>().ShouldEqual("https://planner.cratis.io/github-app/created");
+
+    [Fact]
+    void should_send_the_operator_to_the_public_origin_after_installing() =>
+        _manifest["setup_url"]!.GetValue<string>().ShouldEqual("https://planner.cratis.io/github-app/installed");
+
+    [Fact]
+    void should_point_the_webhook_at_the_public_origin() =>
+        _manifest["hook_attributes"]!["url"]!.GetValue<string>().ShouldEqual("https://planner.cratis.io/webhooks/github");
+
+    [Fact]
+    void should_present_the_public_origin_as_the_app_url() =>
+        _manifest["url"]!.GetValue<string>().ShouldEqual("https://planner.cratis.io");
+}
+#endif

--- a/Source/Planner/GitHub/App/for_RequestOrigin/when_resolving_the_origin/and_the_request_came_straight_to_the_planner.cs
+++ b/Source/Planner/GitHub/App/for_RequestOrigin/when_resolving_the_origin/and_the_request_came_straight_to_the_planner.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Microsoft.AspNetCore.Http;
+
+namespace Planner.GitHub.App.for_RequestOrigin.when_resolving_the_origin;
+
+public class and_the_request_came_straight_to_the_planner : Specification
+{
+    HttpRequest _request;
+    string _result;
+
+    void Establish()
+    {
+        _request = new DefaultHttpContext().Request;
+        _request.Scheme = "http";
+        _request.Host = new HostString("localhost", 5200);
+    }
+
+    void Because() => _result = RequestOrigin.From(_request);
+
+    [Fact]
+    void should_use_the_requests_own_scheme_and_host() => _result.ShouldEqual("http://localhost:5200");
+}
+#endif

--- a/Source/Planner/GitHub/App/for_RequestOrigin/when_resolving_the_origin/and_the_request_came_through_a_reverse_proxy.cs
+++ b/Source/Planner/GitHub/App/for_RequestOrigin/when_resolving_the_origin/and_the_request_came_through_a_reverse_proxy.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Microsoft.AspNetCore.Http;
+
+namespace Planner.GitHub.App.for_RequestOrigin.when_resolving_the_origin;
+
+public class and_the_request_came_through_a_reverse_proxy : Specification
+{
+    HttpRequest _request;
+    string _result;
+
+    void Establish()
+    {
+        _request = new DefaultHttpContext().Request;
+        _request.Scheme = "http";
+        _request.Host = new HostString("planner");
+        _request.Headers[RequestOrigin.ForwardedProtoHeader] = "https";
+        _request.Headers[RequestOrigin.ForwardedHostHeader] = "planner.cratis.io";
+    }
+
+    void Because() => _result = RequestOrigin.From(_request);
+
+    [Fact]
+    void should_use_the_origin_the_client_reached_the_proxy_on() =>
+        _result.ShouldEqual("https://planner.cratis.io");
+}
+#endif

--- a/Source/Planner/GitHub/App/for_RequestOrigin/when_resolving_the_origin/and_the_request_came_through_several_proxies.cs
+++ b/Source/Planner/GitHub/App/for_RequestOrigin/when_resolving_the_origin/and_the_request_came_through_several_proxies.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Microsoft.AspNetCore.Http;
+
+namespace Planner.GitHub.App.for_RequestOrigin.when_resolving_the_origin;
+
+public class and_the_request_came_through_several_proxies : Specification
+{
+    HttpRequest _request;
+    string _result;
+
+    void Establish()
+    {
+        _request = new DefaultHttpContext().Request;
+        _request.Scheme = "http";
+        _request.Host = new HostString("planner");
+        _request.Headers[RequestOrigin.ForwardedProtoHeader] = "https, http";
+        _request.Headers[RequestOrigin.ForwardedHostHeader] = "planner.cratis.io, ingress.internal";
+    }
+
+    void Because() => _result = RequestOrigin.From(_request);
+
+    [Fact]
+    void should_use_the_first_hop_which_is_the_one_facing_the_client() =>
+        _result.ShouldEqual("https://planner.cratis.io");
+}
+#endif

--- a/Source/Planner/Hosting/ClusteringMode.cs
+++ b/Source/Planner/Hosting/ClusteringMode.cs
@@ -4,18 +4,22 @@
 namespace Planner.Hosting;
 
 /// <summary>
-/// Represents how the co-hosted silo discovers its cluster and where it keeps its reminders.
+/// Represents how the co-hosted silo discovers its cluster.
 /// </summary>
+/// <remarks>
+/// The mode picks the membership provider only. Reminders are always kept by Orleans' in-memory
+/// reminder service, in both modes - see <see cref="OrleansConfigurationExtensions.AddPlannerOrleans"/>
+/// for why the MongoDB reminder table is not an option.
+/// </remarks>
 public enum ClusteringMode
 {
     /// <summary>
-    /// A single silo on localhost with in-memory reminders - for local development.
+    /// A single silo on localhost - for local development.
     /// </summary>
     Localhost = 0,
 
     /// <summary>
-    /// MongoDB backed membership and reminders - for running more than one instance, and for
-    /// reminders that survive a restart.
+    /// MongoDB backed cluster membership - for running more than one instance.
     /// </summary>
     MongoDB = 1
 }

--- a/Source/Planner/Hosting/OrleansConfigurationExtensions.cs
+++ b/Source/Planner/Hosting/OrleansConfigurationExtensions.cs
@@ -11,14 +11,15 @@ namespace Planner.Hosting;
 /// Extension methods for co-hosting the Planner's Orleans silo.
 /// </summary>
 /// <remarks>
-/// The Planner co-hosts a single silo in-process. Locally the silo uses localhost clustering with
-/// in-memory reminders; set <c>Planner:Orleans:Clustering</c> to <c>MongoDB</c> for durable
-/// clustering and reminders when running more than one instance - typically in Kubernetes.
+/// The Planner co-hosts a single silo in-process. Locally the silo uses localhost clustering; set
+/// <c>Planner:Orleans:Clustering</c> to <c>MongoDB</c> for durable cluster membership when running
+/// more than one instance - typically in Kubernetes. Reminders always come from Orleans' own
+/// in-memory reminder service, in both modes - see <see cref="AddPlannerOrleans"/>.
 /// </remarks>
 public static class OrleansConfigurationExtensions
 {
     /// <summary>
-    /// The MongoDB database holding the Orleans clustering and reminder tables.
+    /// The MongoDB database holding the Orleans cluster membership table.
     /// </summary>
     public const string OrleansDatabaseName = "planner-orleans";
 
@@ -27,6 +28,23 @@ public static class OrleansConfigurationExtensions
     /// </summary>
     /// <param name="builder">The <see cref="WebApplicationBuilder"/> to configure.</param>
     /// <returns>The same <see cref="WebApplicationBuilder"/> for chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// <c>Orleans.Providers.MongoDB</c> has no Orleans 10 release - 9.5.0 is a 9.x binary - so only the
+    /// parts of it that Cratis Studio proves safe on the 10.x runtime are used here: cluster membership,
+    /// and nothing else. Studio runs the exact same package pair in production with MongoDB clustering
+    /// across several co-hosted silos and never touches the 9.x reminder table.
+    /// </para>
+    /// <para>
+    /// The reminder table is where that version skew bites. Pointing the 10.x <c>LocalReminderService</c>
+    /// at the 9.x <c>MongoReminderTable</c> makes the reminder service stop responding: the first
+    /// <c>RegisterOrUpdateReminder</c> never completes, the calling grain's request times out, the
+    /// reminder row is never written, and neither recurring grain ever ticks. Orleans' own in-memory
+    /// reminder service is 10.x end to end and works in both modes, so it is used unconditionally.
+    /// Reminders then do not survive a full cluster restart - which costs nothing here, because
+    /// <see cref="PlannerGrainsActivator"/> re-registers both of them on every start.
+    /// </para>
+    /// </remarks>
     public static WebApplicationBuilder AddPlannerOrleans(this WebApplicationBuilder builder)
     {
         var options = OrleansOptions.From(builder.Configuration);
@@ -58,13 +76,17 @@ public static class OrleansConfigurationExtensions
                     options.DatabaseName = OrleansDatabaseName;
                     options.Strategy = MongoDBMembershipStrategy.SingleDocument;
                 });
-                silo.UseMongoDBReminders(options => options.DatabaseName = OrleansDatabaseName);
             }
             else
             {
                 silo.UseLocalhostClustering();
-                silo.UseInMemoryReminderService();
             }
+
+            // Never the 9.x MongoDB reminder table on the 10.x runtime - it hangs the reminder
+            // service outright (see the remarks on this method). This keeps every reminder code
+            // path on 10.x, which leaves cluster membership as the only thing the 9.x provider
+            // does - exactly the arrangement Studio runs in production.
+            silo.UseInMemoryReminderService();
         });
 
         return builder;

--- a/Source/Planner/Hosting/OrleansOptions.cs
+++ b/Source/Planner/Hosting/OrleansOptions.cs
@@ -25,7 +25,7 @@ public class OrleansOptions
     public bool Enabled { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets how the silo discovers its cluster and where it keeps its reminders.
+    /// Gets or sets how the silo discovers its cluster.
     /// </summary>
     public ClusteringMode Clustering { get; set; } = ClusteringMode.Localhost;
 


### PR DESCRIPTION
# Summary

The Planner's co-hosted Orleans silo asked a 9.x `Orleans.Providers.MongoDB` binary for its reminder
table while running on the Orleans 10.2.2 runtime. Verified against a real silo, that combination
stops the reminder service dead: the very first reminder registration never completes, so with
`Planner:Orleans:Clustering=MongoDB` the recurring scheduling pass and the daily GitHub
consolidation have never actually run. Cratis Studio runs the same package pair in production
without trouble because it only ever uses it for cluster membership — the Planner now does the same.

## Fixed

- The recurring scheduling pass and the daily GitHub consolidation now actually run when the Planner
  is configured with `Planner:Orleans:Clustering=MongoDB`. The MongoDB Orleans provider is used for
  cluster membership only; reminders come from Orleans' own reminder service. (#41)
- Connecting the GitHub App from a deployed Planner no longer sends the operator's browser to an
  unroutable in-cluster address. The App manifest's redirect, setup and webhook URLs are derived
  from the origin the request arrived on, honoring `X-Forwarded-Proto` / `X-Forwarded-Host`.
- The Planner now ships the centrally pinned Chronicle client version — it previously resolved
  transitively, which central package management does not pin, so the published image lagged behind
  and still logged the Chronicle connection string unredacted.

## Changed

- `Planner:Orleans:Clustering` selects the cluster membership provider only. Reminders are in-memory
  in both modes and are re-registered on every start, so they no longer survive a full cluster
  restart.
- Running the Planner behind a reverse proxy now requires the ingress to forward
  `X-Forwarded-Proto` and `X-Forwarded-Host` for the GitHub App connect flow to work.
