### PR TITLE
Capture a crash dump when the Planner dies on a fatal signal

### DIFF
--- a/Documentation/Planner/running-in-the-cloud.md
+++ b/Documentation/Planner/running-in-the-cloud.md
@@ -68,10 +68,87 @@ env:
   re-registered on every start (see [Configuration](./configuration.md#orleans---plannerorleans)).
   The key deliberately sits under `Planner:`, not under `Orleans:` - that section belongs to Orleans,
   which reads `Orleans:Clustering` as the name of a clustering provider it must resolve.
-- Set `DOTNET_DbgEnableMiniDump=1` (and `DOTNET_DbgMiniDumpType=4`, with `DOTNET_DbgMiniDumpName`
-  pointing at a mounted path) when investigating a silent native crash. A container that dies with
-  exit 139 and no log output leaves nothing to attach a stack to otherwise; the dump is the only
-  artifact that turns one into a diagnosable failure.
+- Crash dump capture is already configured in the image, but a dump only survives the container
+  that wrote it if `/dumps` is a mounted volume, which the Deployment has to supply - see
+  [Crash dumps](#crash-dumps).
+
+## Crash dumps
+
+A container that dies with exit 139 (SIGSEGV) and no log output leaves nothing to attach a stack
+to. The Planner image is therefore built to write a dump on any native crash. The variables are
+baked into `Source/Planner/Dockerfile`, so there is nothing to set in the Deployment:
+
+| Variable | Value in the image | What it does |
+| --- | --- | --- |
+| `DOTNET_DbgEnableMiniDump` | `1` | Enables core dump generation. Off by default |
+| `DOTNET_DbgMiniDumpType` | `2` (`Heap`) | Module and thread lists, all stacks, exception and handle information, and all memory except mapped module images |
+| `DOTNET_DbgMiniDumpName` | `/dumps/planner.%p.%t.dmp` | Where the dump is written. `%p` is the process id and `%t` the crash time in seconds since the epoch, so successive crashes never overwrite each other |
+| `DOTNET_EnableCrashReport` | `1` | Also writes a JSON report of the threads and stack frames of the crashing process, named after the dump with `.crashreport.json` appended |
+| `DOTNET_CreateDumpDiagnostics` | `1` | Logs what `createdump` itself did to the crashing process's console, so a dump that fails to be written says why instead of failing silently |
+
+`Heap` rather than `Full`: it keeps every stack and all memory except the mapped module images,
+which are recoverable from the image anyway, while a `Full` dump is materially more likely to
+exceed the pod's ephemeral-storage limit - and overrunning an `emptyDir` evicts the pod, deleting
+the very dump that was being written. See the .NET
+[Collect dumps on crash](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/collect-dumps-crash)
+reference for the full set of variables.
+
+### The dump is worthless without a volume
+
+`/dumps` exists in the image because `createdump` opens the dump file but never creates the
+directory it lives in. It is still in the container's **writable layer**, and a container that
+exits 139 is discarded and replaced by a fresh one - so unless that path is a volume, the dump
+dies with the container that wrote it. Add to the Planner Deployment:
+
+```yaml
+spec:
+  template:
+    spec:
+      volumes:
+        - name: dumps
+          emptyDir:
+            sizeLimit: 2Gi
+      containers:
+        - name: planner
+          volumeMounts:
+            - name: dumps
+              mountPath: /dumps
+```
+
+An `emptyDir` lives as long as the **pod**, not the container. It survives the crash and restart
+that a SIGSEGV self-heals from, which is exactly the case here, but a rollout, an eviction or a
+node drain removes the pod and takes the dump with it. That is enough **provided someone collects
+the dump before the next rollout**. Use a `PersistentVolumeClaim` instead if a dump has to outlive
+the pod.
+
+Two traps:
+
+- Keep `sizeLimit` **below** the container's `resources.limits.ephemeral-storage`. A disk-backed
+  `emptyDir` counts against that limit, so a `sizeLimit` above it lets the dump breach the pod's
+  storage budget and get the pod evicted part-way through the write.
+- Do **not** set `emptyDir.medium: Memory`. A tmpfs dump counts against the pod's memory limit, so
+  a large enough dump OOM-kills the pod while writing the one artifact you needed.
+
+### Getting a dump out
+
+```bash
+kubectl exec -n studio deploy/planner -- ls -lh /dumps
+kubectl cp studio/<pod>:/dumps/planner.<pid>.<time>.dmp ./planner.dmp
+```
+
+The restarted container sees the dump too - the volume outlived the container that crashed, which
+is the whole point of mounting it.
+
+Record two more things in the same session: the image digest
+(`kubectl get pod <pod> -o jsonpath='{.status.containerStatuses[0].imageID}'`) and `dotnet --info`
+from inside the container. A `Heap` dump deliberately omits the module images, so analysis needs
+the matching binaries, and both `cratis/planner:latest` and the `aspnet:10.0` base it builds on
+float - the tag that produced this dump is not the tag you will pull next week.
+
+Read the `.crashreport.json` first. It sits next to the dump, is a few kilobytes, and lists the
+threads and their stack frames as JSON - usually enough on its own to settle whether the crash was
+managed or native, which is what decides whether opening the dump in `dotnet-dump analyze` is
+worth the effort.
 
 ## Operational access for alert investigations
 

--- a/Source/Planner/Dockerfile
+++ b/Source/Planner/Dockerfile
@@ -6,10 +6,37 @@
 # the published output in.
 FROM mcr.microsoft.com/dotnet/aspnet:10.0
 
+# Somewhere for createdump to write. createdump opens the dump file but never creates the
+# directory it lives in, so /dumps has to exist in the image or the write simply fails. 1777
+# (sticky, world-writable - the /tmp permissions) keeps it writable both as root, the default
+# here since the aspnet base image sets no USER, and as whatever UID a Pod securityContext
+# imposes instead.
+RUN mkdir -p /dumps && chmod 1777 /dumps
+
 WORKDIR /app
 COPY out ./
 
 ENV ASPNETCORE_URLS=http://+:8080
 EXPOSE 8080
+
+# Capture a dump on a native crash. The Planner has an intermittent SIGSEGV (exit 139) that
+# produces no log output whatsoever, so without this there is nothing to attach a stack to.
+#
+# Type 2 (Heap) rather than 4 (Full): Heap keeps every stack and all memory except the mapped
+# module images, and those are recoverable from the image anyway. Full materially raises the
+# chance of exceeding the pod's ephemeral-storage limit, and overrunning an emptyDir evicts the
+# pod - which deletes the very dump being written.
+#
+# CreateDumpDiagnostics matters here specifically: the entire complaint is "zero log output", so
+# a createdump that itself fails - a seccomp profile denying ptrace, say - has to say so on the
+# crashing process's console rather than fail silently and leave us exactly as empty-handed.
+#
+# None of this survives the crashed container unless /dumps is a mounted volume - see
+# Documentation/Planner/running-in-the-cloud.md.
+ENV DOTNET_DbgEnableMiniDump=1 \
+    DOTNET_DbgMiniDumpType=2 \
+    DOTNET_DbgMiniDumpName=/dumps/planner.%p.%t.dmp \
+    DOTNET_EnableCrashReport=1 \
+    DOTNET_CreateDumpDiagnostics=1
 
 ENTRYPOINT ["dotnet", "Planner.dll"]


### PR DESCRIPTION
# Summary

The Planner intermittently exits 139 (SIGSEGV) at startup with **no log output whatsoever** (#41), so there is nothing to attach a stack to and nothing to diagnose from.

This does **not** fix that crash. It makes the next occurrence produce an artifact instead of a shrug — which is the prerequisite for fixing it.

## Added

- Crash dump capture baked into the Planner image, so a native crash writes a dump plus a JSON crash report (#41).

## Why in the image rather than the Deployment

A crash that has to be reproduced *after* reconfiguring is a crash nobody catches — the setting has to already be on when it happens. `main` today only *recommends* these variables in prose, which means they are not set when the crash actually occurs.

| Variable | Value | What it does |
| --- | --- | --- |
| `DOTNET_DbgEnableMiniDump` | `1` | Enables core dump generation (off by default) |
| `DOTNET_DbgMiniDumpType` | `2` (Heap) | All stacks and memory except mapped module images |
| `DOTNET_DbgMiniDumpName` | `/dumps/planner.%p.%t.dmp` | `%p`/`%t` so successive crashes never overwrite |
| `DOTNET_EnableCrashReport` | `1` | JSON report of threads and stack frames |
| `DOTNET_CreateDumpDiagnostics` | `1` | Logs what `createdump` itself did |

**Heap rather than Full**: Full materially raises the chance of exceeding the pod's ephemeral-storage limit, and overrunning an `emptyDir` evicts the pod — deleting the very dump being written. Note this differs from the type 4 the current docs suggest.

**`CreateDumpDiagnostics` matters here specifically**: the entire complaint is "zero log output", so a `createdump` that itself fails — a seccomp profile denying `ptrace`, say — must say so on the crashing process's console rather than fail silently and leave us equally empty-handed.

## The dump is worthless without a volume

`/dumps` is created in the image because `createdump` opens the dump file but never creates the directory. It is still the container's **writable layer**, and a container that exits 139 is discarded — so unless that path is a mounted volume, the dump dies with the container that wrote it. The documentation now says so explicitly and shows the Deployment snippet.

## Verification

`dotnet build Planner.slnx -c Debug` → 0 errors. The single warning is the pre-existing `ASPIRE010` diagnostic, which reproduces on a pristine `main` checkout and is unrelated.

Not verified: no dump has been captured from a real crash — that requires the crash to recur with this image deployed and a volume mounted.
