### PR TITLE
Sweep work whose container died without reporting

### DIFF
--- a/Documentation/Planner/configuration.md
+++ b/Documentation/Planner/configuration.md
@@ -61,6 +61,7 @@ instead of git's own unconfigured default.
 | Key | Default | Purpose |
 | --- | --- | --- |
 | `MaxConcurrentWorkPerAccount` | `1` | How many units of work may run concurrently per account |
+| `MaxRunningDuration` | `1.00:00:00` (24 hours) | How long a unit of work may stay running before it is swept as presumed dead. `00:00:00` disables the sweep |
 | `DefaultModel` | `sonnet` | The model for implementation work when nothing suggested one |
 | `InvestigationModel` | `opus` | The model used for investigations |
 | `Limits:<Plan>:SessionsPerFiveHours` | 1 / 3 / 6 | Sessions per rolling five-hour window for Pro / Max5x / Max20x |
@@ -68,6 +69,23 @@ instead of git's own unconfigured default.
 
 The limits are deliberately conservative approximations of the Claude plan boundaries - tune them
 to your accounts' real experience.
+
+### The stuck-work sweep
+
+A worker container that dies without reporting - an OOM kill, a node eviction, a crash - leaves its
+work item `Running` forever: nothing else moves it out of that state, and since
+`MaxConcurrentWorkPerAccount` defaults to `1`, one stuck item wedges its account indefinitely. Every
+scheduling pass sweeps work that has been `Running` longer than `MaxRunningDuration`: it stops the
+worker (best effort, in case it is somehow still around), revokes the worker's callback token, and
+fails the work with a reason that says it was swept, not that it genuinely failed.
+
+The worker runtime (Docker locally, Kubernetes in production) has no way to ask whether a container
+is still alive, so the sweep can only go on elapsed time - it cannot tell a dead container from a
+slow one. That is why the default is a generous 24 hours: an agent legitimately running for hours on
+a hard issue is normal, and failing a container that is still working would be a worse outcome than
+the bug this closes. Set `Planner:Scheduling:MaxRunningDuration` to `00:00:00` to disable the sweep
+entirely, or to a smaller value (e.g. `04:00:00`) if your workloads are reliably short and you want
+faster recovery.
 
 ## Alerts - `Planner:Alerts`
 

--- a/Source/Planner/Work/Scheduling/SchedulingOptions.cs
+++ b/Source/Planner/Work/Scheduling/SchedulingOptions.cs
@@ -23,6 +23,20 @@ public class SchedulingOptions
     public int MaxConcurrentWorkPerAccount { get; set; } = 1;
 
     /// <summary>
+    /// Gets or sets how long a unit of work may stay running before the scheduler treats its worker
+    /// as dead and fails it. This is the only way a container that dies without reporting - an OOM
+    /// kill, a node eviction, a crash - ever releases the concurrency slot it holds: nothing else
+    /// ever moves a stuck item out of the running state, and <see cref="MaxConcurrentWorkPerAccount"/>
+    /// defaults to <c>1</c>, so one such item wedges its account indefinitely. The worker runtime
+    /// exposes no way to ask whether a container is still alive, so this sweep can only go on
+    /// duration - which makes the default deliberately generous: an agent legitimately running for
+    /// hours on a hard issue is normal, and failing a container that is still working is worse than
+    /// leaving a dead one queued a while longer. <see cref="TimeSpan.Zero"/> disables the sweep
+    /// entirely.
+    /// </summary>
+    public TimeSpan MaxRunningDuration { get; set; } = TimeSpan.FromHours(24);
+
+    /// <summary>
     /// Gets or sets the model used for implementation work when neither the work nor an
     /// investigation suggested one.
     /// </summary>

