### PR TITLE
Tell the operator when a command silently fails

### DIFF
--- a/Source/Planner/Alerts/Alerts.tsx
+++ b/Source/Planner/Alerts/Alerts.tsx
@@ -17,6 +17,7 @@ import { ResolveAlert } from './Resolving/Resolving';
 import { DeleteAlert } from './Deleting/Deleting';
 import { ScheduleAlertInvestigation } from '../Work/SchedulingAlertInvestigation/SchedulingAlertInvestigation';
 import { Current as GetOperationsSettings } from '../Operations/OperationsSettings';
+import { commandFailureMessage } from '../Common/commandFeedback';
 
 /**
  * The alerts page - what running systems have reported, what agents made of it, and the actions a
@@ -29,6 +30,7 @@ export const Alerts = () => {
     const [noteFor, setNoteFor] = useState<Alert | undefined>(undefined);
     const [resolveFor, setResolveFor] = useState<Alert | undefined>(undefined);
     const [convertFor, setConvertFor] = useState<Alert | undefined>(undefined);
+    const [problem, setProblem] = useState<string | undefined>(undefined);
 
     const operations = operationsResult.data;
     const hasOperationalAccess = !!operations &&
@@ -37,14 +39,19 @@ export const Alerts = () => {
     const investigate = async (alert: Alert) => {
         const command = new ScheduleAlertInvestigation();
         command.alert = alert.id;
-        await command.execute();
+        const result = await command.execute();
+        setProblem(commandFailureMessage(result));
     };
 
     const remove = async (alert: Alert) => {
         const command = new DeleteAlert();
         command.alert = alert.id;
-        await command.execute();
-        setSelected(undefined);
+        const result = await command.execute();
+        const failure = commandFailureMessage(result);
+        setProblem(failure);
+        if (!failure) {
+            setSelected(undefined);
+        }
     };
 
     return (
@@ -55,6 +62,10 @@ export const Alerts = () => {
                         className='w-full justify-start'
                         severity='warn'
                         text='No operational access is configured, so an agent investigating an alert can only reason from the alert itself - it cannot look at the running system. Set Planner:Operations to give it a cluster, a container runtime or logs.' />
+                </div>}
+            {problem &&
+                <div className='flex shrink-0 items-center px-4 py-2'>
+                    <Message className='w-full justify-start' severity='error' text={problem} />
                 </div>}
             <DataPage
                 title='Alerts'

--- a/Source/Planner/Common/commandFeedback.ts
+++ b/Source/Planner/Common/commandFeedback.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ICommandResult } from '@cratis/arc/commands';
+
+/**
+ * Gets the problem to report for a failed command, based on the granular `CommandResult` flags -
+ * checked in the order authorization, then validation, then exceptions. Never surfaces
+ * `exceptionMessages`/a stack trace to the user.
+ * Accepts any response type since only the granular result flags are inspected.
+ * @param result The result of executing the command.
+ * @returns The problem to report, or `undefined` when the command succeeded.
+ */
+export const commandFailureMessage = (result: ICommandResult<unknown>): string | undefined => {
+    if (!result.isAuthorized) {
+        return 'You are not authorized to do this - sign in again and retry.';
+    }
+
+    if (!result.isValid) {
+        return result.validationResults.map((validationResult) => validationResult.message).join(' ');
+    }
+
+    if (result.hasExceptions) {
+        return 'Something went wrong. Try again.';
+    }
+
+    return undefined;
+};

