### PR TITLE
Stop work status propagation from quarantining its observer

### DIFF
--- a/Source/Planner/Issues/Listing/for_Issue/when_projecting/and_an_investigated_issue_is_handed_back.cs
+++ b/Source/Planner/Issues/Listing/for_Issue/when_projecting/and_an_investigated_issue_is_handed_back.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Planner.Issues.ChangingStatus;
+using Planner.Issues.RecordingInvestigation;
+using Planner.Issues.Registration;
+
+namespace Planner.Issues.Listing.for_Issue.when_projecting;
+
+/// <summary>
+/// The shape an auto-investigated issue ends up in: an agent picked it up, produced a plan, and
+/// handed it back. It must read as waiting for a human - findings and suggested model attached,
+/// status back to none - and never as still in progress, which is where the scheduler can never
+/// reach it again.
+/// </summary>
+public class and_an_investigated_issue_is_handed_back : Specification
+{
+    static readonly IssueId _issueId = IssueId.From("Cratis", "Studio", 512);
+
+    ReadModelScenario<Issue> _scenario;
+
+    void Establish() => _scenario = new();
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_issueId)
+            .Events(
+                new IssueRegistered("Cratis", "Studio", 512, "Something is broken", "Bug", "someuser", DateTimeOffset.UnixEpoch, AuthorAssociation.External, true, IssueBody.NotSet, []),
+                new IssueDevelopmentStarted(),
+                new IssueInvestigated("Split the reducer and project the totals instead", "opus"),
+                new IssueStatusCleared());
+
+    [Fact] void should_have_no_status() => _scenario.Instance.Status.ShouldEqual(IssueStatus.None);
+    [Fact] void should_keep_the_investigation() => _scenario.Instance.Investigation.ShouldEqual(new InvestigationSummary("Split the reducer and project the totals instead"));
+    [Fact] void should_keep_the_suggested_model() => _scenario.Instance.SuggestedModel.ShouldEqual(new ModelName("opus"));
+}
+#endif

--- a/Source/Planner/Work/PropagatingStatus/PropagatingStatus.cs
+++ b/Source/Planner/Work/PropagatingStatus/PropagatingStatus.cs
@@ -5,6 +5,7 @@ using Planner.Issues;
 using Planner.Issues.AssociatingPullRequest;
 using Planner.Issues.ChangingStatus;
 using Planner.Work.Completing;
+using Planner.Work.CompletingInvestigation;
 using Planner.Work.Failing;
 using Planner.Work.Listing;
 using Planner.Work.Starting;
@@ -15,7 +16,8 @@ namespace Planner.Work.PropagatingStatus;
 /// <summary>
 /// Reacts to work lifecycle events by propagating the resulting status onto the covered issues:
 /// started work puts them in progress, completed work associates the produced pull request and
-/// marks them for review, and failed work clears their status so a human decides what happens next.
+/// marks them for review, and failed, stopped or investigated work clears their status so a human
+/// decides what happens next.
 /// </summary>
 /// <param name="eventStore">The <see cref="IEventStore"/> for reading the work's read model.</param>
 /// <param name="commandPipeline">The <see cref="ICommandPipeline"/> for executing commands.</param>
