### PR TITLE
Stop the hook bridge from failing open when a guard cannot run

### DIFF
--- a/.pi/extensions/cratis-hooks/index.ts
+++ b/.pi/extensions/cratis-hooks/index.ts
@@ -17,6 +17,7 @@
  */
 
 import { spawn } from "node:child_process";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
@@ -24,24 +25,35 @@ interface ScriptRun {
 	code: number;
 	stdout: string;
 	stderr: string;
+	/** The script could not be executed at all, as opposed to running and deciding. */
+	failed?: boolean;
 }
 
-/** Run a corpus hook script, feeding `stdinJson` on stdin. Never throws. */
+/**
+ * Run a corpus hook script, feeding `stdinJson` on stdin. Never throws.
+ *
+ * `failed` separates "the script ran and returned a verdict" from "the script never ran", which
+ * the exit code alone cannot express: bash exits 127 for a missing script, and a script that
+ * fails to spawn produces no code at all. Both used to surface as `code: 0` — indistinguishable
+ * from a deliberate allow — so a hook that was absent or unrunnable silently permitted the very
+ * writes it exists to refuse. Callers decide what to do with `failed`; this function only reports
+ * it honestly.
+ */
 function runScript(script: string, stdinJson: string, cwd: string, signal?: AbortSignal): Promise<ScriptRun> {
 	return new Promise<ScriptRun>((resolve) => {
 		let proc: ReturnType<typeof spawn>;
 		try {
 			proc = spawn("bash", [script], { cwd, stdio: ["pipe", "pipe", "pipe"] });
-		} catch {
-			resolve({ code: 0, stdout: "", stderr: "" });
+		} catch (error) {
+			resolve({ code: 127, stdout: "", stderr: String(error), failed: true });
 			return;
 		}
 		let stdout = "";
 		let stderr = "";
 		proc.stdout?.on("data", (d) => (stdout += d.toString()));
 		proc.stderr?.on("data", (d) => (stderr += d.toString()));
-		proc.on("error", () => resolve({ code: 0, stdout, stderr }));
-		proc.on("close", (code) => resolve({ code: code ?? 0, stdout, stderr }));
+		proc.on("error", (error) => resolve({ code: 127, stdout, stderr: stderr || String(error), failed: true }));
+		proc.on("close", (code) => resolve({ code: code ?? 0, stdout, stderr, failed: code === 127 }));
 		if (signal) {
 			const kill = () => proc.kill("SIGTERM");
 			if (signal.aborted) kill();
@@ -68,6 +80,25 @@ function writeTarget(toolName: string, input: any): { filePath?: string; content
 	return { filePath };
 }
 
+/**
+ * Whether a hook script is installed at all.
+ *
+ * A repository that ships no hook scripts is a supported configuration — the corpus scripts
+ * themselves degrade to a silent no-op when `jq` is missing, on the stated principle that a hook
+ * must never break a session. So an absent script is not an error and is not enforced.
+ *
+ * The dangerous case is the other one: the script is present, so this repository clearly intends
+ * the guard to run, but it cannot be executed. That is a broken guard rather than an absent one,
+ * and it is the case that must never be mistaken for permission.
+ */
+function isInstalled(script: string): boolean {
+	try {
+		return fs.statSync(script).isFile();
+	} catch {
+		return false;
+	}
+}
+
 export default function (pi: ExtensionAPI) {
 	const scriptsDir = path.join(process.cwd(), ".ai", "hooks", "scripts");
 	const guardWrites = path.join(scriptsDir, "cratis-guard-writes.sh");
@@ -86,8 +117,22 @@ export default function (pi: ExtensionAPI) {
 		if (event.toolName !== "write" && event.toolName !== "edit") return;
 		const { filePath, content, newString } = writeTarget(event.toolName, (event as any).input);
 		if (!filePath) return;
+		if (!isInstalled(guardWrites)) return; // no guard installed in this repository - nothing to enforce
 		const payload = JSON.stringify({ cwd: ctx.cwd, tool_input: { file_path: filePath, content, new_string: newString } });
 		const run = await runScript(guardWrites, payload, ctx.cwd, ctx.signal);
+
+		// The guard is installed but could not run. Allowing here would mean the one case the guard
+		// exists to catch - a protected write - passes silently precisely because the guard is broken.
+		// Block instead, and say why, so a broken guard is loud rather than permissive.
+		if (run.failed) {
+			return {
+				block: true,
+				reason:
+					`cratis-guard-writes is installed at ${guardWrites} but could not be run, so this write cannot be checked.` +
+					`${run.stderr.trim() ? `\n\n${run.stderr.trim()}` : ""}` +
+					"\n\nFix the script (or remove it if this repository is not meant to enforce write guards) and retry.",
+			};
+		}
 		if (run.code === 2) return { block: true, reason: run.stderr.trim() || "Blocked by cratis-guard-writes." };
 	});
 
@@ -97,12 +142,29 @@ export default function (pi: ExtensionAPI) {
 		if (event.isError) return;
 		const { filePath } = writeTarget(event.toolName, (event as any).input);
 		if (!filePath) return;
+		if (!isInstalled(patternScan)) return;
 		const payload = JSON.stringify({
 			cwd: ctx.cwd,
 			session_id: ctx.sessionManager.getSessionId?.() ?? "nosession",
 			tool_input: { file_path: filePath },
 		});
 		const run = await runScript(patternScan, payload, ctx.cwd, ctx.signal);
+
+		// Advisory, not a gate: a broken pattern scan must not fail a write that already succeeded.
+		// It is still surfaced rather than swallowed, because a scan that silently stops running
+		// looks exactly like a scan that finds nothing.
+		if (run.failed) {
+			const existing = Array.isArray(event.content) ? event.content : [];
+			return {
+				content: [
+					...existing,
+					{
+						type: "text",
+						text: `\n\n[cratis-hooks] cratis-pattern-scan is installed but could not be run, so no pattern checks were applied to this edit.`,
+					},
+				],
+			};
+		}
 		if (run.code !== 0 || !run.stdout.trim()) return;
 		let reminder = "";
 		try {
@@ -117,11 +179,24 @@ export default function (pi: ExtensionAPI) {
 
 	// ── Stop → quality gate (re-runs the gates the change touched; keeps the model going on failure) ──
 	pi.on("agent_settled", async (_event, ctx) => {
+		if (!isInstalled(qualityGate)) return;
 		const payload = JSON.stringify({
 			session_id: ctx.sessionManager.getSessionId?.() ?? "nosession",
 			stop_hook_active: gateActive,
 		});
 		const run = await runScript(qualityGate, payload, ctx.cwd);
+
+		// A gate that cannot run has not passed. Say so rather than letting the turn end quietly,
+		// but only once per user turn, on the same re-entry guard a real gate failure uses.
+		if (run.failed && !gateActive) {
+			gateActive = true;
+			pi.sendUserMessage(
+				`The Cratis quality gate is installed at ${qualityGate} but could not be run, so nothing was verified this turn.` +
+					`${run.stderr.trim() ? `\n\n${run.stderr.trim()}` : ""}`,
+				{ deliverAs: "followUp" },
+			);
+			return;
+		}
 		if (run.code === 2 && !gateActive) {
 			gateActive = true; // don't block again until the next user turn resets it
 			const message = run.stderr.trim() || "A Cratis quality gate failed. Fix it and re-run the gate.";


### PR DESCRIPTION
# Summary

`runScript` resolved `{code: 0}` whenever a script **could not be executed** — the spawn threw,
the child emitted `error`, or bash exited 127 because the file wasn't there. Zero is *also* what a
hook returns when it inspects a write and decides to allow it. So **"the guard never ran" and "the
guard approved this" were the same value**, and a missing or broken guard silently permitted
exactly the writes it exists to refuse.

**This is not hypothetical — it is how the `.pi` port in #117 was caught.** `main` had only
`validate-ai-setup.sh` under `.ai/hooks/scripts/`, so the first guard test against the ported
extension **created `package-lock.json` and reported success**. A one-sided test (protected write,
expect a block) would have certified that bridge as healthy.

## The fix

`ScriptRun` now carries `failed`, set when the spawn throws, when `error` fires, and when the
close code is **127**. The exit code alone cannot carry this: 127 is bash's own "cannot execute",
and a spawn failure produces no code at all.

The three callers then decide **differently, because they are not the same kind of hook**:

| Hook | On "could not run" | Why |
| --- | --- | --- |
| **Write guard** | **Blocks**, naming the script path + stderr | Allowing means a protected write passes *because* the guard is broken |
| **Pattern scan** | Appends a note, does not block | Advisory; the write already happened — but a scan that silently stops looks like a scan that finds nothing |
| **Quality gate** | Reports it could not run | A gate that cannot run has not passed; reuses the existing `gateActive` re-entry guard so it speaks once per turn |

**A script that is simply absent stays a silent no-op, deliberately.** The corpus scripts already
degrade to a no-op when `jq` is missing, on the stated principle in `.ai/hooks/README.md` that
*"a hook must never break a session"*, and a repository shipping no hooks is supported.
`isInstalled` draws the line with a `statSync`: **absent = nothing to enforce;
present-but-unrunnable = a broken guard.** Only the second is a defect.

## Verification — three directions, not one

Against a real `pi` (v0.84.2):

| Scenario | Result |
| --- | --- |
| Guard present and working | **Blocked** — unchanged behavior (regression check) |
| Guard present but broken (shebang → nonexistent interpreter) | **Blocked**, with the interpreter error quoted back |
| Guard absent | **Allowed**, silently |

**Proven load-bearing:** reverting this file to `main`'s version and re-running the middle case
lets the write **succeed and create the file**; with the fix it is refused. Both files restored
afterwards and confirmed by **`shasum`**, not `diff`.

Also verified empirically, because the fix depends on it: **a missing script arrives through the
`close` handler with code 127, not through the `error` event** — so the close-path check is the
one that catches it.

## Gates

`validate-ai-setup.sh` exit 0 · `shellcheck` clean · Factory validation 29 schemas / 2 workflows /
14 profiles.

## Not verified

The quality-gate path was reasoned about, not exercised — firing it needs a real failing gate
inside a session.
