### PR TITLE
Give the Planner a clearly-AI GitHub identity: Stagehand (AI)

### DIFF
--- a/Source/Planner/Alerts/ConvertingToIssue/ConvertingToIssue.cs
+++ b/Source/Planner/Alerts/ConvertingToIssue/ConvertingToIssue.cs
@@ -42,7 +42,7 @@ public record ConvertAlertToIssue(AlertId Alert, RepositoryId Repository, IssueT
             return ValidationResult.Error("That repository is not tracked by the Planner");
         }
 
-        var created = await gitHub.CreateIssue(repository.Owner, repository.Name, Title, Body);
+        var created = await gitHub.CreateIssue(repository.Owner, repository.Name, Title, $"{Body.Value}{AIIdentity.Footer()}");
         if (created is null)
         {
             return ValidationResult.Error($"GitHub would not create an issue in {repository.Owner.Value}/{repository.Name.Value}");

--- a/Source/Planner/Alerts/ConvertingToIssue/when_converting_an_alert_to_an_issue/and_github_creates_it.cs
+++ b/Source/Planner/Alerts/ConvertingToIssue/when_converting_an_alert_to_an_issue/and_github_creates_it.cs
@@ -47,7 +47,7 @@ public class and_github_creates_it : Specification
         new OrganizationName("Cratis"),
         new RepositoryName("Studio"),
         new IssueTitle("Loki retention never applies"),
-        new IssueBody("The agent found the retention config is not read at startup."),
+        Arg.Is<IssueBody>(body => body.Value.StartsWith("The agent found the retention config is not read at startup.", StringComparison.Ordinal) && body.Value.Contains(AIIdentity.DisplayName, StringComparison.Ordinal)),
         Arg.Any<CancellationToken>());
 
     [Fact]

--- a/Source/Planner/GitHub/AIIdentity.cs
+++ b/Source/Planner/GitHub/AIIdentity.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Planner.GitHub.GitIdentity;
+
+namespace Planner.GitHub;
+
+/// <summary>
+/// The Planner's own identity on GitHub - the name every comment, issue and pull request it or a
+/// worker produces should be recognizable under. Named for the person who works the show from
+/// behind the scenes so it never gets seen, in the same theatre vocabulary as the rest of Cratis
+/// (Chronicle, Stage, Scene, Screenplay, Prologue, Narrator, Prompter).
+/// </summary>
+public static class AIIdentity
+{
+    /// <summary>
+    /// The display name every comment, commit and pull request should be recognizable under -
+    /// makes the AI nature explicit rather than reading like a person's name.
+    /// </summary>
+    public const string DisplayName = "Stagehand (AI)";
+
+    /// <summary>
+    /// The default <see cref="GitUserName"/> worker containers commit as when no git identity has
+    /// been configured - a fresh deployment should never be stuck without one.
+    /// </summary>
+    public static readonly GitUserName DefaultGitUserName = new(DisplayName);
+
+    /// <summary>
+    /// The default <see cref="GitUserEmail"/> worker containers commit as when no git identity has
+    /// been configured - a GitHub-style noreply address, so it can never receive mail meant for a
+    /// real person.
+    /// </summary>
+    public static readonly GitUserEmail DefaultGitUserEmail = new("stagehand-ai@users.noreply.github.com");
+
+    /// <summary>
+    /// The footer appended to every comment, issue body and pull request description the Planner or
+    /// a worker writes, so it is unmistakably AI-authored wherever it shows up on GitHub.
+    /// </summary>
+    /// <returns>The markdown footer.</returns>
+    public static string Footer() => $"\n\n---\n_Posted by {DisplayName} - an autonomous agent, not a person. Review accordingly._";
+}

--- a/Source/Planner/GitHub/App/GitHubAppManifest.cs
+++ b/Source/Planner/GitHub/App/GitHubAppManifest.cs
@@ -15,7 +15,7 @@ public static class GitHubAppManifest
     /// The name the App is registered with when none is given. GitHub requires App names to be
     /// globally unique, so a second registration has to pass a name of its own.
     /// </summary>
-    public const string DefaultName = "Cratis Planner";
+    public const string DefaultName = AIIdentity.DisplayName;
 
     /// <summary>
     /// The webhook events the App subscribes to.