--- a/Source/Planner/Work/Scheduling/WorkDispatcher.cs
+++ b/Source/Planner/Work/Scheduling/WorkDispatcher.cs
@@ -57,6 +57,7 @@ public class WorkDispatcher(
     public async Task RunSchedulingPass(CancellationToken cancellationToken = default)
     {
         var openWork = await Find(workItems, work => work.Status == WorkStatus.Scheduled || work.Status == WorkStatus.Running, cancellationToken);
+        await SweepStuckWork(openWork, cancellationToken);
         await ScheduleReadyIssues(openWork, cancellationToken);
         await DispatchPendingWork(cancellationToken);
     }
@@ -141,6 +142,51 @@ public class WorkDispatcher(
                 var model = members.Select(member => member.SuggestedModel).FirstOrDefault(suggested => suggested is not null);
                 await commandPipeline.Execute(new ScheduleWork(WorkPurpose.Implementation, members.Select(member => member.Id), model));
             }
+        }
+    }
+
+    /// <summary>
+    /// Fails any unit of work that has been running longer than
+    /// <see cref="SchedulingOptions.MaxRunningDuration"/> without reporting - the only recovery for a
+    /// worker container that died without reporting (an OOM kill, a node eviction, a crash) rather
+    /// than a human noticing and stopping it by hand. There is no way to ask the worker runtime
+    /// whether a container is still alive, so this is duration-only - see
+    /// <see cref="SchedulingOptions.MaxRunningDuration"/> for why the default is deliberately
+    /// generous. A zero or negative duration disables the sweep entirely.
+    /// </summary>
+    /// <param name="openWork">The currently scheduled and running work.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> for the operation.</param>
+    /// <returns>Awaitable task.</returns>
+    async Task SweepStuckWork(IReadOnlyList<WorkItem> openWork, CancellationToken cancellationToken)
+    {
+        var maxDuration = schedulingOptions.Value.MaxRunningDuration;
+        if (maxDuration <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        var now = timeProvider.GetUtcNow();
+        var stuck = openWork.Where(work =>
+            work.Status == WorkStatus.Running &&
+            work.StartedAt is { } startedAt &&
+            now - startedAt > maxDuration);
+
+        foreach (var work in stuck)
+        {
+            logger.SweepingStuckWork(work.Id, maxDuration);
+
+            // Best effort - if the container is genuinely still alive despite the deadline, this
+            // makes sure it actually stops rather than being orphaned while its work item is failed.
+            await workerRuntime.Stop(work.Id, cancellationToken);
+
+            // Every other terminal path retires the per-work callback token explicitly - the launch
+            // failure below, the callback endpoint and StopWork all do. A swept item is terminal too,
+            // so its token goes with it rather than staying valid until it ages out.
+            callbackTokens.Revoke(work.Id);
+
+            await commandPipeline.Execute(new Failing.FailWork(
+                work.Id,
+                $"Swept after running longer than the configured maximum of {maxDuration} without reporting - presumed dead rather than genuinely failed."));
         }
     }
 

--- a/Source/Planner/Work/Scheduling/WorkDispatcherLog.cs
+++ b/Source/Planner/Work/Scheduling/WorkDispatcherLog.cs
@@ -24,4 +24,7 @@ internal static partial class WorkDispatcherLog
 
     [LoggerMessage(LogLevel.Error, "Scheduling pass failed")]
     internal static partial void SchedulingPassFailed(this ILogger logger, Exception exception);
+
+    [LoggerMessage(LogLevel.Warning, "Work {Work} has been running longer than the maximum of {MaxDuration} without reporting - sweeping it as presumed dead")]
+    internal static partial void SweepingStuckWork(this ILogger logger, WorkId work, TimeSpan maxDuration);
 }

