### PR TITLE
Never rewrite history, and never squash or rebase a merge

### DIFF
--- a/.ai/rules/git-commits.md
+++ b/.ai/rules/git-commits.md
@@ -6,6 +6,49 @@ applyTo: "**/*"
 
 Commits are the permanent record of how the codebase evolved. Each commit should tell a clear story: *what* changed and *why*. A reviewer reading `git log --oneline` should understand the arc of the work without opening any diffs.
 
+## Never rewrite history
+
+**Committed history is append-only. Never rewrite it — under any circumstances, on any branch, including your own.**
+
+These commands are **forbidden** unless the human explicitly asks for that specific command on that specific branch in that specific message:
+
+| Forbidden | Why |
+|---|---|
+| `git rebase` (any form, incl. `-i`, `--onto`, `--autosquash`) | rewrites every replayed commit; the originals become unreachable |
+| `git commit --amend` | replaces the tip commit; the original is unreachable immediately |
+| `git reset --hard`, `git reset` onto an earlier commit | discards commits and, with `--hard`, uncommitted work too |
+| `git push --force`, `git push --force-with-lease`, `git push -f` | destroys the remote's copy — the one backup that survives local loss |
+| `git branch -D` / `git branch -d` on a branch holding unmerged commits | strands those commits with no ref; `git gc` then deletes them |
+| `git checkout`/`git switch` away while another agent's commits sit only on this branch | the commits leave with the branch and the working tree silently reverts |
+| `git filter-branch`, `git filter-repo`, history-rewriting scripts | rewrites the entire history graph |
+| `git gc --prune=now`, `git reflog expire` | destroys the recovery path for anything already stranded |
+| `git merge --squash`, `gh pr merge --squash`, `--rebase`, the **Squash and merge** / **Rebase and merge** buttons | collapses or replays the branch's commits into new ones; every original commit becomes unreachable and the branch's real history is destroyed at the moment of merge |
+
+**Merging is part of this rule, and it is the easiest place to get it wrong.** A squash merge feels
+like an integration step rather than a rewrite, which is exactly why it slips past: the branch is
+deleted straight afterwards, so the commits it collapsed have no ref left and `gc` eventually takes
+them. **Always merge with a true merge commit** — `git merge --no-ff`, or `gh pr merge --merge`.
+Never `--squash`, never `--rebase`, and never the equivalent buttons in the GitHub UI.
+
+If a repository's settings only allow squash or rebase merges, that is a **setting to raise with the
+owner, not a licence to squash.** Stop and ask.
+
+**This is not stylistic.** A commit can exist as an object (`git cat-file -t <sha>` succeeds) while being absent from every branch *and* from the working tree — reachable only through `git reflog`, and only until `gc` runs. Work has already been lost in this repository exactly this way: a branch checkout carried another session's commit away, the branch was deleted, and the file changes silently reverted in the tree. It was recovered from the reflog by luck, because someone asked the right question in time.
+
+### What to do instead
+
+- **Made a mistake in the last commit?** Add a new commit that corrects it. The wrong state stays in history, and that is fine — history is a record of what happened, not a curated story of what you wish had happened.
+- **Need to undo a commit?** `git revert <sha>` — it records the undo as a new commit and loses nothing.
+- **Messy commits before a PR?** Leave them. A reviewer reading a coherent series of small commits is better served than by one squashed blob, and the project does not require a linear history.
+- **Landing a PR?** `gh pr merge --merge` (a real merge commit). **Not `--squash`, not `--rebase`.** The commits on the branch are the record of how the change was actually built; squashing throws that away permanently in exchange for a tidier `main`, which is not a trade this project makes.
+- **Need someone else's changes?** `git merge`, never `git rebase`.
+- **Need to move a commit to another branch?** `git cherry-pick` — it copies, leaving the original reachable.
+- **Working alongside another agent or session?** Use `git worktree add` so each has its own checkout and branch. Never two sessions committing in one working tree.
+
+### Before you finish
+
+Verify your own commits are still reachable on the branch **and** that their content is still in the working tree — those are two different things. `git log --oneline -5` plus a `grep` for something the commit introduced. If a commit has gone missing, `git reflog` is the recovery tool: find the SHA, `git tag` it immediately so `gc` cannot take it, then `git cherry-pick` it back.
+
 ## Logical Grouping
 
 Every commit must be a **single logical unit of work**. Group related changes together; separate unrelated changes into distinct commits.