--- a/Source/Planner/Common/for_commandFeedback/when_a_command_fails.ts
+++ b/Source/Planner/Common/for_commandFeedback/when_a_command_fails.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Guid } from '@cratis/fundamentals';
+import { ICommandResult } from '@cratis/arc/commands';
+import { ValidationResult, ValidationResultSeverity } from '@cratis/arc/validation';
+import { commandFailureMessage } from '../commandFeedback';
+
+const successfulResult: ICommandResult = {
+    correlationId: Guid.empty,
+    isSuccess: true,
+    isAuthorized: true,
+    isValid: true,
+    hasExceptions: false,
+    validationResults: [],
+    exceptionMessages: [],
+    authorizationFailureReason: '',
+    exceptionStackTrace: '',
+};
+
+describe('when a command fails', () => {
+    it('should report no problem for a successful result', () => {
+        (commandFailureMessage(successfulResult) === undefined).should.be.true;
+    });
+
+    it('should report an authorization problem when the command was not authorized', () => {
+        const result: ICommandResult = { ...successfulResult, isAuthorized: false };
+        commandFailureMessage(result)!.should.equal('You are not authorized to do this - sign in again and retry.');
+    });
+
+    it('should report the validation messages when the command is invalid', () => {
+        const result: ICommandResult = {
+            ...successfulResult,
+            isValid: false,
+            validationResults: [new ValidationResult(ValidationResultSeverity.Error, 'The work has already finished', [], undefined)],
+        };
+        commandFailureMessage(result)!.should.equal('The work has already finished');
+    });
+
+    it('should report a generic problem when the command threw an exception', () => {
+        const result: ICommandResult = {
+            ...successfulResult,
+            hasExceptions: true,
+            exceptionMessages: ['Something exploded internally, with a stack trace and secrets'],
+        };
+        commandFailureMessage(result)!.should.equal('Something went wrong. Try again.');
+    });
+
+    it('should never leak exception details to the operator', () => {
+        const result: ICommandResult = {
+            ...successfulResult,
+            hasExceptions: true,
+            exceptionMessages: ['Something exploded internally, with a stack trace and secrets'],
+        };
+        commandFailureMessage(result)!.should.not.include('exploded');
+    });
+});

--- a/Source/Planner/Common/index.ts
+++ b/Source/Planner/Common/index.ts
@@ -1,1 +1,2 @@
 export * from './AuthorAssociation';
+export * from './commandFeedback';

--- a/Source/Planner/Repositories/Repositories.tsx
+++ b/Source/Planner/Repositories/Repositories.tsx
@@ -25,6 +25,7 @@ import { AllRepositoryGroups, RepositoryGroup } from './Groups/Listing/Listing';
 import { CreateRepositoryGroup } from './Groups/Creating/Creating';
 import { ChangeRepositoryGroup } from './Groups/Changing/Changing';
 import { DeleteRepositoryGroup } from './Groups/Deleting/Deleting';