--- a/Source/Planner/Work/Scheduling/for_WorkDispatcher/when_running_pass/and_the_maximum_running_duration_is_disabled.cs
+++ b/Source/Planner/Work/Scheduling/for_WorkDispatcher/when_running_pass/and_the_maximum_running_duration_is_disabled.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Planner.Accounts;
+using Planner.Work.Failing;
+using Planner.Work.Listing;
+
+namespace Planner.Work.Scheduling.for_WorkDispatcher.when_running_pass;
+
+public class and_the_maximum_running_duration_is_disabled : given.all_dependencies
+{
+    static readonly WorkId _workId = WorkId.New();
+
+    void Establish()
+    {
+        _schedulingOptions.MaxRunningDuration = TimeSpan.Zero;
+
+        // Absurdly overdue - the sweep must still never fire while it is switched off.
+        _workItemsData.Add(new WorkItem(_workId, WorkPurpose.Implementation, [new IssueId("cratis-studio-1")], ModelName.NotSet, UserName.NotSet, WorkStatus.Running, AccountId.New(), _now.AddDays(-30)));
+    }
+
+    async Task Because() => await _dispatcher.RunSchedulingPass();
+
+    [Fact]
+    async Task should_not_stop_the_worker() =>
+        await _workerRuntime.DidNotReceive().Stop(Arg.Any<WorkId>(), Arg.Any<CancellationToken>());
+
+    [Fact]
+    void should_not_revoke_the_callback_token() =>
+        _callbackTokens.DidNotReceive().Revoke(Arg.Any<WorkId>());
+
+    [Fact]
+    async Task should_not_fail_the_work() =>
+        await _commandPipeline.DidNotReceive().Execute(Arg.Any<FailWork>());
+}
+#endif

--- a/Source/Planner/Work/Scheduling/for_WorkDispatcher/when_running_pass/and_work_exceeds_the_maximum_running_duration.cs
+++ b/Source/Planner/Work/Scheduling/for_WorkDispatcher/when_running_pass/and_work_exceeds_the_maximum_running_duration.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Planner.Accounts;
+using Planner.Work.Failing;
+using Planner.Work.Listing;
+
+namespace Planner.Work.Scheduling.for_WorkDispatcher.when_running_pass;
+
+public class and_work_exceeds_the_maximum_running_duration : given.all_dependencies
+{
+    static readonly WorkId _workId = WorkId.New();
+
+    void Establish()
+    {
+        _schedulingOptions.MaxRunningDuration = TimeSpan.FromHours(24);
+        _workItemsData.Add(new WorkItem(_workId, WorkPurpose.Implementation, [new IssueId("cratis-studio-1")], ModelName.NotSet, UserName.NotSet, WorkStatus.Running, AccountId.New(), _now.AddHours(-25)));
+    }
+
+    async Task Because() => await _dispatcher.RunSchedulingPass();
+
+    [Fact]
+    async Task should_stop_the_worker() =>
+        await _workerRuntime.Received(1).Stop(_workId, Arg.Any<CancellationToken>());
+
+    [Fact]
+    void should_revoke_the_callback_token() =>
+        _callbackTokens.Received(1).Revoke(_workId);
+
+    [Fact]
+    async Task should_fail_the_work_as_swept() =>
+        await _commandPipeline.Received(1).Execute(Arg.Is<FailWork>(command => command.Work == _workId));
+}
+#endif

--- a/Source/Planner/Work/Scheduling/for_WorkDispatcher/when_running_pass/and_work_is_within_the_maximum_running_duration.cs
+++ b/Source/Planner/Work/Scheduling/for_WorkDispatcher/when_running_pass/and_work_is_within_the_maximum_running_duration.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Planner.Accounts;
+using Planner.Work.Failing;
+using Planner.Work.Listing;
+
+namespace Planner.Work.Scheduling.for_WorkDispatcher.when_running_pass;
+
+public class and_work_is_within_the_maximum_running_duration : given.all_dependencies
+{
+    static readonly WorkId _workId = WorkId.New();
+
+    void Establish()
+    {
+        _schedulingOptions.MaxRunningDuration = TimeSpan.FromHours(24);
+
+        // An hour into a session is normal, not stuck - well inside the 24-hour maximum.
+        _workItemsData.Add(new WorkItem(_workId, WorkPurpose.Implementation, [new IssueId("cratis-studio-1")], ModelName.NotSet, UserName.NotSet, WorkStatus.Running, AccountId.New(), _now.AddHours(-1)));
+    }
+
+    async Task Because() => await _dispatcher.RunSchedulingPass();
+
+    [Fact]
+    async Task should_not_stop_the_worker() =>
+        await _workerRuntime.DidNotReceive().Stop(Arg.Any<WorkId>(), Arg.Any<CancellationToken>());
+
+    [Fact]
+    void should_not_revoke_the_callback_token() =>
+        _callbackTokens.DidNotReceive().Revoke(Arg.Any<WorkId>());
+
+    [Fact]
+    async Task should_not_fail_the_work() =>
+        await _commandPipeline.DidNotReceive().Execute(Arg.Any<FailWork>());
+}
+#endif