@@ -29,8 +31,7 @@ public class WorkStatusPropagation(IEventStore eventStore, ICommandPipeline comm
     /// <returns>Awaitable task.</returns>
     public async Task On(WorkStarted @event, EventContext context)
     {
-        var work = await eventStore.ReadModels.GetInstanceById<WorkItem>(context.EventSourceId);
-        foreach (var issue in work.Issues)
+        foreach (var issue in await CoveredIssues(context))
         {
             await commandPipeline.Execute(new ChangeIssueStatus(issue, IssueStatus.InProgress));
         }
@@ -45,9 +46,8 @@ public class WorkStatusPropagation(IEventStore eventStore, ICommandPipeline comm
     /// <returns>Awaitable task.</returns>
     public async Task On(WorkCompleted @event, EventContext context)
     {
-        var work = await eventStore.ReadModels.GetInstanceById<WorkItem>(context.EventSourceId);
         var hasPullRequest = @event.PullRequest != PullRequestNumber.NotSet;
-        foreach (var issue in work.Issues)
+        foreach (var issue in await CoveredIssues(context))
         {
             if (hasPullRequest)
             {
@@ -71,8 +71,7 @@ public class WorkStatusPropagation(IEventStore eventStore, ICommandPipeline comm
     /// <returns>Awaitable task.</returns>
     public async Task On(WorkFailed @event, EventContext context)
     {
-        var work = await eventStore.ReadModels.GetInstanceById<WorkItem>(context.EventSourceId);
-        foreach (var issue in work.Issues)
+        foreach (var issue in await CoveredIssues(context))
         {
             await commandPipeline.Execute(new ChangeIssueStatus(issue, IssueStatus.None));
         }
@@ -86,10 +85,46 @@ public class WorkStatusPropagation(IEventStore eventStore, ICommandPipeline comm
     /// <returns>Awaitable task.</returns>
     public async Task On(WorkStopped @event, EventContext context)
     {
-        var work = await eventStore.ReadModels.GetInstanceById<WorkItem>(context.EventSourceId);
-        foreach (var issue in work.Issues)
+        foreach (var issue in await CoveredIssues(context))
         {
             await commandPipeline.Execute(new ChangeIssueStatus(issue, IssueStatus.None));
         }
+    }
+
+    /// <summary>
+    /// Hands every covered issue back to a human when an investigation completes. An investigation
+    /// produces a plan and a suggested model - both recorded on the issue and posted to GitHub -
+    /// but no code and no pull request, so the issue is not in progress and not for review. Clearing
+    /// the status returns it to the backlog with its findings attached, where a person decides
+    /// whether to mark it ready for development; promoting it automatically would send an agent
+    /// straight at code an outside reporter asked for, with nobody having read the plan.
+    /// </summary>
+    /// <param name="event">The <see cref="InvestigationCompleted"/> event.</param>
+    /// <param name="context">The <see cref="EventContext"/>.</param>
+    /// <returns>Awaitable task.</returns>
+    public async Task On(InvestigationCompleted @event, EventContext context)
+    {
+        foreach (var issue in await CoveredIssues(context))
+        {
+            await commandPipeline.Execute(new ChangeIssueStatus(issue, IssueStatus.None));
+        }
+    }
+
+    /// <summary>
+    /// The issues a unit of work covers, or nothing at all when it covers none. Ad-hoc work and
+    /// alert investigations are not about issues, and <see cref="WorkItem.Issues"/> is not populated
+    /// for them - an alert investigation is scheduled by an event that carries no issues at all. The
+    /// work item can also be absent entirely when the read model has not caught up. None of those is
+    /// a reason to throw: a throw here pauses the partition and can quarantine the observer, which
+    /// does not resume on its own.
+    /// </summary>
+    /// <param name="context">The <see cref="EventContext"/> of the work lifecycle event.</param>
+    /// <returns>The identities of the covered issues.</returns>
+    async Task<IEnumerable<IssueId>> CoveredIssues(EventContext context)
+    {
+        var work = await eventStore.ReadModels.GetInstanceById<WorkItem>(context.EventSourceId);
+        return work?.Purpose is WorkPurpose.Investigation or WorkPurpose.Implementation
+            ? work.Issues ?? []
+            : [];
     }
 }

--- a/Source/Planner/Work/PropagatingStatus/for_WorkStatusPropagation/when_an_investigation_completes.cs
+++ b/Source/Planner/Work/PropagatingStatus/for_WorkStatusPropagation/when_an_investigation_completes.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Planner.Issues;
+using Planner.Issues.ChangingStatus;
+using Planner.Work.CompletingInvestigation;
+using Planner.Work.Listing;
+
+namespace Planner.Work.PropagatingStatus.for_WorkStatusPropagation;
+
+/// <summary>
+/// Investigation work reports back with <see cref="InvestigationCompleted"/> rather than
+/// <see cref="Completing.WorkCompleted"/>, so an issue put in progress when the investigation
+/// started must be handed back to a human here - otherwise it reads as "an agent is working on it"
+/// forever and the scheduler, which only picks up ready issues, can never touch it again.
+/// </summary>
+public class when_an_investigation_completes : given.a_work_item
+{
+    void Establish() => SetWorkItem(new WorkItem(
+        _workId,
+        WorkPurpose.Investigation,
+        [new IssueId("cratis-studio-1")],
+        ModelName.NotSet,
+        UserName.NotSet));
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_workId)
+            .Events(new InvestigationCompleted(
+                "Split the reducer and project the totals instead",
+                "opus",
+                TokenCount.NotSet,
+                TokenCount.NotSet,
+                UsageCost.NotSet,
+                1000));
+
+    [Fact]
+    async Task should_clear_the_status_of_the_investigated_issue() =>
+        await _commandPipeline.Received(1).Execute(Arg.Is<ChangeIssueStatus>(command =>
+            command.Issue == new IssueId("cratis-studio-1") && command.Status == IssueStatus.None));
+
+    [Fact]
+    async Task should_not_leave_the_issue_in_progress() =>
+        await _commandPipeline.DidNotReceive().Execute(Arg.Is<ChangeIssueStatus>(command =>
+            command.Status == IssueStatus.InProgress));
+}
+#endif

--- a/Source/Planner/Work/PropagatingStatus/for_WorkStatusPropagation/when_work_starts/and_the_work_covers_issues.cs
+++ b/Source/Planner/Work/PropagatingStatus/for_WorkStatusPropagation/when_work_starts/and_the_work_covers_issues.cs
@@ -8,9 +8,9 @@ using Planner.Issues.ChangingStatus;
 using Planner.Work.Listing;
 using Planner.Work.Starting;
 
-namespace Planner.Work.PropagatingStatus.for_WorkStatusPropagation;
+namespace Planner.Work.PropagatingStatus.for_WorkStatusPropagation.when_work_starts;
 
-public class when_work_starts : given.a_work_item
+public class and_the_work_covers_issues : given.a_work_item
 {
     void Establish() => SetWorkItem(new WorkItem(
         _workId,

--- a/Source/Planner/Work/PropagatingStatus/for_WorkStatusPropagation/when_work_starts/and_the_work_is_an_alert_investigation.cs
+++ b/Source/Planner/Work/PropagatingStatus/for_WorkStatusPropagation/when_work_starts/and_the_work_is_an_alert_investigation.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Planner.Accounts;
+using Planner.Issues.ChangingStatus;
+using Planner.Work.Listing;
+using Planner.Work.Starting;
+
+namespace Planner.Work.PropagatingStatus.for_WorkStatusPropagation.when_work_starts;
+
+/// <summary>
+/// An alert investigation is scheduled by an event that carries no issues at all, so nothing
+/// populates <see cref="WorkItem.Issues"/> and it comes back unset. The reactor subscribes to
+/// <see cref="WorkStarted"/> for every purpose, so this is a shape it genuinely sees in production.
+/// The handler is invoked directly rather than through the scenario, because the reactor invoker -
+/// in the scenario exactly as in production - captures a handler exception into its invocation
+/// result instead of surfacing it. A throw would therefore look like a passing spec here, while in
+/// production it pauses the partition and can quarantine the observer for good.
+/// </summary>
+public class and_the_work_is_an_alert_investigation : given.a_work_item
+{
+    WorkStatusPropagation _reactor;
+    Exception _error;
+
+    void Establish()
+    {
+        SetWorkItem(new WorkItem(
+            _workId,
+            WorkPurpose.AlertInvestigation,
+            null!,
+            ModelName.NotSet,
+            UserName.NotSet));
+        _reactor = new(_eventStore, _commandPipeline);
+    }
+
+    async Task Because() => _error = await Cratis.Specifications.Catch.Exception(() =>
+        _reactor.On(new WorkStarted(AccountId.New(), "sonnet"), EventContext.EmptyWithEventSourceId(_workId)));
+
+    [Fact] void should_not_fail_the_partition() => _error.ShouldBeNull();
+
+    [Fact]
+    async Task should_leave_every_issue_alone() =>
+        await _commandPipeline.DidNotReceive().Execute(Arg.Any<ChangeIssueStatus>());
+}
+#endif

--- a/Source/Planner/Work/ReportingInvestigation/ReportingInvestigation.cs
+++ b/Source/Planner/Work/ReportingInvestigation/ReportingInvestigation.cs
@@ -28,8 +28,11 @@ public class InvestigationReporting(IEventStore eventStore, ICommandPipeline com
     [OnceOnly]
     public async Task On(InvestigationCompleted @event, EventContext context)
     {
+        // The work item can be absent, and its issues unset, for the same reasons a status
+        // propagation can find nothing to propagate - neither is worth throwing over, because a
+        // throw pauses the partition and can quarantine the observer.
         var work = await eventStore.ReadModels.GetInstanceById<WorkItem>(context.EventSourceId);
-        foreach (var issueId in work.Issues)
+        foreach (var issueId in work?.Issues ?? [])
         {
             await commandPipeline.Execute(new RecordInvestigation(issueId, @event.Findings, @event.SuggestedModel));
 


### PR DESCRIPTION
# Summary

Every alert investigation currently quarantines the work-status observer on `main`. A throw inside a reactor pauses the partition and quarantines the observer, and the observer does **not** resume on its own — so this is not a transient error, it is a stuck pipeline that needs an operator to clear.

## Fixed

- Work status propagation no longer quarantines its observer when work has no covered issues. `WorkStatusPropagation` and `InvestigationReporting` both read the `WorkItem` read model and iterated `work.Issues` unguarded. Neither is populated for an alert investigation — it is scheduled by an event carrying no issues at all — and the read model can be absent entirely when it has not caught up yet. Both are now guarded and filtered by purpose, so only `Investigation` and `Implementation` work propagates issue status.
- Investigation work no longer strands its issues at **In progress** forever. Nothing handled `InvestigationCompleted`: an investigation produces a plan and a suggested model, but no code and no pull request, so the terminal transition never fired.

## Verification

| Check | Result |
| --- | --- |
| `dotnet build Planner.slnx -c Debug` | 0 errors |
| `dotnet test Source/Planner/Planner.csproj -c Debug` | **389 passed, 0 failed** (362 on `main`) |

Proven load-bearing rather than merely observed green: restoring the unguarded read that is on `main` today fails `when_work_starts/and_the_work_is_an_alert_investigation`, and restoring the guard returns the suite to green.

The one build warning is the pre-existing `ASPIRE010` diagnostic, which reproduces on a pristine `main` checkout and is unrelated to this change.
