### PR TITLE
Authenticate worker callback, input and log endpoints

### DIFF
--- a/Source/Claude/entrypoint.sh
+++ b/Source/Claude/entrypoint.sh
@@ -12,6 +12,7 @@
 #   PLANNER_PROMPT           - the instructions for the agent (markdown)
 #   PLANNER_MODEL            - the model to use (e.g. opus, sonnet)
 #   PLANNER_CALLBACK_URL     - URL the container reports progress/completion to
+#   PLANNER_CALLBACK_TOKEN   - bearer token the container authenticates its callbacks with
 #   PLANNER_GIT_USER_NAME    - git config user.name for commits made in this container
 #   PLANNER_GIT_USER_EMAIL   - git config user.email for commits made in this container
 #   GITHUB_TOKEN             - a short-lived GitHub App installation token, used for git and the GitHub CLI
@@ -47,6 +48,10 @@ report() {
     local cost="${5:-0}"
     local duration="${6:-0}"
     if [[ -n "${PLANNER_CALLBACK_URL:-}" ]]; then
+        local auth_args=()
+        if [[ -n "${PLANNER_CALLBACK_TOKEN:-}" ]]; then
+            auth_args=(-H "Authorization: Bearer ${PLANNER_CALLBACK_TOKEN}")
+        fi
         jq -cn \
             --arg status "$status" \
             --arg detail "$detail" \
@@ -55,7 +60,7 @@ report() {
             --argjson costUsd "$cost" \
             --argjson durationMs "$duration" \
             '{status: $status, detail: $detail, inputTokens: $inputTokens, outputTokens: $outputTokens, costUsd: $costUsd, durationMs: $durationMs}' |
-        curl -fsS -X POST "${PLANNER_CALLBACK_URL}" -H 'Content-Type: application/json' -d @- \
+        curl -fsS -X POST "${PLANNER_CALLBACK_URL}" -H 'Content-Type: application/json' "${auth_args[@]}" -d @- \
             || log "Failed to report status '${status}' to ${PLANNER_CALLBACK_URL}"
     fi
 }

--- a/Source/Planner/Program.cs
+++ b/Source/Planner/Program.cs
@@ -58,6 +58,7 @@ builder.Services.Configure<OperationsOptions>(builder.Configuration.GetSection(O
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<IWorkDispatcher, WorkDispatcher>();
 builder.Services.AddSingleton<IWorkerEnvironment, WorkerEnvironment>();
+builder.Services.AddSingleton<IWorkerCallbackTokens, WorkerCallbackTokens>();
 builder.Services.AddSingleton<IIssueSynchronizer, IssueSynchronizer>();
 builder.Services.AddHostedService<PlannerGrainsActivator>();
 builder.Services.AddHealthChecks();

--- a/Source/Planner/Work/Callback/IWorkerCallbackTokens.cs
+++ b/Source/Planner/Work/Callback/IWorkerCallbackTokens.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Planner.Work.Callback;
+
+/// <summary>
+/// Defines the issuing and validation of the bearer token a worker container's callbacks
+/// authenticate with.
+/// </summary>
+public interface IWorkerCallbackTokens
+{
+    /// <summary>
+    /// Issues a new callback token for a unit of work, replacing any token issued for it before.
+    /// </summary>
+    /// <param name="work">The identity of the work the token authenticates callbacks for.</param>
+    /// <returns>The new <see cref="CallbackToken"/>.</returns>
+    CallbackToken Issue(WorkId work);
+
+    /// <summary>
+    /// Validates a presented token against the one issued for a unit of work, in constant time.
+    /// </summary>
+    /// <param name="work">The identity of the work the request claims to be reporting on.</param>
+    /// <param name="presentedToken">The token presented on the request, when any.</param>
+    /// <returns><see langword="true"/> when the token is valid and not expired.</returns>
+    bool Validate(WorkId work, string? presentedToken);
+
+    /// <summary>
+    /// Revokes the token issued for a unit of work - called once the work reaches a terminal state,
+    /// so a finished worker's credential cannot be replayed.
+    /// </summary>
+    /// <param name="work">The identity of the work whose token to revoke.</param>
+    void Revoke(WorkId work);
+}

--- a/Source/Planner/Work/Callback/WorkerCallbackEndpoints.cs
+++ b/Source/Planner/Work/Callback/WorkerCallbackEndpoints.cs
@@ -49,8 +49,10 @@ public static class WorkerCallbackEndpoints
         app.MapPost("/api/work/{workId}/callback", async (
             string workId,
             WorkerCallbackPayload payload,
+            HttpRequest request,
             IEventStore eventStore,
-            ICommandPipeline commandPipeline) =>
+            ICommandPipeline commandPipeline,
+            IWorkerCallbackTokens callbackTokens) =>
         {
             if (!Guid.TryParse(workId, out var parsedWorkId))
             {
@@ -58,6 +60,11 @@ public static class WorkerCallbackEndpoints
             }
 
             WorkId id = parsedWorkId;
+            if (!callbackTokens.Validate(id, BearerToken(request)))
+            {
+                return Results.Unauthorized();
+            }
+
             var work = await eventStore.ReadModels.GetInstanceById<WorkItem>((EventSourceId)id);
             if (work is null)
             {
@@ -80,6 +87,7 @@ public static class WorkerCallbackEndpoints
                         payload.OutputTokens,
                         payload.CostUsd,
                         payload.DurationMs));
+                    callbackTokens.Revoke(id);
                     break;
 
                 case "completed":
@@ -95,11 +103,13 @@ public static class WorkerCallbackEndpoints
                         payload.OutputTokens,
                         payload.CostUsd,
                         payload.DurationMs));
+                    callbackTokens.Revoke(id);
                     break;
 
                 case "failed":
                     var reason = string.IsNullOrWhiteSpace(payload.Detail) ? "The worker reported a failure" : payload.Detail;
                     await commandPipeline.Execute(new FailWork(id, reason));
+                    callbackTokens.Revoke(id);
                     break;
 
                 default:
@@ -112,9 +122,15 @@ public static class WorkerCallbackEndpoints
         app.MapPost("/api/work/{workId}/input", async (
             string workId,
             WorkerInputPayload payload,
+            HttpContext context,
             IWorkerRuntime workerRuntime,
             CancellationToken cancellationToken) =>
         {
+            if (!RequireSignedInUser(context))
+            {
+                return Results.Unauthorized();
+            }
+
             if (!Guid.TryParse(workId, out var parsedWorkId) || string.IsNullOrWhiteSpace(payload.Text))
             {
                 return Results.BadRequest();
@@ -127,9 +143,16 @@ public static class WorkerCallbackEndpoints
         app.MapGet("/api/work/{workId}/log", async (
             string workId,
             HttpResponse response,
+            HttpContext context,
             IWorkerRuntime workerRuntime,
             CancellationToken cancellationToken) =>
         {
+            if (!RequireSignedInUser(context))
+            {
+                response.StatusCode = StatusCodes.Status401Unauthorized;
+                return;
+            }
+
             if (!Guid.TryParse(workId, out var parsedWorkId))
             {
                 response.StatusCode = StatusCodes.Status400BadRequest;
@@ -156,4 +179,24 @@ public static class WorkerCallbackEndpoints
 
         return app;
     }
+
+    /// <summary>
+    /// Extracts the bearer token from a worker container's callback request.
+    /// </summary>
+    /// <param name="request">The <see cref="HttpRequest"/> to read the header from.</param>
+    /// <returns>The presented token, or <see langword="null"/> when none was given.</returns>
+    static string? BearerToken(HttpRequest request)
+    {
+        var header = request.Headers.Authorization.ToString();
+        return header.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase) ? header["Bearer ".Length..].Trim() : null;
+    }
+
+    /// <summary>
+    /// Whether the request carries an authenticated user - these two endpoints are steered and
+    /// tailed from the Work page in the browser, not by the worker container, so they authenticate
+    /// like the rest of the application rather than with the worker's callback token.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> of the request.</param>
+    /// <returns><see langword="true"/> when a signed-in user is making the request.</returns>
+    static bool RequireSignedInUser(HttpContext context) => context.User?.Identity?.IsAuthenticated == true;
 }

--- a/Source/Planner/Work/Callback/WorkerCallbackTokens.cs
+++ b/Source/Planner/Work/Callback/WorkerCallbackTokens.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Planner.Work.Callback;
+
+/// <summary>
+/// Issues and validates the per-work-item bearer token a worker container's callbacks authenticate
+/// with. A token is minted the moment a worker is dispatched, travels to the container as the
+/// <c>PLANNER_CALLBACK_TOKEN</c> environment variable, and is required on every request the
+/// container makes back to the Planner - deliberately kept out of the event log (it is a session
+/// credential, not a domain fact) and out of any read model, so it never round-trips to a browser.
+/// </summary>
+/// <param name="timeProvider">The <see cref="TimeProvider"/> tokens expire against.</param>
+public class WorkerCallbackTokens(TimeProvider timeProvider) : IWorkerCallbackTokens
+{
+    static readonly TimeSpan _maxLifetime = TimeSpan.FromHours(12);
+
+    readonly ConcurrentDictionary<WorkId, (string HashHex, DateTimeOffset IssuedAt)> _tokens = new();
+
+    /// <inheritdoc/>
+    public CallbackToken Issue(WorkId work)
+    {
+        Prune();
+        var token = CallbackToken.New();
+        _tokens[work] = (Hash(token.Value), timeProvider.GetUtcNow());
+        return token;
+    }
+
+    /// <inheritdoc/>
+    public bool Validate(WorkId work, string? presentedToken)
+    {
+        if (string.IsNullOrEmpty(presentedToken) || !_tokens.TryGetValue(work, out var entry))
+        {
+            return false;
+        }
+
+        if (timeProvider.GetUtcNow() - entry.IssuedAt > _maxLifetime)
+        {
+            _tokens.TryRemove(work, out _);
+            return false;
+        }
+
+        return CryptographicOperations.FixedTimeEquals(
+            Convert.FromHexString(Hash(presentedToken)),
+            Convert.FromHexString(entry.HashHex));
+    }
+
+    /// <inheritdoc/>
+    public void Revoke(WorkId work) => _tokens.TryRemove(work, out _);
+
+    static string Hash(string value) => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value)));
+
+    void Prune()
+    {
+        var cutoff = timeProvider.GetUtcNow() - _maxLifetime;
+        foreach (var (work, entry) in _tokens)
+        {
+            if (entry.IssuedAt < cutoff)
+            {
+                _tokens.TryRemove(work, out _);
+            }
+        }
+    }
+}

--- a/Source/Planner/Work/Callback/for_WorkerCallbackTokens/when_issuing_and_validating.cs
+++ b/Source/Planner/Work/Callback/for_WorkerCallbackTokens/when_issuing_and_validating.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+namespace Planner.Work.Callback.for_WorkerCallbackTokens;
+
+public class when_issuing_and_validating : Specification
+{
+    static readonly WorkId _work = WorkId.New();
+    static readonly DateTimeOffset _now = new(2026, 8, 8, 12, 0, 0, TimeSpan.Zero);
+
+    TimeProvider _timeProvider;
+    WorkerCallbackTokens _tokens;
+    CallbackToken _issued;
+
+    void Establish()
+    {
+        _timeProvider = Substitute.For<TimeProvider>();
+        _timeProvider.GetUtcNow().Returns(_ => _now);
+        _tokens = new(_timeProvider);
+    }
+
+    void Because() => _issued = _tokens.Issue(_work);
+
+    [Fact] void should_validate_the_issued_token() => _tokens.Validate(_work, _issued.Value).ShouldBeTrue();
+    [Fact] void should_not_validate_a_wrong_token() => _tokens.Validate(_work, "not-the-token").ShouldBeFalse();
+    [Fact] void should_not_validate_a_missing_token() => _tokens.Validate(_work, null).ShouldBeFalse();
+    [Fact] void should_not_validate_for_unknown_work() => _tokens.Validate(WorkId.New(), _issued.Value).ShouldBeFalse();
+
+    [Fact]
+    void should_not_validate_after_being_revoked()
+    {
+        _tokens.Revoke(_work);
+        _tokens.Validate(_work, _issued.Value).ShouldBeFalse();
+    }
+
+    [Fact]
+    void should_not_validate_an_expired_token()
+    {
+        _timeProvider.GetUtcNow().Returns(_ => _now + TimeSpan.FromHours(13));
+        _tokens.Validate(_work, _issued.Value).ShouldBeFalse();
+    }
+
+    [Fact]
+    void should_invalidate_the_previous_token_when_reissued()
+    {
+        var reissued = _tokens.Issue(_work);
+        _tokens.Validate(_work, _issued.Value).ShouldBeFalse();
+        _tokens.Validate(_work, reissued.Value).ShouldBeTrue();
+    }
+}
+#endif

--- a/Source/Planner/Work/CallbackToken.cs
+++ b/Source/Planner/Work/CallbackToken.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Cryptography;
+using Cratis.Chronicle.Compliance.GDPR;
+
+namespace Planner.Work;
+
+/// <summary>
+/// A one-time bearer credential a worker container authenticates its callbacks with - handed to the
+/// container as an environment variable and never persisted to the event log. Marked
+/// <see cref="PIIAttribute"/> for the rare case a value of it does end up on a projected record, so
+/// Chronicle still encrypts it at rest.
+/// </summary>
+/// <param name="Value">The underlying value.</param>
+[PII]
+public record CallbackToken(string Value) : ConceptAs<string>(Value)
+{
+    /// <summary>
+    /// The value representing an unset callback token.
+    /// </summary>
+    public static readonly CallbackToken NotSet = new(string.Empty);
+
+    /// <summary>
+    /// Implicitly convert from <see cref="string"/> to <see cref="CallbackToken"/>.
+    /// </summary>
+    /// <param name="value">The value to convert from.</param>
+    public static implicit operator CallbackToken(string value) => new(value);
+
+    /// <summary>
+    /// Creates a new, cryptographically random callback token.
+    /// </summary>
+    /// <returns>A new <see cref="CallbackToken"/>.</returns>
+    public static CallbackToken New() => new(Convert.ToHexString(RandomNumberGenerator.GetBytes(32)));
+}

--- a/Source/Planner/Work/Scheduling/WorkDispatcher.cs
+++ b/Source/Planner/Work/Scheduling/WorkDispatcher.cs
@@ -9,6 +9,7 @@ using Planner.Accounts.Credentials;
 using Planner.Accounts.Listing;
 using Planner.Alerts;
 using Planner.Issues.Grouping;
+using Planner.Work.Callback;
 using Planner.Work.Listing;
 using Planner.Work.Starting;
 using Planner.Work.Workers;
@@ -27,6 +28,7 @@ namespace Planner.Work.Scheduling;
 /// <param name="readModels">The <see cref="IReadModels"/> for keyed lookups (credentials).</param>
 /// <param name="workerRuntime">The <see cref="IWorkerRuntime"/> that launches worker containers.</param>
 /// <param name="workerEnvironment">Builds the environment a worker container runs with.</param>
+/// <param name="callbackTokens">Issues the bearer token a launched worker's callbacks authenticate with.</param>
 /// <param name="commandPipeline">The <see cref="ICommandPipeline"/> for executing commands.</param>
 /// <param name="timeProvider">The <see cref="TimeProvider"/> for usage-window calculations.</param>
 /// <param name="workerOptions">The worker configuration.</param>
@@ -40,6 +42,7 @@ public class WorkDispatcher(
     IReadModels readModels,
     IWorkerRuntime workerRuntime,
     IWorkerEnvironment workerEnvironment,
+    IWorkerCallbackTokens callbackTokens,
     ICommandPipeline commandPipeline,
     TimeProvider timeProvider,
     IOptions<WorkerOptions> workerOptions,
@@ -154,7 +157,8 @@ public class WorkDispatcher(
         }
 
         var model = ResolveModel(work, coveredIssues);
-        var environment = await workerEnvironment.Build(work, coveredIssues, credentials, model, cancellationToken);
+        var callbackToken = callbackTokens.Issue(work.Id);
+        var environment = await workerEnvironment.Build(work, coveredIssues, credentials, model, callbackToken, cancellationToken);
 
         try
         {
@@ -163,6 +167,7 @@ public class WorkDispatcher(
         catch (Exception exception)
         {
             logger.CouldNotLaunchWorker(exception, work.Id);
+            callbackTokens.Revoke(work.Id);
             await commandPipeline.Execute(new Failing.FailWork(work.Id, $"Could not launch worker: {exception.Message}"));
             return false;
         }

--- a/Source/Planner/Work/Scheduling/for_WorkDispatcher/given/all_dependencies.cs
+++ b/Source/Planner/Work/Scheduling/for_WorkDispatcher/given/all_dependencies.cs
@@ -12,6 +12,7 @@ using Planner.Alerts;
 using Planner.GitHub.App;
 using Planner.GitHub.GitIdentity.Listing;
 using Planner.Operations;
+using Planner.Work.Callback;
 using Planner.Work.Listing;
 using Planner.Work.Workers;
 using ListedIssue = Planner.Issues.Listing.Issue;
@@ -36,6 +37,7 @@ public class all_dependencies : Specification
     protected AlertOptions _alertOptions;
     protected OperationsOptions _operationsOptions;
     protected IGitHubAppTokenResolver _gitHubAppTokenResolver;
+    protected IWorkerCallbackTokens _callbackTokens;
     protected WorkDispatcher _dispatcher;
 
     protected List<WorkItem> _workItemsData;
@@ -66,6 +68,8 @@ public class all_dependencies : Specification
         _operationsOptions = new();
         _gitHubAppTokenResolver = Substitute.For<IGitHubAppTokenResolver>();
         _gitHubAppTokenResolver.GetToken(Arg.Any<OrganizationName>(), Arg.Any<CancellationToken>()).Returns("installation-token");
+        _callbackTokens = Substitute.For<IWorkerCallbackTokens>();
+        _callbackTokens.Issue(Arg.Any<WorkId>()).Returns(_ => CallbackToken.New());
 
         // The real environment builder rather than a substitute - the specs assert on what a worker
         // container is actually handed, which is precisely what it produces.
@@ -82,6 +86,7 @@ public class all_dependencies : Specification
             _readModels,
             _workerRuntime,
             _workerEnvironment,
+            _callbackTokens,
             _commandPipeline,
             _timeProvider,
             Options.Create(_workerOptions),

--- a/Source/Planner/Work/Stopping/Stopping.cs
+++ b/Source/Planner/Work/Stopping/Stopping.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Planner.Work.Callback;
 using Planner.Work.Listing;
 using Planner.Work.Workers;
 
@@ -20,8 +21,9 @@ public record StopWork(WorkId Work)
     /// </summary>
     /// <param name="work">The work's read model - resolved by the command's event source id.</param>
     /// <param name="workerRuntime">The <see cref="IWorkerRuntime"/> to stop the worker through.</param>
+    /// <param name="callbackTokens">Revokes the stopped worker's callback token so it cannot report anything further.</param>
     /// <returns>The <see cref="WorkStopped"/> event, or a validation error.</returns>
-    public async Task<Result<WorkStopped, ValidationResult>> Handle(WorkItem? work, IWorkerRuntime workerRuntime)
+    public async Task<Result<WorkStopped, ValidationResult>> Handle(WorkItem? work, IWorkerRuntime workerRuntime, IWorkerCallbackTokens callbackTokens)
     {
         if (work is null)
         {
@@ -38,6 +40,7 @@ public record StopWork(WorkId Work)
             await workerRuntime.Stop(Work);
         }
 
+        callbackTokens.Revoke(Work);
         return new WorkStopped();
     }
 }

--- a/Source/Planner/Work/Stopping/when_stopping_work/and_it_already_finished.cs
+++ b/Source/Planner/Work/Stopping/when_stopping_work/and_it_already_finished.cs
@@ -3,6 +3,7 @@
 
 #if DEBUG
 using Microsoft.Extensions.DependencyInjection;
+using Planner.Work.Callback;
 using Planner.Work.Listing;
 using Planner.Work.Workers;
 
@@ -13,14 +14,17 @@ public class and_it_already_finished : Specification
     static readonly WorkId _workId = WorkId.New();
 
     IWorkerRuntime _workerRuntime;
+    IWorkerCallbackTokens _callbackTokens;
     CommandScenario<StopWork> _scenario;
     CommandResult _result;
 
     void Establish()
     {
         _workerRuntime = Substitute.For<IWorkerRuntime>();
+        _callbackTokens = Substitute.For<IWorkerCallbackTokens>();
         _scenario = new();
         _scenario.Services.AddSingleton(_workerRuntime);
+        _scenario.Services.AddSingleton(_callbackTokens);
         _scenario.Given.ForEventSource(_workId).ReadModel(new WorkItem(
             _workId,
             WorkPurpose.Implementation,
@@ -35,5 +39,6 @@ public class and_it_already_finished : Specification
     [Fact] void should_not_succeed() => _result.ShouldNotBeSuccessful();
     [Fact] void should_have_validation_errors() => _result.ShouldHaveValidationErrors();
     [Fact] async Task should_not_touch_the_worker() => await _workerRuntime.DidNotReceive().Stop(Arg.Any<WorkId>(), Arg.Any<CancellationToken>());
+    [Fact] void should_not_revoke_any_callback_token() => _callbackTokens.DidNotReceive().Revoke(Arg.Any<WorkId>());
 }
 #endif

--- a/Source/Planner/Work/Stopping/when_stopping_work/and_it_is_running.cs
+++ b/Source/Planner/Work/Stopping/when_stopping_work/and_it_is_running.cs
@@ -3,6 +3,7 @@
 
 #if DEBUG
 using Microsoft.Extensions.DependencyInjection;
+using Planner.Work.Callback;
 using Planner.Work.Listing;
 using Planner.Work.Workers;
 
@@ -13,14 +14,17 @@ public class and_it_is_running : Specification
     static readonly WorkId _workId = WorkId.New();
 
     IWorkerRuntime _workerRuntime;
+    IWorkerCallbackTokens _callbackTokens;
     CommandScenario<StopWork> _scenario;
     CommandResult _result;
 
     void Establish()
     {
         _workerRuntime = Substitute.For<IWorkerRuntime>();
+        _callbackTokens = Substitute.For<IWorkerCallbackTokens>();
         _scenario = new();
         _scenario.Services.AddSingleton(_workerRuntime);
+        _scenario.Services.AddSingleton(_callbackTokens);
         _scenario.Given.ForEventSource(_workId).ReadModel(new WorkItem(
             _workId,
             WorkPurpose.Implementation,
@@ -34,6 +38,7 @@ public class and_it_is_running : Specification
 
     [Fact] void should_succeed() => _result.ShouldBeSuccessful();
     [Fact] async Task should_stop_the_worker() => await _workerRuntime.Received(1).Stop(_workId, Arg.Any<CancellationToken>());
+    [Fact] void should_revoke_the_callback_token() => _callbackTokens.Received(1).Revoke(_workId);
     [Fact] void should_append_work_stopped() => _scenario.EventSequence.ShouldHaveAppendedEvent<WorkStopped>();
 }
 #endif

--- a/Source/Planner/Work/Workers/IWorkerEnvironment.cs
+++ b/Source/Planner/Work/Workers/IWorkerEnvironment.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Planner.Accounts.Credentials;
+using Planner.Work.Callback;
 using Planner.Work.Listing;
 using ListedIssue = Planner.Issues.Listing.Issue;
 
@@ -20,6 +21,7 @@ public interface IWorkerEnvironment
     /// <param name="coveredIssues">The issues the work covers - empty for anything but issue work.</param>
     /// <param name="credentials">The Claude account credentials the session authenticates with.</param>
     /// <param name="model">The resolved model the session runs.</param>
+    /// <param name="callbackToken">The bearer token the container must present when it reports progress back.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> for the operation.</param>
     /// <returns>The environment variables.</returns>
     Task<IReadOnlyDictionary<string, string>> Build(
@@ -27,5 +29,6 @@ public interface IWorkerEnvironment
         IReadOnlyList<ListedIssue> coveredIssues,
         AccountCredentials credentials,
         ModelName model,
+        CallbackToken callbackToken,
         CancellationToken cancellationToken = default);
 }

--- a/Source/Planner/Work/Workers/WorkerEnvironment.cs
+++ b/Source/Planner/Work/Workers/WorkerEnvironment.cs
@@ -11,6 +11,7 @@ using Planner.Issues.Grouping;
 using Planner.Issues.Grouping.Listing;
 using Planner.Operations;
 using Planner.Repositories.Listing;
+using Planner.Work.Callback;
 using Planner.Work.Listing;
 using ListedAlert = Planner.Alerts.Listing.Alert;
 using ListedIssue = Planner.Issues.Listing.Issue;
@@ -37,6 +38,7 @@ public class WorkerEnvironment(
         IReadOnlyList<ListedIssue> coveredIssues,
         AccountCredentials credentials,
         ModelName model,
+        CallbackToken callbackToken,
         CancellationToken cancellationToken = default)
     {
         var environment = new Dictionary<string, string>
@@ -44,6 +46,7 @@ public class WorkerEnvironment(
             ["PLANNER_WORK_ID"] = work.Id.Value.ToString(),
             ["PLANNER_MODEL"] = model.Value,
             ["PLANNER_CALLBACK_URL"] = $"{workerOptions.Value.CallbackBaseUrl.TrimEnd('/')}/api/work/{work.Id.Value}/callback",
+            ["PLANNER_CALLBACK_TOKEN"] = callbackToken.Value,
             ["PLANNER_BRANCH"] = $"planner/work-{work.Id.Value:N}",
             ["CLAUDE_CODE_OAUTH_TOKEN"] = credentials.Token.Value
         };

--- a/Source/Planner/Work/Workers/for_WorkerEnvironment/given/all_dependencies.cs
+++ b/Source/Planner/Work/Workers/for_WorkerEnvironment/given/all_dependencies.cs
@@ -17,6 +17,7 @@ namespace Planner.Work.Workers.for_WorkerEnvironment.given;
 public class all_dependencies : Specification
 {
     protected static readonly WorkId _workId = WorkId.New();
+    protected static readonly CallbackToken _callbackToken = CallbackToken.New();
 
     protected IReadModels _readModels;
     protected IGitHubAppTokenResolver _gitHubAppTokenResolver;

--- a/Source/Planner/Work/Workers/for_WorkerEnvironment/when_building_for_an_alert_investigation/and_nothing_operational_is_configured.cs
+++ b/Source/Planner/Work/Workers/for_WorkerEnvironment/when_building_for_an_alert_investigation/and_nothing_operational_is_configured.cs
@@ -20,7 +20,8 @@ public class and_nothing_operational_is_configured : context
         new WorkItem(_workId, WorkPurpose.AlertInvestigation, [], ModelName.NotSet, UserName.NotSet, Alert: _alertId),
         [],
         _credentials,
-        "opus");
+        "opus",
+        _callbackToken);
 
     [Fact] void should_still_dispatch_the_work() => _result["PLANNER_PROMPT"].ShouldNotBeEmpty();
     [Fact] void should_tell_the_agent_it_can_reach_nothing() => _result["PLANNER_PROMPT"].ShouldContain("gave you no access");

--- a/Source/Planner/Work/Workers/for_WorkerEnvironment/when_building_for_an_alert_investigation/and_operational_access_is_configured.cs
+++ b/Source/Planner/Work/Workers/for_WorkerEnvironment/when_building_for_an_alert_investigation/and_operational_access_is_configured.cs
@@ -27,7 +27,8 @@ public class and_operational_access_is_configured : context
         new WorkItem(_workId, WorkPurpose.AlertInvestigation, [], ModelName.NotSet, UserName.NotSet, Alert: _alertId),
         [],
         _credentials,
-        "opus");
+        "opus",
+        _callbackToken);
 
     [Fact] void should_hand_over_the_kubeconfig() => _result["PLANNER_KUBECONFIG"].ShouldEqual("apiVersion: v1\nkind: Config");
     [Fact] void should_hand_over_the_namespace() => _result["PLANNER_KUBE_NAMESPACE"].ShouldEqual("studio");

--- a/Source/Planner/Work/Workers/for_WorkerEnvironment/when_building_for_issue_work/and_a_callback_token_is_given.cs
+++ b/Source/Planner/Work/Workers/for_WorkerEnvironment/when_building_for_issue_work/and_a_callback_token_is_given.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Planner.Issues;
+using Planner.Work.Listing;
+using context = Planner.Work.Workers.for_WorkerEnvironment.given.all_dependencies;
+using ListedIssue = Planner.Issues.Listing.Issue;
+
+namespace Planner.Work.Workers.for_WorkerEnvironment.when_building_for_issue_work;
+
+public class and_a_callback_token_is_given : context
+{
+    static readonly ListedIssue _issue = new(
+        "Cratis/Studio#1",
+        "Cratis",
+        "Studio",
+        1,
+        "An issue",
+        "Bug",
+        "someuser",
+        DateTimeOffset.UtcNow,
+        AuthorAssociation.Member,
+        true,
+        IssueStatus.ReadyForDevelopment);
+
+    IReadOnlyDictionary<string, string> _result;
+
+    void Establish() => BuildEnvironmentBuilder();
+
+    async Task Because() => _result = await _environment.Build(
+        new WorkItem(_workId, WorkPurpose.Implementation, [_issue.Id], ModelName.NotSet, UserName.NotSet),
+        [_issue],
+        _credentials,
+        "sonnet",
+        _callbackToken);
+
+    [Fact] void should_hand_the_worker_its_callback_token() => _result["PLANNER_CALLBACK_TOKEN"].ShouldEqual(_callbackToken.Value);
+}
+#endif


### PR DESCRIPTION
# Summary

The worker callback (`/api/work/{id}/callback`) and the browser-facing
steering (`/api/work/{id}/input`) and log-stream (`/api/work/{id}/log`)
endpoints had no authentication at all - anyone who could reach the
Planner directly could report a fabricated result for any work item,
steer someone else's running session, or tail its console output.

## Security

- The worker callback endpoint now requires the per-work bearer token issued at dispatch time; the worker entrypoint sends it back as `Authorization: Bearer <token>` on every report, and the token is revoked once the work completes, fails, or is stopped (#86)
- The steering-input and log-stream endpoints now require an authenticated session, consistent with the rest of the application (#86)