--- a/Source/Planner/GitHub/App/GitHubAppOptions.cs
+++ b/Source/Planner/GitHub/App/GitHubAppOptions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Planner.GitHub;
+
 namespace Planner.GitHub.App;
 
 /// <summary>
@@ -48,6 +50,14 @@ public class GitHubAppOptions
     /// Gets or sets the shared secret GitHub signs webhook deliveries with.
     /// </summary>
     public string WebhookSecret { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the login of the machine user account issues are assigned to while an agent works
+    /// on them. GitHub does not allow assigning issues to an App itself, only to a user account - set
+    /// this to a dedicated account's login (e.g. a bot account named after <see cref="AIIdentity.DisplayName"/>)
+    /// to enable assignment; leave empty to skip it entirely.
+    /// </summary>
+    public string AIUserLogin { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets whether the App has been configured with the minimum required to authenticate.

--- a/Source/Planner/GitHub/GitHubClient.cs
+++ b/Source/Planner/GitHub/GitHubClient.cs
@@ -133,6 +133,22 @@ public class GitHubClient(HttpClient httpClient, IGitHubAppTokenResolver tokenRe
     }
 
     /// <inheritdoc/>
+    public async Task AssignIssue(OrganizationName owner, RepositoryName repository, IssueNumber number, UserName assignee, CancellationToken cancellationToken = default)
+    {
+        var payload = JsonSerializer.Serialize(new { assignees = new[] { assignee.Value } });
+        using var response = await Send(owner, HttpMethod.Post, $"repos/{owner.Value}/{repository.Value}/issues/{number.Value}/assignees", new StringContent(payload, Encoding.UTF8, "application/json"), cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+
+    /// <inheritdoc/>
+    public async Task UnassignIssue(OrganizationName owner, RepositoryName repository, IssueNumber number, UserName assignee, CancellationToken cancellationToken = default)
+    {
+        var payload = JsonSerializer.Serialize(new { assignees = new[] { assignee.Value } });
+        using var response = await Send(owner, HttpMethod.Delete, $"repos/{owner.Value}/{repository.Value}/issues/{number.Value}/assignees", new StringContent(payload, Encoding.UTF8, "application/json"), cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+
+    /// <inheritdoc/>
     public async Task<bool> IsOrganizationMember(OrganizationName organization, UserName user, CancellationToken cancellationToken = default)
     {
         using var response = await Send(organization, HttpMethod.Get, $"orgs/{organization.Value}/members/{user.Value}", null, cancellationToken);

--- a/Source/Planner/GitHub/GitHubConfiguration.tsx
+++ b/Source/Planner/GitHub/GitHubConfiguration.tsx
@@ -108,11 +108,11 @@ export const GitHubConfiguration = () => {
                     width='30rem'
                     okLabel='Save'
                     cancelLabel='Cancel'
-                    initialValues={{ name: identity?.name ?? '', email: identity?.email ?? '' }}
+                    initialValues={{ name: identity?.name ?? 'Stagehand (AI)', email: identity?.email ?? 'stagehand-ai@users.noreply.github.com' }}
                     onConfirm={() => setEditIdentityVisible(false)}
                     onCancel={() => setEditIdentityVisible(false)}>
-                    <InputTextField<SetGitIdentity> value={(instance) => instance.name} title='Name' placeholder='e.g. Cratis Planner' />
-                    <InputTextField<SetGitIdentity> value={(instance) => instance.email} title='Email' placeholder='e.g. planner@example.com' />
+                    <InputTextField<SetGitIdentity> value={(instance) => instance.name} title='Name' placeholder='e.g. Stagehand (AI)' />
+                    <InputTextField<SetGitIdentity> value={(instance) => instance.email} title='Email' placeholder='e.g. stagehand-ai@users.noreply.github.com' />
                 </CommandDialog>}
         </Page>
     );

--- a/Source/Planner/GitHub/GitIdentity/Setting/Setting.cs
+++ b/Source/Planner/GitHub/GitIdentity/Setting/Setting.cs
@@ -37,7 +37,15 @@ public class SetGitIdentityValidator : CommandValidator<SetGitIdentity>
     public SetGitIdentityValidator()
     {
         RuleFor(_ => _.Name).NotEmpty().WithMessage("A git user name is required");
+        RuleFor(_ => _.Name)
+            .Must(name => name.Contains("(AI)", StringComparison.OrdinalIgnoreCase) || name.EndsWith("[bot]", StringComparison.OrdinalIgnoreCase))
+            .When(_ => !string.IsNullOrEmpty(_.Name.Value))
+            .WithMessage("The git identity should make clear this is an AI agent, e.g. 'Stagehand (AI)'");
         RuleFor(_ => _.Email).NotEmpty().WithMessage("A git user email is required");
+        RuleFor(_ => _.Email)
+            .Must(email => email.EndsWith("@users.noreply.github.com", StringComparison.OrdinalIgnoreCase))
+            .When(_ => !string.IsNullOrEmpty(_.Email.Value))
+            .WithMessage("Use a noreply GitHub email so the identity can never receive mail meant for a person");
     }
 }
 

--- a/Source/Planner/GitHub/GitIdentity/Setting/when_setting_git_identity/and_information_is_valid.cs
+++ b/Source/Planner/GitHub/GitIdentity/Setting/when_setting_git_identity/and_information_is_valid.cs
@@ -11,14 +11,14 @@ public class and_information_is_valid : Specification
 
     void Establish() => _scenario = new();
 
-    async Task Because() => _result = await _scenario.Execute(new SetGitIdentity("Cratis Planner", "planner@cratis.io"));
+    async Task Because() => _result = await _scenario.Execute(new SetGitIdentity("Stagehand (AI)", "stagehand-ai@users.noreply.github.com"));
 
     [Fact] void should_succeed() => _result.ShouldBeSuccessful();
 
     [Fact]
     void should_append_git_identity_set() => _scenario.EventSequence.ShouldHaveAppendedEvent<GitIdentitySet>(
         @event =>
-            @event.Name == new GitUserName("Cratis Planner") &&
-            @event.Email == new GitUserEmail("planner@cratis.io"));
+            @event.Name == new GitUserName("Stagehand (AI)") &&
+            @event.Email == new GitUserEmail("stagehand-ai@users.noreply.github.com"));
 }
 #endif

--- a/Source/Planner/GitHub/GitIdentity/Setting/when_setting_git_identity/and_the_email_is_not_a_noreply_address.cs
+++ b/Source/Planner/GitHub/GitIdentity/Setting/when_setting_git_identity/and_the_email_is_not_a_noreply_address.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+namespace Planner.GitHub.GitIdentity.Setting.when_setting_git_identity;
+
+public class and_the_email_is_not_a_noreply_address : Specification
+{
+    CommandScenario<SetGitIdentity> _scenario;
+    CommandResult _result;
+
+    void Establish() => _scenario = new();
+
+    async Task Because() => _result = await _scenario.Execute(new SetGitIdentity("Stagehand (AI)", "planner@cratis.io"));
+
+    [Fact] void should_not_succeed() => _result.ShouldNotBeSuccessful();
+    [Fact] void should_have_validation_errors() => _result.ShouldHaveValidationErrors();
+}
+#endif

--- a/Source/Planner/GitHub/GitIdentity/Setting/when_setting_git_identity/and_the_name_does_not_read_as_ai.cs
+++ b/Source/Planner/GitHub/GitIdentity/Setting/when_setting_git_identity/and_the_name_does_not_read_as_ai.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+namespace Planner.GitHub.GitIdentity.Setting.when_setting_git_identity;
+
+public class and_the_name_does_not_read_as_ai : Specification
+{
+    CommandScenario<SetGitIdentity> _scenario;
+    CommandResult _result;
+
+    void Establish() => _scenario = new();
+
+    async Task Because() => _result = await _scenario.Execute(new SetGitIdentity("Cratis Planner", "stagehand-ai@users.noreply.github.com"));
+
+    [Fact] void should_not_succeed() => _result.ShouldNotBeSuccessful();
+    [Fact] void should_have_validation_errors() => _result.ShouldHaveValidationErrors();
+}
+#endif

--- a/Source/Planner/GitHub/IGitHubClient.cs
+++ b/Source/Planner/GitHub/IGitHubClient.cs
@@ -68,6 +68,28 @@ public interface IGitHubClient
     Task<bool> MergePullRequest(OrganizationName owner, RepositoryName repository, PullRequestNumber number, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Assigns a user to an issue, in addition to whoever is already assigned.
+    /// </summary>
+    /// <param name="owner">The organization owning the repository.</param>
+    /// <param name="repository">The repository the issue belongs to.</param>
+    /// <param name="number">The issue number.</param>
+    /// <param name="assignee">The login of the user to assign.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> for the operation.</param>
+    /// <returns>Awaitable task.</returns>
+    Task AssignIssue(OrganizationName owner, RepositoryName repository, IssueNumber number, UserName assignee, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a user's assignment from an issue.
+    /// </summary>
+    /// <param name="owner">The organization owning the repository.</param>
+    /// <param name="repository">The repository the issue belongs to.</param>
+    /// <param name="number">The issue number.</param>
+    /// <param name="assignee">The login of the user to unassign.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> for the operation.</param>
+    /// <returns>Awaitable task.</returns>
+    Task UnassignIssue(OrganizationName owner, RepositoryName repository, IssueNumber number, UserName assignee, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Checks whether a user is a member of an organization.
     /// </summary>
     /// <param name="organization">The organization to check membership in.</param>

--- a/Source/Planner/Work/AssigningAIIdentity/AssigningAIIdentity.cs
+++ b/Source/Planner/Work/AssigningAIIdentity/AssigningAIIdentity.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Options;
+using Planner.GitHub;
+using Planner.GitHub.App;
+using Planner.Work.Completing;
+using Planner.Work.Failing;
+using Planner.Work.Listing;
+using Planner.Work.Starting;
+using Planner.Work.Stopping;
+using ListedIssue = Planner.Issues.Listing.Issue;
+
+namespace Planner.Work.AssigningAIIdentity;
+
+/// <summary>
+/// Reacts to work lifecycle events by assigning the covered issues to the Planner's AI identity on
+/// GitHub while an agent works on them, and unassigning once it hands them back - so anyone looking
+/// at GitHub can tell what the Planner has taken on. GitHub does not allow assigning issues to an
+/// App itself, only to a user account, so this only does anything once
+/// <see cref="GitHubAppOptions.AIUserLogin"/> is configured with a machine user's login; it is a
+/// silent no-op otherwise.
+/// </summary>
+/// <param name="eventStore">The <see cref="IEventStore"/> for reading the work's read model.</param>
+/// <param name="gitHub">The <see cref="IGitHubClient"/> for assigning/unassigning on GitHub.</param>
+/// <param name="options">The GitHub App configuration - carries the AI identity's login.</param>
+public class AIIdentityAssignment(IEventStore eventStore, IGitHubClient gitHub, IOptions<GitHubAppOptions> options) : IReactor
+{
+    /// <summary>
+    /// Assigns every issue covered by a unit of work to the AI identity once it starts running.
+    /// </summary>
+    /// <param name="event">The <see cref="WorkStarted"/> event.</param>
+    /// <param name="context">The <see cref="EventContext"/>.</param>
+    /// <returns>Awaitable task.</returns>
+    public Task On(WorkStarted @event, EventContext context) => ForCoveredIssues(context, Assign);
+
+    /// <summary>
+    /// Unassigns the AI identity from every issue covered by a unit of work once it completes.
+    /// </summary>
+    /// <param name="event">The <see cref="WorkCompleted"/> event.</param>
+    /// <param name="context">The <see cref="EventContext"/>.</param>
+    /// <returns>Awaitable task.</returns>
+    public Task On(WorkCompleted @event, EventContext context) => ForCoveredIssues(context, Unassign);
+
+    /// <summary>
+    /// Unassigns the AI identity from every issue covered by a unit of work once it fails.
+    /// </summary>
+    /// <param name="event">The <see cref="WorkFailed"/> event.</param>
+    /// <param name="context">The <see cref="EventContext"/>.</param>
+    /// <returns>Awaitable task.</returns>
+    public Task On(WorkFailed @event, EventContext context) => ForCoveredIssues(context, Unassign);
+
+    /// <summary>
+    /// Unassigns the AI identity from every issue covered by a unit of work once it is stopped.
+    /// </summary>
+    /// <param name="event">The <see cref="WorkStopped"/> event.</param>
+    /// <param name="context">The <see cref="EventContext"/>.</param>
+    /// <returns>Awaitable task.</returns>
+    public Task On(WorkStopped @event, EventContext context) => ForCoveredIssues(context, Unassign);
+
+    async Task ForCoveredIssues(EventContext context, Func<ListedIssue, CancellationToken, Task> action)
+    {
+        if (string.IsNullOrWhiteSpace(options.Value.AIUserLogin))
+        {
+            return;
+        }
+
+        var work = await eventStore.ReadModels.GetInstanceById<WorkItem>(context.EventSourceId);
+        foreach (var issueId in work.Issues)
+        {
+            var issue = await eventStore.ReadModels.GetInstanceById<ListedIssue>((EventSourceId)issueId);
+            if (issue is not null)
+            {
+                await action(issue, CancellationToken.None);
+            }
+        }
+    }
+
+    Task Assign(ListedIssue issue, CancellationToken cancellationToken) =>
+        gitHub.AssignIssue(issue.Owner, issue.Repository, issue.Number, options.Value.AIUserLogin, cancellationToken);
+
+    Task Unassign(ListedIssue issue, CancellationToken cancellationToken) =>
+        gitHub.UnassignIssue(issue.Owner, issue.Repository, issue.Number, options.Value.AIUserLogin, cancellationToken);
+}

--- a/Source/Planner/Work/AssigningAIIdentity/for_AIIdentityAssignment/given/a_reactor.cs
+++ b/Source/Planner/Work/AssigningAIIdentity/for_AIIdentityAssignment/given/a_reactor.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Cratis.Chronicle.Testing.Reactors;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Planner.GitHub;
+using Planner.GitHub.App;
+using Planner.Work.Listing;
+using ListedIssue = Planner.Issues.Listing.Issue;
+
+namespace Planner.Work.AssigningAIIdentity.for_AIIdentityAssignment.given;
+
+public class a_reactor : Specification
+{
+    protected static readonly WorkId _workId = WorkId.New();
+
+    protected IEventStore _eventStore;
+    protected IGitHubClient _gitHub;
+    protected GitHubAppOptions _options;
+
+    protected ReactorScenario<AIIdentityAssignment> _scenario;
+
+    void Establish()
+    {
+        _eventStore = Substitute.For<IEventStore>();
+        _gitHub = Substitute.For<IGitHubClient>();
+        _options = new();
+
+        _scenario = new(new ServiceCollection()
+            .AddSingleton(_eventStore)
+            .AddSingleton(_gitHub)
+            .AddSingleton<IOptions<GitHubAppOptions>>(Options.Create(_options))
+            .BuildServiceProvider());
+    }
+
+    protected void SetWorkItem(WorkItem work) =>
+        _eventStore.ReadModels.GetInstanceById<WorkItem>(Arg.Any<ReadModelKey>(), Arg.Any<ReadModelSessionId>())
+            .Returns(work);
+
+    protected void SetIssue(ListedIssue issue) =>
+        _eventStore.ReadModels.GetInstanceById<ListedIssue>(Arg.Any<ReadModelKey>(), Arg.Any<ReadModelSessionId>())
+            .Returns(issue);
+}
+#endif

--- a/Source/Planner/Work/AssigningAIIdentity/for_AIIdentityAssignment/when_work_completes/and_an_ai_login_is_configured.cs
+++ b/Source/Planner/Work/AssigningAIIdentity/for_AIIdentityAssignment/when_work_completes/and_an_ai_login_is_configured.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Planner.Issues;
+using Planner.Work.Completing;
+using Planner.Work.Listing;
+using ListedIssue = Planner.Issues.Listing.Issue;
+
+namespace Planner.Work.AssigningAIIdentity.for_AIIdentityAssignment.when_work_completes;
+
+public class and_an_ai_login_is_configured : given.a_reactor
+{
+    void Establish()
+    {
+        _options.AIUserLogin = "stagehand-ai";
+        SetWorkItem(new WorkItem(_workId, WorkPurpose.Implementation, [new IssueId("cratis-studio-1")], ModelName.NotSet, UserName.NotSet));
+        SetIssue(new ListedIssue(
+            "cratis-studio-1", "Cratis", "Studio", 1, "An issue", "Bug", "someuser", DateTimeOffset.UtcNow, AuthorAssociation.Member, true, IssueStatus.ForReview));
+    }
+
+    async Task Because() => await _scenario.Given.ForEventSource(_workId).Events(
+        new WorkCompleted("Done", PullRequestNumber.NotSet, PullRequestUrl.NotSet, OrganizationName.NotSet, RepositoryName.NotSet, TokenCount.NotSet, TokenCount.NotSet, UsageCost.NotSet, 0));
+
+    [Fact]
+    async Task should_unassign_the_issue_from_the_ai_identity() =>
+        await _gitHub.Received(1).UnassignIssue(new OrganizationName("Cratis"), new RepositoryName("Studio"), new IssueNumber(1), new UserName("stagehand-ai"), Arg.Any<CancellationToken>());
+}
+#endif

--- a/Source/Planner/Work/AssigningAIIdentity/for_AIIdentityAssignment/when_work_fails/and_an_ai_login_is_configured.cs
+++ b/Source/Planner/Work/AssigningAIIdentity/for_AIIdentityAssignment/when_work_fails/and_an_ai_login_is_configured.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Planner.Issues;
+using Planner.Work.Failing;
+using Planner.Work.Listing;
+using ListedIssue = Planner.Issues.Listing.Issue;
+
+namespace Planner.Work.AssigningAIIdentity.for_AIIdentityAssignment.when_work_fails;
+
+public class and_an_ai_login_is_configured : given.a_reactor
+{
+    void Establish()
+    {
+        _options.AIUserLogin = "stagehand-ai";
+        SetWorkItem(new WorkItem(_workId, WorkPurpose.Implementation, [new IssueId("cratis-studio-1")], ModelName.NotSet, UserName.NotSet));
+        SetIssue(new ListedIssue(
+            "cratis-studio-1", "Cratis", "Studio", 1, "An issue", "Bug", "someuser", DateTimeOffset.UtcNow, AuthorAssociation.Member, true, IssueStatus.None));
+    }
+
+    async Task Because() => await _scenario.Given.ForEventSource(_workId).Events(new WorkFailed("It broke"));
+
+    [Fact]
+    async Task should_unassign_the_issue_from_the_ai_identity() =>
+        await _gitHub.Received(1).UnassignIssue(new OrganizationName("Cratis"), new RepositoryName("Studio"), new IssueNumber(1), new UserName("stagehand-ai"), Arg.Any<CancellationToken>());
+}
+#endif

--- a/Source/Planner/Work/AssigningAIIdentity/for_AIIdentityAssignment/when_work_starts/and_an_ai_login_is_configured.cs
+++ b/Source/Planner/Work/AssigningAIIdentity/for_AIIdentityAssignment/when_work_starts/and_an_ai_login_is_configured.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Planner.Accounts;
+using Planner.Issues;
+using Planner.Work.Listing;
+using Planner.Work.Starting;
+using ListedIssue = Planner.Issues.Listing.Issue;
+
+namespace Planner.Work.AssigningAIIdentity.for_AIIdentityAssignment.when_work_starts;
+
+public class and_an_ai_login_is_configured : given.a_reactor
+{
+    void Establish()
+    {
+        _options.AIUserLogin = "stagehand-ai";
+        SetWorkItem(new WorkItem(_workId, WorkPurpose.Implementation, [new IssueId("cratis-studio-1")], ModelName.NotSet, UserName.NotSet));
+        SetIssue(new ListedIssue(
+            "cratis-studio-1", "Cratis", "Studio", 1, "An issue", "Bug", "someuser", DateTimeOffset.UtcNow, AuthorAssociation.Member, true, IssueStatus.InProgress));
+    }
+
+    async Task Because() => await _scenario.Given.ForEventSource(_workId).Events(new WorkStarted(AccountId.New(), "sonnet"));
+
+    [Fact]
+    async Task should_assign_the_issue_to_the_ai_identity() =>
+        await _gitHub.Received(1).AssignIssue(new OrganizationName("Cratis"), new RepositoryName("Studio"), new IssueNumber(1), new UserName("stagehand-ai"), Arg.Any<CancellationToken>());
+}
+#endif

--- a/Source/Planner/Work/AssigningAIIdentity/for_AIIdentityAssignment/when_work_starts/and_no_ai_login_is_configured.cs
+++ b/Source/Planner/Work/AssigningAIIdentity/for_AIIdentityAssignment/when_work_starts/and_no_ai_login_is_configured.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Planner.Accounts;
+using Planner.Issues;
+using Planner.Work.Listing;
+using Planner.Work.Starting;
+using ListedIssue = Planner.Issues.Listing.Issue;
+
+namespace Planner.Work.AssigningAIIdentity.for_AIIdentityAssignment.when_work_starts;
+
+public class and_no_ai_login_is_configured : given.a_reactor
+{
+    void Establish()
+    {
+        SetWorkItem(new WorkItem(_workId, WorkPurpose.Implementation, [new IssueId("cratis-studio-1")], ModelName.NotSet, UserName.NotSet));
+        SetIssue(new ListedIssue(
+            "cratis-studio-1", "Cratis", "Studio", 1, "An issue", "Bug", "someuser", DateTimeOffset.UtcNow, AuthorAssociation.Member, true, IssueStatus.InProgress));
+    }
+
+    async Task Because() => await _scenario.Given.ForEventSource(_workId).Events(new WorkStarted(AccountId.New(), "sonnet"));
+
+    [Fact]
+    async Task should_not_assign_anything() =>
+        await _gitHub.DidNotReceive().AssignIssue(Arg.Any<OrganizationName>(), Arg.Any<RepositoryName>(), Arg.Any<IssueNumber>(), Arg.Any<UserName>(), Arg.Any<CancellationToken>());
+}
+#endif

--- a/Source/Planner/Work/ReportingInvestigation/ReportingInvestigation.cs
+++ b/Source/Planner/Work/ReportingInvestigation/ReportingInvestigation.cs
@@ -40,7 +40,7 @@ public class InvestigationReporting(IEventStore eventStore, ICommandPipeline com
                     issue.Owner,
                     issue.Repository,
                     issue.Number,
-                    $"## Investigation\n\n{@event.Findings.Value}\n\n_Suggested model for implementation: `{@event.SuggestedModel.Value}`_");
+                    $"## Investigation\n\n{@event.Findings.Value}\n\n_Suggested model for implementation: `{@event.SuggestedModel.Value}`_{AIIdentity.Footer()}");
             }
         }
     }

--- a/Source/Planner/Work/Workers/WorkerEnvironment.cs
+++ b/Source/Planner/Work/Workers/WorkerEnvironment.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.Options;
 using Planner.Accounts.Credentials;
 using Planner.Alerts;
+using Planner.GitHub;
 using Planner.GitHub.App;
 using Planner.GitHub.GitIdentity;
 using Planner.GitHub.GitIdentity.Listing;
@@ -51,12 +52,11 @@ public class WorkerEnvironment(
             ["CLAUDE_CODE_OAUTH_TOKEN"] = credentials.Token.Value
         };
 
+        // A fresh deployment should never be stuck without a commit identity - fall back to the
+        // Planner's own AI identity rather than leaving worker commits unattributed.
         var gitIdentity = await readModels.GetInstanceById<ConfiguredGitIdentity>((EventSourceId)GitIdentityId.Default);
-        if (gitIdentity is not null)
-        {
-            environment["PLANNER_GIT_USER_NAME"] = gitIdentity.Name.Value;
-            environment["PLANNER_GIT_USER_EMAIL"] = gitIdentity.Email.Value;
-        }
+        environment["PLANNER_GIT_USER_NAME"] = gitIdentity?.Name.Value ?? AIIdentity.DefaultGitUserName.Value;
+        environment["PLANNER_GIT_USER_EMAIL"] = gitIdentity?.Email.Value ?? AIIdentity.DefaultGitUserEmail.Value;
 
         return work.Purpose switch
         {


### PR DESCRIPTION
# Summary

Names the Planner's AI identity - **Stagehand (AI)**, in the Cratis
theatre vocabulary - and makes it visible everywhere the Planner or a
worker writes to GitHub, instead of looking like an anonymous bot or,
worse, a person.

## Added

- `AIIdentity` - the display name and the comment footer every GitHub-writing code path can reuse (#72)
- `SetGitIdentity` now rejects a name that doesn't read as AI and an email that isn't a GitHub noreply address; a fresh deployment defaults to the AI identity instead of committing unattributed (#72)
- Investigation comments and issues created from a converted alert carry an AI-authored footer (#72)
- Opt-in issue assignment: set `Planner:GitHubApp:AIUserLogin` to a machine user's login and the Planner assigns/unassigns covered issues as work starts and finishes - a silent no-op when unset, since GitHub cannot assign issues to an App itself (#72)

## Changed

- The default GitHub App name is now "Stagehand (AI)" instead of "Cratis Planner" (#72)

## Related

Still open from Cratis/Stagehand#6: deciding between staying App-only vs. adding a real machine user account is an operator decision (this PR adds the plumbing either way); hands-off App connection (encrypted-at-rest credentials, no copy-and-restart) is a separate, larger piece of work.