@@ -29,6 +72,7 @@ Every commit must be a **single logical unit of work**. Group related changes to
 Ask: "If I needed to revert this commit, would I lose exactly one coherent change?" If reverting would undo two unrelated things, it should be two commits.
 
 Common split points:
+
 1. **Infrastructure / plumbing first** — interface additions, new types, or schema changes that later commits build on.
 2. **Core logic second** — the behavioral change that uses the new infrastructure.
 3. **Specs / tests third** — the specs that prove the behavioral change works. Specs may also be combined with the core logic commit when they are tightly coupled (e.g., a TDD red-green cycle or a bug fix with its regression test).
@@ -40,7 +84,7 @@ When a task produces both source fixes and new integration specs, prefer separat
 
 ### Format
 
-```
+```text
 <imperative summary of what this commit does>
 
 <optional body — why the change was made, context, trade-offs>
@@ -53,14 +97,14 @@ When a task produces both source fixes and new integration specs, prefer separat
 
 ### Good examples
 
-```
+```text
 Fix duplicate key crash in IdentityStorage.Populate
 
 The upsert used InsertOne which threw on existing identities.
 Replace with ReplaceOne using upsert: true.
 ```
 
-```
+```text
 Add type-safe event migration API with expression-based builders
 
 Introduce EventTypeMigration<TUpgrade, TPrevious> base class with
@@ -68,7 +112,7 @@ typed property builders for Split, Join, Rename, and DefaultValue
 operations. Migrators are discovered automatically by convention.
 ```
 
-```
+```text
 Add integration specs for observer replay on redaction
 ```
 

--- a/.ai/skills/ship-changes/SKILL.md
+++ b/.ai/skills/ship-changes/SKILL.md
@@ -14,6 +14,15 @@ This skill takes local modifications from the working tree and lands them on
 project conventions for commits, PR descriptions, and labels — and leaves no
 resolved issue open behind it.
 
+> **Never rewrite history while shipping.** No `rebase`, no `commit --amend`, no
+> `reset --hard`, no `push --force` (or `--force-with-lease`), no deleting a branch that
+> still holds unmerged commits — on any branch, including your own, unless the human asks
+> for that exact command in that exact message. Correct a mistake with a **new commit**;
+> undo with `git revert`; move work with `git cherry-pick`; integrate with `git merge`.
+> Do not tidy a messy series before opening the PR — the series is the record.
+> See [git-commits.md](../../rules/git-commits.md#never-rewrite-history) for the full
+> prohibition and the recovery procedure.
+
 ## Inputs
 
 Collect the following before starting:
@@ -24,7 +33,7 @@ Collect the following before starting:
 
 ## Step 1 — Review the working tree
 
-```
+```bash
 git status
 git diff
 ```
@@ -42,7 +51,7 @@ Branch off of current `main`. Always use a prefix:
 | `feat/` | new features, new slices, new capabilities |
 | `chore/` | build infra, tooling, docs, refactoring |
 
-```
+```bash
 git checkout -b <prefix>/<short-description>
 ```
 
@@ -63,7 +72,7 @@ Never mix unrelated changes in a single commit.
 
 Stage files explicitly — never `git add .` or `git add -A`:
 
-```
+```bash
 git add <file1> <file2>
 git diff --cached          # verify staged content before committing
 git commit -m "<message>"
@@ -71,7 +80,7 @@ git commit -m "<message>"
 
 ### Commit message format
 
-```
+```text
 <imperative summary — 72-char max, no trailing period>
 
 <optional body: WHY the change was made, context, trade-offs>
@@ -84,7 +93,7 @@ git commit -m "<message>"
 
 **Good examples:**
 
-```
+```text
 Add _PackPrivateAssemblyGlobs target for runtime-only NuGet package embedding
 
 Extend the shared client build infrastructure with a new MSBuild target.
@@ -92,7 +101,7 @@ The new PrivatePackageAssemblyGlob item type globs $(OutputPath) at pack
 time and embeds matching DLLs into lib/{tfm}/ without a nuspec dependency.
 ```
 