+import { commandFailureMessage } from '../Common/commandFeedback';
 
 /** One row per (group, repository) pair - the shape a subheader-grouped, expandable DataTable needs. */
 type GroupMemberRow = {
@@ -80,6 +81,7 @@ export const Repositories = () => {
     const [mapCodeFor, setMapCodeFor] = useState<Repository | undefined>(undefined);
     const [changeGroupFor, setChangeGroupFor] = useState<RepositoryGroup | undefined>(undefined);
     const [syncing, setSyncing] = useState(false);
+    const [problem, setProblem] = useState<string | undefined>(undefined);
 
     const selectedGroup = selectedGroupRow?.group;
 
@@ -117,7 +119,8 @@ export const Repositories = () => {
     const removeRepository = async (repository: Repository) => {
         const command = new RemoveRepository();
         command.repository = repository.id;
-        await command.execute();
+        const result = await command.execute();
+        setProblem(commandFailureMessage(result));
     };
 
     // Adding an organization is what triggers discovery, so adding one that is already there is the
@@ -125,14 +128,19 @@ export const Repositories = () => {
     const retryDiscovery = async (organization: Organization) => {
         const command = new AddOrganization();
         command.name = organization.name;
-        await command.execute();
+        const result = await command.execute();
+        setProblem(commandFailureMessage(result));
     };
 
     const deleteGroup = async (group: RepositoryGroup) => {
         const command = new DeleteRepositoryGroup();
         command.group = group.id;
-        await command.execute();
-        setSelectedGroupRow(undefined);
+        const result = await command.execute();
+        const failure = commandFailureMessage(result);
+        setProblem(failure);
+        if (!failure) {
+            setSelectedGroupRow(undefined);
+        }
     };
 
     const synchronizeNow = async () => {
@@ -152,6 +160,10 @@ export const Repositories = () => {
                         className='w-full justify-start'
                         severity='warn'
                         text='No GitHub App is configured, so nothing can be read from GitHub. Organizations and repositories added now will be recorded, but their repositories and issues will not load until an App is connected under Settings - GitHub.' />
+                </div>}
+            {problem &&
+                <div className='flex shrink-0 items-center px-4 py-2'>
+                    <Message className='w-full justify-start' severity='error' text={problem} />
                 </div>}
             <TabView
                 className='flex min-h-0 flex-1 flex-col'

--- a/Source/Planner/Work/WorkDetails.tsx
+++ b/Source/Planner/Work/WorkDetails.tsx
@@ -5,11 +5,14 @@ import { useEffect, useRef, useState } from 'react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import { Button } from 'primereact/button';
 import { InputText } from 'primereact/inputtext';
+import { Message } from 'primereact/message';
 import { Tag } from 'primereact/tag';
 import { WorkItem } from './Listing/Listing';
 import { WorkPurpose } from './WorkPurpose';
 import { WorkStatus } from './WorkStatus';
 import { StopWork } from './Stopping/Stopping';
+import { commandFailureMessage } from '../Common/commandFeedback';
+import { logStreamFailureMessage, steeringFailureMessage } from './workDetailsFeedback';
 
 /**
  * Props for the {@link WorkDetails} component.
@@ -53,14 +56,20 @@ export const workPurposeLabel = (purpose: WorkPurpose) => {
 export const WorkDetails = ({ work }: WorkDetailsProps) => {
     const [lines, setLines] = useState<string[]>([]);
     const [steer, setSteer] = useState('');
+    const [problem, setProblem] = useState<string | undefined>(undefined);
     const consoleRef = useRef<HTMLPreElement>(null);
     const active = work.status === WorkStatus.running;
 
     useEffect(() => {
         setLines([]);
+        setProblem(undefined);
         const source = new EventSource(`/api/work/${work.id}/log`);
         source.onmessage = (event) => setLines((current) => [...current.slice(-2000), event.data as string]);
-        source.onerror = () => source.close();
+        source.onerror = () => {
+            const message = logStreamFailureMessage(source.readyState);
+            if (message) setProblem(message);
+            source.close();
+        };
         return () => source.close();
     }, [work.id]);
 
@@ -71,17 +80,27 @@ export const WorkDetails = ({ work }: WorkDetailsProps) => {
     const stop = async () => {
         const command = new StopWork();
         command.work = work.id;
-        await command.execute();
+        const result = await command.execute();
+        setProblem(commandFailureMessage(result));
     };
 
     const sendSteering = async () => {
         if (!steer.trim()) return;
-        await fetch(`/api/work/${work.id}/input`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ text: steer }),
-        });
-        setSteer('');
+        try {
+            const response = await fetch(`/api/work/${work.id}/input`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ text: steer }),
+            });
+            if (!response.ok) {
+                setProblem(steeringFailureMessage(response.status));
+                return;
+            }
+            setProblem(undefined);
+            setSteer('');
+        } catch {
+            setProblem(steeringFailureMessage(undefined));
+        }
     };
 
     const usage = (work.inputTokens ?? 0) + (work.outputTokens ?? 0);
@@ -94,6 +113,8 @@ export const WorkDetails = ({ work }: WorkDetailsProps) => {
                 {(work.status === WorkStatus.scheduled || work.status === WorkStatus.running) &&
                     <Button label='Stop' icon='pi pi-stop-circle' severity='danger' size='small' outlined onClick={stop} />}
             </div>
+
+            {problem && <Message className='w-full justify-start' severity='error' text={problem} />}
 
             <div className='text-sm text-[var(--text-color-secondary)]'>
                 Model: {work.model || 'auto'}

--- a/Source/Planner/Work/for_workDetailsFeedback/when_steering_fails.ts
+++ b/Source/Planner/Work/for_workDetailsFeedback/when_steering_fails.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { steeringFailureMessage } from '../workDetailsFeedback';
+
+describe('when steering fails', () => {
+    it('should report an authentication problem for a 401 response', () => {
+        steeringFailureMessage(401).should.equal('Your session has expired - sign in again to steer the running session.');
+    });
+
+    it('should report a generic problem for another non-ok status', () => {
+        steeringFailureMessage(500).should.equal('Sending failed - the running session did not receive your message.');
+    });
+
+    it('should report a generic problem for a network failure', () => {
+        steeringFailureMessage(undefined).should.equal('Sending failed - the running session did not receive your message.');
+    });
+});

--- a/Source/Planner/Work/for_workDetailsFeedback/when_the_log_stream_fails.ts
+++ b/Source/Planner/Work/for_workDetailsFeedback/when_the_log_stream_fails.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { logStreamFailureMessage } from '../workDetailsFeedback';
+
+describe('when the log stream fails', () => {
+    it('should report a problem when the connection was refused (closed)', () => {
+        logStreamFailureMessage(2)!.should.equal('The console log stream was refused - sign in again to keep watching this work.');
+    });
+
+    it('should report no problem when the stream is merely connecting or has ended normally', () => {
+        (logStreamFailureMessage(0) === undefined).should.be.true;
+    });
+});

--- a/Source/Planner/Work/workDetailsFeedback.ts
+++ b/Source/Planner/Work/workDetailsFeedback.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * The `EventSource.readyState` value meaning the connection is closed - the server answered with
+ * something that is not a usable event stream. For the work log route this only happens when the
+ * operator's session is no longer authenticated.
+ */
+const closedReadyState = 2;
+
+/**
+ * Gets the problem to report for a failed console log stream, based on the `EventSource`'s
+ * `readyState` at the moment `onerror` fired.
+ *
+ * A `CONNECTING` (0) readyState covers both a transient transport error and the stream ending
+ * normally (the worker container is gone) - the two are indistinguishable from `readyState` alone,
+ * so no problem is reported for it. Reporting one here would flash an error on every completed
+ * work item, since the stream is opened for every item including finished ones.
+ * @param readyState The `EventSource.readyState` at the moment `onerror` fired.
+ * @returns The problem to report, or `undefined` when nothing should be shown.
+ */
+export const logStreamFailureMessage = (readyState: number): string | undefined =>
+    readyState === closedReadyState
+        ? 'The console log stream was refused - sign in again to keep watching this work.'
+        : undefined;
+
+/**
+ * Gets the problem to report for a failed steering request, based on the HTTP response status.
+ * `undefined` is passed when the request failed before a response was received (a network error).
+ * @param status The HTTP status of the response, or `undefined` for a network failure.
+ * @returns The problem to report.
+ */
+export const steeringFailureMessage = (status: number | undefined): string =>
+    status === 401
+        ? 'Your session has expired - sign in again to steer the running session.'
+        : 'Sending failed - the running session did not receive your message.';


### PR DESCRIPTION
# Summary

Seven actions across three pages awaited a command and threw the result away. An operator who
stopped work that had already finished, deleted an alert without authorization, or retried
discovery against a repository the App cannot see **saw nothing at all** - the button simply did
nothing. Two of the call sites cleared the selection optimistically as though it had worked.

## Changed

The five command call sites now read the `CommandResult` they already get back:

| Page | Command |
| --- | --- |
| `Work/WorkDetails.tsx` | `StopWork` |
| `Alerts/Alerts.tsx` | `ScheduleAlertInvestigation`, `DeleteAlert` |
| `Repositories/Repositories.tsx` | `RemoveRepository`, `AddOrganization`, `DeleteRepositoryGroup` |

The optimistic clears in `DeleteAlert` and `DeleteRepositoryGroup` are gated on success rather than
run unconditionally.

## The helper

`commandFailureMessage` lands directly in `Common/`, shared by all three pages. It checks the
granular flags in the order authorization → validation → exceptions, and **deliberately never
surfaces `exceptionMessages` or the stack trace** - an exception becomes "Something went wrong.
Try again." A spec asserts that non-leak directly rather than trusting the implementation to keep
it.

`WorkDetails` also has two non-command failures on the same screen, and they stay local to it
because they interpret transport state rather than a `CommandResult`: the console log stream's
`EventSource.onerror` and the steering `fetch`. The log stream reports a problem only for
`readyState` CLOSED (2) - CONNECTING (0) covers both a transient error and the stream ending
normally when the worker container is gone, and the two are indistinguishable from `readyState`
alone, so reporting there would flash an error on every completed work item.

## Note on the port

The branch this is ported from split the work three ways - `WorkDetails`, then Alerts + Repositories
with the helper duplicated, then an extraction into `Common`. That split existed only to decompose
the review; the helper lands in `Common/` directly here rather than being duplicated and then
extracted.

## Verification

Measured against a **pristine `1b9f2bf` baseline of 7 tests in 2 files**:

| Gate | Result |
| --- | --- |
| `yarn test` | **17 passed in 5 files** (+10 across 3 new spec files) |
| `yarn lint:ci` | clean |
| `yarn g:compile` | clean |
| `yarn g:compile:specs` | clean |
| `yarn build` | built |

**Proven load-bearing in both directions.** Making `commandFailureMessage` always return
`undefined` - which is exactly the behavior being fixed - fails the four failure-detection
assertions and leaves the success case passing, so the specs are not vacuous. Restored and
re-verified green against a `shasum` of the pre-break copy.

## Not verified

No failing command was exercised against a running Planner in a browser. The helper is proven by
spec; the wiring at the seven call sites is proven by compilation and review only.