### PR DESCRIPTION
# Summary

A worker container that dies without reporting - an OOM kill, a node eviction, a crash - leaves
its work item `Running` forever. Nothing else moves it out of that state, and since
`MaxConcurrentWorkPerAccount` defaults to `1`, **one dead container wedges an entire account
indefinitely** and the issues it covered are never rescheduled. The only recovery was a human
noticing and clicking Stop.

## Added

- `SchedulingOptions.MaxRunningDuration` (default 24 hours, `00:00:00` disables the sweep)
- `WorkDispatcher.SweepStuckWork`, run at the top of the scheduling pass that already runs every
  minute - it stops the worker (best effort), revokes the work's callback token, and executes
  `FailWork` with a reason that says it was *swept*, not that it genuinely failed
- A `SweepingStuckWork` warning log message
- A "stuck-work sweep" section in `Documentation/Planner/configuration.md`

## Why 24 hours

Nothing in the codebase bounds a legitimate session - the worker entrypoint runs the CLI to
completion with no timeout or step limit, and the Kubernetes job's `TtlSecondsAfterFinished` is
post-completion cleanup, not a run cap. `IWorkerRuntime` exposes `Start`, `Stop`, `StreamLogs` and
`SendInput` and nothing that reports container status, so the sweep can only go on elapsed time -
it cannot tell a dead container from a slow one. Sweeping a live agent mid-work is a worse outcome
than the bug this closes, so the default sits at several multiples of anything plausible.

## Callback token

The sweep revokes the work's callback token. Every other terminal path already retires it
explicitly - the launch-failure path in `Dispatch`, the three terminal branches of the callback
endpoint, and `StopWork` - so a swept item, which is terminal too, should not leave a valid token
behind until it ages out of the 12-hour window. This is additive to #108's terminal-state guard,
which already rejects a *late report* from a swept container; this closes the credential rather
than the transition.

## Verification

| Gate | Result |
| --- | --- |
| `dotnet build Planner.slnx -c Debug` | 0 errors |
| `dotnet build Source/Planner/Planner.csproj -c Release -p:DisableProxyGenerator=true` (what `planner-build.yml` runs) | 0 warnings, 0 errors |
| `dotnet test Source/Planner/Planner.csproj -c Debug --no-build` | **403 passed** (baseline 394 on `1b9f2bf`, +9 predicted before running, matched exactly) |
| `dotnet test Source/Factory.Core.Specs/...` | 195 passed |
| `bash .ai/hooks/scripts/validate-ai-setup.sh` | passed |

**Proven load-bearing in both directions.** Removing the `SweepStuckWork` call from
`RunSchedulingPass` fails exactly the three positive assertions (stop, revoke, fail) and leaves the
six negative ones passing - so the specs are not vacuous. Restored and re-verified green
(`shasum` match against the pre-break copy).

Specced in all three directions for the same reason: work past the deadline is stopped, revoked and
failed; work within it is untouched; a disabled sweep never fails anything however overdue.

## Note on `ASPIRE010`

`dotnet build Planner.slnx -c Release` fails with `ASPIRE010` **on a pristine `1b9f2bf` checkout
with zero local edits** - verified in a separate detached worktree. It is a local Aspire
CLI-bundle environment issue, not code, and CI does not build `Composition` in Release.

## Not verified

The sweep has not been observed against a real dead container - it is proven by spec, not against a
running Chronicle and a genuinely OOM-killed worker.