-```
+```text
 Fix duplicate key crash in IdentityStorage.Populate
 
 The upsert used InsertOne which threw on existing identities.
@@ -108,7 +117,7 @@ Replace with ReplaceOne using upsert: true.
 
 ## Step 4 — Push the branch
 
-```
+```bash
 git push -u origin <branch-name>
 ```
 
@@ -142,6 +151,7 @@ release notes. Include only non-empty sections.
 ```
 
 Rules:
+
 - Bullets are short, release-note ready, written for a user reading the changelog.
 - Use `# Summary` when the release-note bullets need context. The summary should
   explain what was fixed from the consumer's point of view and why the fix matters
@@ -152,7 +162,7 @@ Rules:
 
 ### Searching for a related issue
 
-```
+```text
 mcp_github_github_search_issues  query="<keywords> repo:<owner>/<repo>"
 ```
 
@@ -188,6 +198,13 @@ Otherwise use `gh pr edit <number> --add-label "<label>"` with one of:
 
 If `gh pr edit` fails on the Projects-classic GraphQL deprecation, add the label with the REST API instead: `gh api -X POST repos/<owner>/<repo>/issues/<number>/labels -f "labels[]=<label>"`. Label **before** the PR's first `verify` run where you can — a run that starts before the label lands sees no label and fails, and needs re-running.
 
+> **The same deprecation breaks `gh pr edit --body-file`, and it fails silently.** `gh pr edit` queries `repository.pullRequest.projectCards` whatever you are editing, so it can error on the deprecation *after* printing nothing useful and leave the body untouched. Always re-read the body after editing it — `gh api repos/<owner>/<repo>/pulls/<number> --jq '.body'` — and if it did not take, PATCH it directly:
+>
+> ```bash
+> printf '%s' "$(cat body.md)" | python3 -c 'import json,sys; print(json.dumps({"body": sys.stdin.read()}))' \
+>   | gh api -X PATCH repos/<owner>/<repo>/pulls/<number> --input -
+> ```
+
 ## Step 7 — Wait for CI to pass
 
 **Skip this step entirely for a documentation-only PR** — merge as soon as it is open. Its `verify` will be red for the deliberately absent version label, and that is the expected outcome, not a failure to chase.
@@ -202,9 +219,20 @@ Otherwise, before merging, poll the PR checks with `pull_request_read`:
 
 Use `mcp_github_github_merge_pull_request` with:
 
-- `merge_method`: `merge`
+- `merge_method`: **`merge`** — a real merge commit, always
 - `owner` / `repo`: the current repository (same as step 5)
 - `pullNumber`: the PR number returned in step 5
+
+**`merge_method` is `merge` and nothing else. Never `squash`, never `rebase`** — and the same
+applies if you reach for the CLI instead: `gh pr merge --merge`, never `gh pr merge --squash` or
+`--rebase`. Squashing is a **history rewrite** (`.ai/rules/git-commits.md#never-rewrite-history`):
+it replaces the branch's commits with one new commit, and because step 10 deletes the branch
+immediately afterwards, nothing is left pointing at the originals. It does not feel like a rewrite
+— it looks like an integration step, and the tidier result looks like an improvement — which is
+precisely why it is the easiest way to break the rule by accident.
+
+If the repository's settings permit only squash or rebase merges, **stop and ask the human.** That
+is a setting to change, not a reason to squash.
 
 ## Step 9 — Close the related issues
 
@@ -218,7 +246,7 @@ on a closing keyword, and this repo deliberately keeps those out of the PR body
 
 For each issue the merged PR **fully resolves**:
 
-```
+```bash
 gh issue close <N> --repo <owner>/<tracker-repo> --comment "Fixed in <owner>/<repo>#<pr-number>."
 gh issue view <N> --repo <owner>/<tracker-repo> --json number,state    # verify it is CLOSED
 ```
@@ -254,18 +282,24 @@ separate public repo (check `.agents/PROJECT.md`). Two consequences:
 
 ## Step 10 — Clean up the branch
 
-```
+```bash
 git checkout main && git pull && git branch -d <branch-name> && git push origin --delete <branch-name>
 ```
 
 Run all four commands in one shell invocation to avoid partial state.
 After this completes, `main` is fully up to date locally.
 
+**Only ever after the merge, and only with lowercase `-d`.** `-d` refuses to delete a
+branch holding commits that are not merged anywhere — that refusal is a safety net, not an
+obstacle. **Never reach for `-D` to force past it**: it strands those commits with no ref,
+and `git gc` then deletes them permanently. If `-d` refuses, the branch still holds work
+that exists nowhere else — stop and find out what it is.
+
 ## Full example sequence
 
 An illustrative end-to-end run for a new slice (paths and numbers are placeholders — use the current repo's):
 
-```
+```bash
 # 1. Review
 git status
 git diff
@@ -294,7 +328,8 @@ gh pr edit <pr-number> --add-label "minor"
 
 # 7. Wait for CI — pull_request_read get_check_runs until green
 
-# 8. Merge (via mcp_github_github_merge_pull_request)
+# 8. Merge (via mcp_github_github_merge_pull_request, merge_method: merge)
+#    CLI equivalent: gh pr merge <pr-number> --merge   # NEVER --squash / --rebase
 
 # 9. Close the issues the PR resolves, and verify
 gh issue close <issue-number> --comment "Fixed in #<pr-number>."


### PR DESCRIPTION
# Summary

`main` has no history rule at all. It exists only on the unmerged `fix/ai-platform-hardening` branch, so every repository the corpus propagates to — around 35 — is running without it today. For a corpus whose purpose is to be the specification of the developer, that is backwards.

## Added

- A **Never rewrite history** section in `git-commits.md`: a table of forbidden commands (`rebase`, `commit --amend`, `reset --hard`, `push --force`, `branch -D` on unmerged work, `filter-branch`, `gc --prune=now`), what to do instead (`revert`, `cherry-pick`, `merge`, worktrees), and how to recover from the reflog.

## Changed

- **Squash and rebase merges are now explicitly forbidden**, not merely discouraged — `git merge --squash`, `gh pr merge --squash`, `--rebase`, and the equivalent GitHub buttons. They are history rewrites: they replace a branch's commits with new ones, and since the branch is normally deleted straight afterwards, nothing points at the originals.
- Merging is stated positively: **always a real merge commit** — `gh pr merge --merge` / `merge_method: merge`. A repository configured to allow only squash or rebase merges is a setting to raise with the owner, not a licence to squash.
- `ship-changes` step 8 already passed `merge_method: merge` but never said *why* and gave no CLI equivalent, so an agent reaching for `gh` instead of the MCP tool had nothing to stop it. It now says both and points back at the rule.

## Why this wording

Neither gap is hypothetical.

- **History loss has happened here**: a branch checkout carried another session's commit away, the branch was deleted, and the file changes silently reverted in the working tree. It was recovered from the reflog by luck.
- **The squash gap was found by falling through it**: this session squash-merged a PR while believing it was complying with the rule. The rule named squashing only as advice about commit hygiene, never as a merge prohibition — so every word could be honoured while a branch history was destroyed at merge time.

## Verification

`bash .ai/hooks/scripts/validate-ai-setup.sh` → exit 0.

Documentation-only: no version label, and per `pull-requests.md` a docs-only PR does not wait on checks.
