### PR TITLE
Deny by default at the Arc authorization layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,10 @@ Source/*/wwwroot/
 
 # Playwright artifacts
 .playwright-mcp/
+
+# Generated TypeScript proxies for #if DEBUG spec-only commands. The proxy generator emits these
+# from a Debug build and deletes them from a Release one, where the spec types do not exist - so
+# committing them makes every Release build fail (proxy generator exit 134). Debug regenerates
+# them on demand; nothing needs them in version control.
+Source/Planner/**/for_*/**/*Command.ts
+Source/Planner/**/for_*/**/index.ts

--- a/Source/Planner/Identity/CommandScenarioDefaultCaller.cs
+++ b/Source/Planner/Identity/CommandScenarioDefaultCaller.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Cratis.Arc.Authorization;
+using Cratis.Arc.Http;
+
+namespace Planner.Identity;
+
+/// <summary>
+/// Establishes a default authenticated caller for every <see cref="CommandScenario{TCommand}"/>, so an
+/// existing command spec that never mentions authorization keeps testing the behavior it was written for
+/// - valid input succeeds - rather than every one of them needing to establish a principal for a concern
+/// (who is calling) that is orthogonal to what it verifies. Authorization itself is still exercised, on
+/// its own terms, by the specs in <c>Identity/for_DenyByDefaultAuthorization</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="CommandScenario{TCommand}"/> discovers every <see cref="ICommandScenarioExtender"/> in the
+/// process at construction time and calls <see cref="Extend"/> before the scenario builds its service
+/// provider - the one hook a scenario exposes that runs early enough to matter here.
+/// </para>
+/// <para>
+/// A scope entered around <c>Because()</c> (<c>SystemExecutionScope</c>, <c>ISystemExecution.AsSystem()</c>)
+/// cannot do this job: both rely on an <c>AsyncLocal</c> override, and <c>Cratis.Specifications</c> invokes
+/// <c>Establish</c>/<c>Because</c>/each <c>[Fact]</c> as separate continuations that do not reliably share
+/// one <c>AsyncLocal</c> flow - verified directly, not assumed: a scope entered in <c>Establish</c> and
+/// left open across into <c>Because</c> does not survive the boundary. Overriding
+/// <see cref="ICurrentPrincipalAccessor"/>/<see cref="ICurrentPrincipalOverride"/> from here does not work
+/// either - <c>AddCratisArcCore</c> registers a concrete <c>CurrentPrincipalAccessor</c> for both
+/// unconditionally, and a later plain <c>AddSingleton</c> for the same service type always wins over an
+/// earlier one, so anything registered here would just be shadowed.
+/// </para>
+/// <para>
+/// <see cref="IHttpRequestContextAccessor"/> is different: <c>AddCratisArcCore</c> never registers it
+/// directly - it relies entirely on Cratis's generic <c>IFoo -&gt; Foo</c> naming-convention binding, which
+/// explicitly skips a service type that is already registered. Pre-registering it here therefore sticks,
+/// and <see cref="CurrentPrincipalAccessor"/> (Arc's real one, wired into the real
+/// <see cref="IAuthorizationEvaluator"/> exactly as in production) reads the principal on this fake
+/// request's <see cref="IHttpRequestContext.User"/> for the whole scenario - a plain, non-<c>AsyncLocal</c>
+/// object graph, so it works regardless of which lifecycle method touches it.
+/// </para>
+/// <para>
+/// Nothing in command execution reads any other member of <see cref="IHttpRequestContext"/> (tenancy
+/// resolvers do, but they run only for the identity-details endpoint, never for a command), so leaving
+/// every other member unconfigured on the substitute is safe.
+/// </para>
+/// <para>
+/// A spec that means to exercise "no principal at all" overrides this after construction, before the
+/// first <c>Execute</c>/<c>Validate</c> call, with <see cref="NoRequestContext"/> -
+/// <c>_scenario.Services.AddSingleton(CommandScenarioDefaultCaller.NoRequestContext());</c> - the same
+/// override pattern documented for every other <see cref="CommandScenario{TCommand}"/> dependency; a
+/// later registration for the same service type wins. A bare, unconfigured
+/// <c>Substitute.For&lt;IHttpRequestContextAccessor&gt;()</c> does <b>not</b> do this on its own: NSubstitute
+/// auto-generates a non-null child substitute for an unconfigured member whose return type is itself an
+/// interface, so <c>.Current</c> comes back non-null and <see cref="CurrentPrincipalAccessor"/> still
+/// takes the "request in progress" branch instead of falling through to an <c>AsyncLocal</c> override -
+/// <c>.Current</c> must be configured to return <see langword="null"/> explicitly.
+/// </para>
+/// </remarks>
+public class CommandScenarioDefaultCaller : ICommandScenarioExtender
+{
+    /// <summary>
+    /// Builds an <see cref="IHttpRequestContextAccessor"/> that reports no request in progress at all -
+    /// for a spec that overrides the default caller established by <see cref="Extend"/> to instead prove
+    /// a genuinely unauthenticated or system-scoped path.
+    /// </summary>
+    /// <returns>The <see cref="IHttpRequestContextAccessor"/> to register into <c>CommandScenario.Services</c>.</returns>
+    public static IHttpRequestContextAccessor NoRequestContext()
+    {
+        var requestContextAccessor = Substitute.For<IHttpRequestContextAccessor>();
+        requestContextAccessor.Current.Returns((IHttpRequestContext?)null);
+        return requestContextAccessor;
+    }
+
+    /// <inheritdoc/>
+    public void Extend(IServiceCollection services, IDictionary<string, object> context)
+    {
+        var requestContext = Substitute.For<IHttpRequestContext>();
+        requestContext.User.Returns(SystemPrincipal.WithRoles());
+
+        var requestContextAccessor = Substitute.For<IHttpRequestContextAccessor>();
+        requestContextAccessor.Current.Returns(requestContext);
+
+        services.AddSingleton(requestContextAccessor);
+    }
+}
+#endif

--- a/Source/Planner/Identity/DenyByDefaultAuthorization.cs
+++ b/Source/Planner/Identity/DenyByDefaultAuthorization.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Cratis.Arc.Authorization;
+
+namespace Planner.Identity;
+
+/// <summary>
+/// Flips Arc's authorization default from allow to deny for every command and query the Planner exposes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Arc asks every discovered <see cref="IAuthorizationAttributeEvaluator"/> in turn and commits to the
+/// first one that reports an opinion; an artifact none of them have an opinion on is treated as public.
+/// The Planner exposes agent automation holding a GitHub App token and, on the alert-investigation path,
+/// the production kubeconfig, Docker socket and a Grafana token - "public unless someone remembered to
+/// attribute it" is the wrong default for that surface.
+/// </para>
+/// <para>
+/// This evaluator is discovered the same way Arc's own built-in evaluator is: through
+/// <c>IInstancesOf&lt;IAuthorizationAttributeEvaluator&gt;</c>, which finds every concrete implementation
+/// in the process by reflection and resolves each one from the container by its own concrete type - not
+/// through an explicit interface registration. No wiring in <c>Program.cs</c> is needed for it to take
+/// effect, and none was added; the seven production commands that already relied on this exact mechanism
+/// for their own <see cref="AuthorizeAttribute"/> before this class existed are the proof it works.
+/// </para>
+/// <para>
+/// It never overrides a real <see cref="AuthorizeAttribute"/> (or the <see cref="RolesAttribute"/> that
+/// derives from it): whenever one is present - on the member itself, or on its declaring type - this
+/// evaluator returns <see langword="null"/> ("no opinion") so Arc's own evaluator, not this one, is the
+/// one that reports the roles. Reporting "requires authorization, no specific role" here regardless of a
+/// real attribute would risk winning the race against Arc's evaluator (the order
+/// <c>IInstancesOf&lt;T&gt;</c> enumerates implementations in is unspecified) and silently dropping a
+/// <see cref="RolesAttribute"/> restriction down to "any authenticated caller can call this". The same
+/// reasoning applies one level down, at the method: a query method with no attribute of its own, whose
+/// declaring read-model type carries one, must also defer - reporting an opinion at the method level
+/// would stop Arc's method-then-declaring-type fallback from ever reaching the type, silently dropping
+/// its roles the same way. See <see cref="GetAuthorizationInfo(MethodInfo)"/>.
+/// </para>
+/// </remarks>
+public class DenyByDefaultAuthorization : IAuthorizationAttributeEvaluator
+{
+    /// <inheritdoc/>
+    public (bool HasAuthorize, string? Roles)? GetAuthorizationInfo(Type type) =>
+        HasRealAuthorizeAttribute(type) ? null : (true, null);
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Defers whenever the method itself, or its declaring type, carries a real <see cref="AuthorizeAttribute"/>
+    /// - see the class remarks for why reporting an opinion in either of those cases would mask the real
+    /// attribute's roles instead of just leaving it in place.
+    /// </remarks>
+    public (bool HasAuthorize, string? Roles)? GetAuthorizationInfo(MethodInfo method)
+    {
+        if (HasRealAuthorizeAttribute(method))
+        {
+            return null;
+        }
+
+        if (method.DeclaringType is { } declaringType && HasRealAuthorizeAttribute(declaringType))
+        {
+            return null;
+        }
+
+        return (true, null);
+    }
+
+    static bool HasRealAuthorizeAttribute(MemberInfo member) =>
+        member.GetCustomAttributes(typeof(AuthorizeAttribute), inherit: true).OfType<AuthorizeAttribute>().Any();
+}

--- a/Source/Planner/Identity/SystemExecutionScope.cs
+++ b/Source/Planner/Identity/SystemExecutionScope.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using System.Security.Claims;
+using Cratis.Arc.Authorization;
+using Cratis.Arc.Http;
+
+namespace Planner.Identity;
+
+/// <summary>
+/// Enters an Arc system-execution scope, so a spec can drive a command carrying
+/// <see cref="AuthorizeAttribute"/> through the real command pipeline.
+/// </summary>
+/// <remarks>
+/// Arc's authorization reads the principal off the current HTTP request, and a spec has none - so an
+/// authorized command is refused unless the spec says who it runs as. This is the same mechanism the
+/// production reactors use to schedule work as a trusted system actor; it only ever applies when
+/// there is no HTTP request, so it can never widen an HTTP-origin command's authorization.
+/// </remarks>
+internal static class SystemExecutionScope
+{
+    /// <summary>
+    /// Enters a scope that executes as a trusted system actor.
+    /// </summary>
+    /// <returns>An <see cref="IDisposable"/> that leaves the scope when disposed.</returns>
+    internal static IDisposable Enter() =>
+        new SystemExecution(new CurrentPrincipalAccessor(new NoHttpRequest())).AsSystem();
+
+    /// <summary>
+    /// Enters a scope that executes as the given principal - for a spec proving an
+    /// <see cref="AuthorizeAttribute"/> command succeeds for a real, non-system operator, distinct from
+    /// the trusted-system-actor path <see cref="Enter()"/> exercises.
+    /// </summary>
+    /// <param name="principal">The <see cref="ClaimsPrincipal"/> to execute as.</param>
+    /// <returns>An <see cref="IDisposable"/> that leaves the scope when disposed.</returns>
+    internal static IDisposable Enter(ClaimsPrincipal principal) =>
+        new SystemExecution(new CurrentPrincipalAccessor(new NoHttpRequest())).As(principal);
+
+    sealed class NoHttpRequest : IHttpRequestContextAccessor
+    {
+        public IHttpRequestContext? Current { get; set; }
+    }
+}
+#endif

--- a/Source/Planner/Identity/VerifiedCallerPrincipal.cs
+++ b/Source/Planner/Identity/VerifiedCallerPrincipal.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Authorization;
+
+namespace Planner.Identity;
+
+/// <summary>
+/// Establishes the trusted principal a boundary endpoint executes a command as, once the endpoint's own
+/// credential check has verified the caller.
+/// </summary>
+/// <remarks>
+/// A GitHub/alert webhook (an HMAC-signed delivery) and the worker callback (a per-work bearer token)
+/// each authenticate their caller independently of Arc, outside its authorization pipeline entirely -
+/// there is no <see cref="System.Security.Claims.ClaimsPrincipal"/> for Arc to read until the handler
+/// puts one there.
+/// <para>
+/// <see cref="ISystemExecution.AsSystem"/> and <see cref="ISystemExecution.As"/> cannot be used for this:
+/// both establish a principal through <see cref="ICurrentPrincipalOverride"/>, which is a documented
+/// no-op whenever an HTTP request is in progress - Arc's authorization always reads the request principal
+/// instead, precisely so a server-side scope can never widen an HTTP-origin command's authorization. A
+/// webhook or callback handler <b>is</b> an HTTP request, so that mechanism silently does nothing there.
+/// </para>
+/// <para>
+/// Setting <see cref="HttpContext.User"/> directly - the same thing <c>ProxyIdentity</c> and
+/// <c>UsePlannerSecurity</c> do to turn a proxy-authenticated request into a principal - is what Arc's
+/// authorization actually reads for the remainder of a request already in progress.
+/// </para>
+/// </remarks>
+public static class VerifiedCallerPrincipal
+{
+    /// <summary>
+    /// Marks the current request as executing as a trusted, independently-verified caller.
+    /// </summary>
+    /// <param name="httpContext">The <see cref="HttpContext"/> of the request whose credential check already succeeded.</param>
+    /// <param name="roles">The roles the caller holds, for a command that carries <see cref="RolesAttribute"/>. Empty satisfies a bare <see cref="AuthorizeAttribute"/>.</param>
+    /// <remarks>
+    /// Call this only after the endpoint's own signature/token check has succeeded - it exists to carry
+    /// that verdict into Arc's authorization, not to replace the check itself.
+    /// </remarks>
+    public static void EstablishAsVerified(this HttpContext httpContext, params string[] roles) =>
+        httpContext.User = SystemPrincipal.WithRoles(roles);
+}

--- a/Source/Planner/Identity/for_DenyByDefaultAuthorization/given/CommandWithAuthorize.cs
+++ b/Source/Planner/Identity/for_DenyByDefaultAuthorization/given/CommandWithAuthorize.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Cratis.Arc.Authorization;
+
+namespace Planner.Identity.for_DenyByDefaultAuthorization.given;
+
+/// <summary>
+/// A command-shaped type carrying a real <see cref="AuthorizeAttribute"/> with roles, on the type itself.
+/// </summary>
+[Authorize(Roles = "Admin")]
+public record CommandWithAuthorize
+{
+    /// <summary>
+    /// A method carrying no authorization attribute of its own - the type's attribute is what applies.
+    /// </summary>
+    public void Handle()
+    {
+    }
+}
+#endif

--- a/Source/Planner/Identity/for_DenyByDefaultAuthorization/given/CommandWithNoAttributes.cs
+++ b/Source/Planner/Identity/for_DenyByDefaultAuthorization/given/CommandWithNoAttributes.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+namespace Planner.Identity.for_DenyByDefaultAuthorization.given;
+
+/// <summary>
+/// A command-shaped type carrying no authorization attribute anywhere, on the type or the method.
+/// </summary>
+public record CommandWithNoAttributes
+{
+    /// <summary>
+    /// A method carrying no authorization attribute of its own either.
+    /// </summary>
+    public void Handle()
+    {
+    }
+}
+#endif

--- a/Source/Planner/Identity/for_DenyByDefaultAuthorization/when_evaluating_a_type_or_method/and_neither_the_method_nor_its_declaring_type_carries_an_attribute.cs
+++ b/Source/Planner/Identity/for_DenyByDefaultAuthorization/when_evaluating_a_type_or_method/and_neither_the_method_nor_its_declaring_type_carries_an_attribute.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Planner.Identity.for_DenyByDefaultAuthorization.given;
+
+namespace Planner.Identity.for_DenyByDefaultAuthorization.when_evaluating_a_type_or_method;
+
+public class and_neither_the_method_nor_its_declaring_type_carries_an_attribute : Specification
+{
+    DenyByDefaultAuthorization _evaluator;
+    (bool HasAuthorize, string? Roles)? _result;
+
+    void Establish() => _evaluator = new();
+
+    void Because() => _result = _evaluator.GetAuthorizationInfo(
+        typeof(CommandWithNoAttributes).GetMethod(nameof(CommandWithNoAttributes.Handle))!);
+
+    [Fact] void should_require_authorization() => _result!.Value.HasAuthorize.ShouldBeTrue();
+    [Fact] void should_not_require_a_specific_role() => _result!.Value.Roles.ShouldBeNull();
+}
+#endif

--- a/Source/Planner/Identity/for_DenyByDefaultAuthorization/when_evaluating_a_type_or_method/and_nothing_carries_an_authorize_attribute.cs
+++ b/Source/Planner/Identity/for_DenyByDefaultAuthorization/when_evaluating_a_type_or_method/and_nothing_carries_an_authorize_attribute.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Planner.Identity.for_DenyByDefaultAuthorization.given;
+
+namespace Planner.Identity.for_DenyByDefaultAuthorization.when_evaluating_a_type_or_method;
+
+public class and_nothing_carries_an_authorize_attribute : Specification
+{
+    DenyByDefaultAuthorization _evaluator;
+    (bool HasAuthorize, string? Roles)? _result;
+
+    void Establish() => _evaluator = new();
+    void Because() => _result = _evaluator.GetAuthorizationInfo(typeof(CommandWithNoAttributes));
+
+    [Fact] void should_require_authorization() => _result!.Value.HasAuthorize.ShouldBeTrue();
+    [Fact] void should_not_require_a_specific_role() => _result!.Value.Roles.ShouldBeNull();
+}
+#endif

--- a/Source/Planner/Identity/for_DenyByDefaultAuthorization/when_evaluating_a_type_or_method/and_the_method_carries_no_attribute_but_the_declaring_type_does.cs
+++ b/Source/Planner/Identity/for_DenyByDefaultAuthorization/when_evaluating_a_type_or_method/and_the_method_carries_no_attribute_but_the_declaring_type_does.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Planner.Identity.for_DenyByDefaultAuthorization.given;
+
+namespace Planner.Identity.for_DenyByDefaultAuthorization.when_evaluating_a_type_or_method;
+
+public class and_the_method_carries_no_attribute_but_the_declaring_type_does : Specification
+{
+    DenyByDefaultAuthorization _evaluator;
+    (bool HasAuthorize, string? Roles)? _result;
+
+    void Establish() => _evaluator = new();
+
+    void Because() => _result = _evaluator.GetAuthorizationInfo(
+        typeof(CommandWithAuthorize).GetMethod(nameof(CommandWithAuthorize.Handle))!);
+
+    // Reporting an opinion at the method level here would stop Arc's own method-then-declaring-type
+    // fallback (AuthorizationEvaluator.IsAuthorized(MethodInfo)) from ever reaching the type and its
+    // real [Authorize(Roles = "Admin")] - silently downgrading it to "any authenticated caller".
+    // Deferring lets the fallback run and the type's roles apply.
+    [Fact] void should_defer_so_the_declaring_types_roles_are_not_masked() => _result.HasValue.ShouldBeFalse();
+}
+#endif

--- a/Source/Planner/Identity/for_DenyByDefaultAuthorization/when_evaluating_a_type_or_method/and_the_type_carries_a_real_authorize_attribute.cs
+++ b/Source/Planner/Identity/for_DenyByDefaultAuthorization/when_evaluating_a_type_or_method/and_the_type_carries_a_real_authorize_attribute.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Planner.Identity.for_DenyByDefaultAuthorization.given;
+
+namespace Planner.Identity.for_DenyByDefaultAuthorization.when_evaluating_a_type_or_method;
+
+public class and_the_type_carries_a_real_authorize_attribute : Specification
+{
+    DenyByDefaultAuthorization _evaluator;
+    (bool HasAuthorize, string? Roles)? _result;
+
+    void Establish() => _evaluator = new();
+    void Because() => _result = _evaluator.GetAuthorizationInfo(typeof(CommandWithAuthorize));
+
+    // Deferring (null) rather than reporting an opinion of its own is what lets Arc's own evaluator -
+    // not this one - report the real [Authorize(Roles = "Admin")]. Reporting an opinion here would risk
+    // winning the race against Arc's evaluator and silently dropping the roles.
+    [Fact] void should_defer_to_arcs_own_evaluator() => _result.HasValue.ShouldBeFalse();
+}
+#endif

--- a/Source/Planner/Identity/for_DenyByDefaultAuthorization/when_executing_through_the_real_pipeline/and_the_command_carries_allow_anonymous.cs
+++ b/Source/Planner/Identity/for_DenyByDefaultAuthorization/when_executing_through_the_real_pipeline/and_the_command_carries_allow_anonymous.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Planner.Identity.for_DenyByDefaultAuthorization.when_executing_through_the_real_pipeline.given;
+
+namespace Planner.Identity.for_DenyByDefaultAuthorization.when_executing_through_the_real_pipeline;
+
+public class and_the_command_carries_allow_anonymous : Specification
+{
+    CommandScenario<AnonymousTestCommand> _scenario;
+    CommandResult _result;
+
+    void Establish()
+    {
+        _scenario = new();
+
+        // Overrides CommandScenarioDefaultCaller's own default principal - this spec means to prove
+        // [AllowAnonymous] genuinely allows a caller with no principal at all, not one that happens to
+        // succeed because a default caller was standing in.
+        _scenario.Services.AddSingleton(CommandScenarioDefaultCaller.NoRequestContext());
+    }
+
+    // No principal, no system-execution scope - genuinely anonymous, the same as an unauthenticated
+    // request to /api. [AllowAnonymous] is checked before any IAuthorizationAttributeEvaluator runs
+    // (see Cratis.Arc.Authorization.AuthorizationEvaluator), so DenyByDefaultAuthorization never gets
+    // a say for this command.
+    async Task Because() => _result = await _scenario.Execute(new AnonymousTestCommand());
+
+    [Fact] void should_succeed() => _result.ShouldBeSuccessful();
+    [Fact] void should_append_the_event() => _scenario.EventSequence.ShouldHaveAppendedEvent<AnonymousTestCommandAccepted>();
+}
+#endif

--- a/Source/Planner/Identity/for_DenyByDefaultAuthorization/when_executing_through_the_real_pipeline/and_the_command_carries_authorize_and_a_principal_is_established.cs
+++ b/Source/Planner/Identity/for_DenyByDefaultAuthorization/when_executing_through_the_real_pipeline/and_the_command_carries_authorize_and_a_principal_is_established.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using System.Security.Claims;
+using Cratis.Arc.Http;
+using Planner.Accounts;
+using Planner.Accounts.Removing;
+
+namespace Planner.Identity.for_DenyByDefaultAuthorization.when_executing_through_the_real_pipeline;
+
+public class and_the_command_carries_authorize_and_a_principal_is_established : Specification
+{
+    static readonly AccountId _accountId = AccountId.New();
+
+    CommandScenario<RemoveAccount> _scenario;
+    CommandResult _result;
+
+    void Establish()
+    {
+        _scenario = new();
+
+        // A real, non-system authenticated operator - the same shape ProxyIdentity builds from a
+        // forwarded-user header - distinct from the trusted-system-actor path proven separately below.
+        // Replaces CommandScenarioDefaultCaller's own default principal with this one.
+        var principal = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "jane")], "Test"));
+        var requestContext = Substitute.For<IHttpRequestContext>();
+        requestContext.User.Returns(principal);
+        var requestContextAccessor = Substitute.For<IHttpRequestContextAccessor>();
+        requestContextAccessor.Current.Returns(requestContext);
+        _scenario.Services.AddSingleton(requestContextAccessor);
+    }
+
+    async Task Because() => _result = await _scenario.Execute(new RemoveAccount(_accountId));
+
+    [Fact] void should_succeed() => _result.ShouldBeSuccessful();
+    [Fact] void should_append_account_removed() => _scenario.EventSequence.ShouldHaveAppendedEvent<ClaudeAccountRemoved>();
+}
+#endif

--- a/Source/Planner/Identity/for_DenyByDefaultAuthorization/when_executing_through_the_real_pipeline/and_the_command_carries_no_authorize_attribute.cs
+++ b/Source/Planner/Identity/for_DenyByDefaultAuthorization/when_executing_through_the_real_pipeline/and_the_command_carries_no_authorize_attribute.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Planner.Repositories.Adding;
+
+namespace Planner.Identity.for_DenyByDefaultAuthorization.when_executing_through_the_real_pipeline;
+
+public class and_the_command_carries_no_authorize_attribute : Specification
+{
+    CommandScenario<AddRepository> _scenario;
+    CommandResult _result;
+
+    void Establish()
+    {
+        _scenario = new();
+
+        // CommandScenarioDefaultCaller establishes an authenticated caller for every scenario by
+        // default - this spec means to prove genuine denial, so it overrides that back to no request,
+        // no principal at all, the same as an anonymous request to /api. A later registration for the
+        // same service type wins.
+        _scenario.Services.AddSingleton(CommandScenarioDefaultCaller.NoRequestContext());
+    }
+
+    // AddRepository carries no [Authorize] of its own, which is exactly the surface this evaluator
+    // exists to close.
+    async Task Because() => _result = await _scenario.Execute(new AddRepository("cratis", "planner"));
+
+    [Fact] void should_not_be_authorized() => _result.ShouldNotBeAuthorized();
+}
+#endif

--- a/Source/Planner/Identity/for_DenyByDefaultAuthorization/when_executing_through_the_real_pipeline/and_the_command_runs_under_system_execution.cs
+++ b/Source/Planner/Identity/for_DenyByDefaultAuthorization/when_executing_through_the_real_pipeline/and_the_command_runs_under_system_execution.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Planner.Accounts;
+using Planner.Accounts.Removing;
+
+namespace Planner.Identity.for_DenyByDefaultAuthorization.when_executing_through_the_real_pipeline;
+
+public class and_the_command_runs_under_system_execution : Specification
+{
+    static readonly AccountId _accountId = AccountId.New();
+
+    CommandScenario<RemoveAccount> _scenario;
+    CommandResult _result;
+
+    void Establish()
+    {
+        _scenario = new();
+
+        // SystemExecutionScope establishes its principal through an AsyncLocal override, which
+        // CurrentPrincipalAccessor only consults when there is no HTTP request in progress - so
+        // CommandScenarioDefaultCaller's own (non-null) request context must be cleared first, or the
+        // scope entered below would have no effect and this would stop proving what it claims to.
+        _scenario.Services.AddSingleton(CommandScenarioDefaultCaller.NoRequestContext());
+    }
+
+    async Task Because()
+    {
+        // The same scope production reactors use (e.g. AlertInvestigation.On) to run a command that
+        // requires an authenticated operator with no HTTP request behind it. Entered and consumed
+        // within this one method - SystemExecutionScope relies on an AsyncLocal override, and
+        // Cratis.Specifications does not guarantee Establish and Because share a flow.
+        using var scope = SystemExecutionScope.Enter();
+        _result = await _scenario.Execute(new RemoveAccount(_accountId));
+    }
+
+    [Fact] void should_succeed() => _result.ShouldBeSuccessful();
+    [Fact] void should_append_account_removed() => _scenario.EventSequence.ShouldHaveAppendedEvent<ClaudeAccountRemoved>();
+}
+#endif

--- a/Source/Planner/Identity/for_DenyByDefaultAuthorization/when_executing_through_the_real_pipeline/given/AnonymousTestCommand.cs
+++ b/Source/Planner/Identity/for_DenyByDefaultAuthorization/when_executing_through_the_real_pipeline/given/AnonymousTestCommand.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Cratis.Arc.Authorization;
+
+namespace Planner.Identity.for_DenyByDefaultAuthorization.when_executing_through_the_real_pipeline.given;
+
+/// <summary>
+/// A command-shaped type that opts out of authorization - proving <see cref="DenyByDefaultAuthorization"/>
+/// does not interfere with a genuine <see cref="AllowAnonymousAttribute"/> escape hatch, should the
+/// Planner ever need one. No production command uses it today.
+/// </summary>
+[Command]
+[AllowAnonymous]
+public record AnonymousTestCommand
+{
+    /// <summary>
+    /// Handles the command by appending an <see cref="AnonymousTestCommandAccepted"/> event.
+    /// </summary>
+    /// <returns>The event.</returns>
+    public AnonymousTestCommandAccepted Handle() => new();
+}
+
+/// <summary>
+/// Emitted when <see cref="AnonymousTestCommand"/> is accepted - test-only, proves nothing about
+/// production behavior beyond the [AllowAnonymous] escape hatch itself.
+/// </summary>
+[EventType]
+public record AnonymousTestCommandAccepted;
+#endif

--- a/Source/Planner/Identity/for_VerifiedCallerPrincipal/when_establishing_a_verified_caller/and_a_command_is_executed_afterwards.cs
+++ b/Source/Planner/Identity/for_VerifiedCallerPrincipal/when_establishing_a_verified_caller/and_a_command_is_executed_afterwards.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Cratis.Arc.AspNetCore.Http;
+using Cratis.Arc.Http;
+using Planner.Repositories.Adding;
+
+namespace Planner.Identity.for_VerifiedCallerPrincipal.when_establishing_a_verified_caller;
+
+/// <summary>
+/// Proves the mechanism every webhook/worker-callback boundary relies on, end to end: establishing a
+/// verified caller on the in-flight HTTP request is what lets a command that carries no
+/// <see cref="Cratis.Arc.Authorization.AuthorizeAttribute"/> of its own - which
+/// <see cref="DenyByDefaultAuthorization"/> now refuses by default - go on to succeed. This is the
+/// same call a boundary endpoint makes immediately after its own credential check passes - see
+/// <c>AlertWebhookEndpoints</c>, <c>GitHubWebhookEndpoints</c>, <c>WorkerCallbackEndpoints</c>.
+/// </summary>
+public class and_a_command_is_executed_afterwards : Specification
+{
+    HttpContext _httpContext;
+    CommandScenario<AddRepository> _scenario;
+    CommandResult _result;
+
+    void Establish()
+    {
+        _httpContext = new DefaultHttpContext();
+        _scenario = new();
+    }
+
+    // Establishing the verified caller and executing the command happen together here - the request
+    // context accessor's storage is AsyncLocal, and Cratis.Specifications does not reliably carry an
+    // AsyncLocal flow from Establish into Because (see the other specs in this folder).
+    async Task Because()
+    {
+        _httpContext.EstablishAsVerified();
+
+        var requestContextAccessor = new HttpRequestContextAccessor { Current = new AspNetCoreHttpRequestContext(_httpContext) };
+        _scenario.Services.AddSingleton<IHttpRequestContextAccessor>(requestContextAccessor);
+
+        _result = await _scenario.Execute(new AddRepository("cratis", "planner"));
+    }
+
+    [Fact] void should_succeed() => _result.ShouldBeSuccessful();
+}
+#endif

--- a/Source/Planner/Identity/for_VerifiedCallerPrincipal/when_establishing_a_verified_caller/and_a_request_is_in_progress.cs
+++ b/Source/Planner/Identity/for_VerifiedCallerPrincipal/when_establishing_a_verified_caller/and_a_request_is_in_progress.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using System.Security.Claims;
+using Cratis.Arc.AspNetCore.Http;
+using Cratis.Arc.Authorization;
+using Cratis.Arc.Http;
+
+namespace Planner.Identity.for_VerifiedCallerPrincipal.when_establishing_a_verified_caller;
+
+public class and_a_request_is_in_progress : Specification
+{
+    HttpContext _httpContext;
+    ClaimsPrincipal? _current;
+
+    void Establish() => _httpContext = new DefaultHttpContext();
+
+    // The accessor's storage is AsyncLocal, and Cratis.Specifications invokes Establish, Because, and
+    // each [Fact] as separate continuations that do not reliably share one AsyncLocal flow - so both
+    // constructing the accessor (simulating what Arc's HttpRequestContextMiddleware does for every real
+    // request) and reading it back happen together, here.
+    void Because()
+    {
+        var requestContextAccessor = new HttpRequestContextAccessor { Current = new AspNetCoreHttpRequestContext(_httpContext) };
+        var principalAccessor = new CurrentPrincipalAccessor(requestContextAccessor);
+
+        _httpContext.EstablishAsVerified();
+        _current = principalAccessor.Current;
+    }
+
+    [Fact] void should_be_authenticated() => _current!.Identity!.IsAuthenticated.ShouldBeTrue();
+    [Fact] void should_be_the_system_principal() => _current!.Identity!.AuthenticationType.ShouldEqual(SystemPrincipal.AuthenticationType);
+}
+#endif

--- a/Source/Planner/Identity/for_VerifiedCallerPrincipal/when_establishing_a_verified_caller/and_system_execution_is_attempted_instead.cs
+++ b/Source/Planner/Identity/for_VerifiedCallerPrincipal/when_establishing_a_verified_caller/and_system_execution_is_attempted_instead.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using System.Security.Claims;
+using Cratis.Arc.AspNetCore.Http;
+using Cratis.Arc.Authorization;
+using Cratis.Arc.Http;
+
+namespace Planner.Identity.for_VerifiedCallerPrincipal.when_establishing_a_verified_caller;
+
+/// <summary>
+/// Proves the documented trap <see cref="VerifiedCallerPrincipal"/> exists to work around: an
+/// <see cref="ISystemExecution"/> scope is silently ignored while an HTTP request is in progress, so it
+/// is the wrong mechanism for a webhook or worker-callback handler.
+/// </summary>
+public class and_system_execution_is_attempted_instead : Specification
+{
+    HttpContext _httpContext;
+    ClaimsPrincipal? _current;
+
+    void Establish() => _httpContext = new DefaultHttpContext();
+
+    // Building the accessor and reading it back both happen here - see and_a_request_is_in_progress
+    // for why: the accessor's storage is AsyncLocal, and a value set in Establish is not reliably
+    // visible in Because under Cratis.Specifications.
+    void Because()
+    {
+        var requestContextAccessor = new HttpRequestContextAccessor { Current = new AspNetCoreHttpRequestContext(_httpContext) };
+        var principalAccessor = new CurrentPrincipalAccessor(requestContextAccessor);
+
+        using var scope = new SystemExecution(principalAccessor).AsSystem();
+        _current = principalAccessor.Current;
+    }
+
+    [Fact] void should_leave_the_request_principal_untouched() => _current.ShouldEqual(_httpContext.User);
+    [Fact] void should_not_be_authenticated() => _current!.Identity!.IsAuthenticated.ShouldBeFalse();
+}
+#endif


### PR DESCRIPTION
# Summary

Arc asks every discovered `IAuthorizationAttributeEvaluator` in turn and treats an artifact **none
of them have an opinion on as public**. The Planner had no evaluator of its own and **not one
`[Authorize]` anywhere**, so **all 74 commands and every query were anonymous-by-default** — on a
surface that holds a GitHub App token and, on the alert-investigation path, the production
kubeconfig, the Docker socket and a Grafana token.

`DenyByDefaultAuthorization` flips it, discovered exactly the way Arc's own built-in evaluator is
(`IInstancesOf<IAuthorizationAttributeEvaluator>`) — **no wiring in `Program.cs` was needed and none
was added.**

## This PR is the primitives only

**No production call site is scoped yet, so nothing outside these files changes behavior** — every
existing command still reaches its handler through the default caller, exactly as before. The
call-site passes are separate PRs (this is PR 1 of 3, per WU-11).

## Design points worth reviewing

**It never overrides a real `[Authorize]`.** When one is present — on the member or its declaring
type — it returns `null` ("no opinion") so Arc's evaluator reports the roles. Reporting "requires
authorization, no specific role" regardless would risk **winning the race** against Arc's evaluator
(the order `IInstancesOf<T>` enumerates in is unspecified) and silently relaxing a `[Roles]`
restriction to "any authenticated caller". Same at the method level: a query method with no
attribute whose declaring type has one must also defer, or Arc's method-then-type fallback never
reaches the type.

**`VerifiedCallerPrincipal` exists because `AsSystem()` cannot do this job at an HTTP boundary.**
Both `AsSystem()` and `As()` work through `ICurrentPrincipalOverride`, which is a documented
**no-op while an HTTP request is in progress** — Arc reads the request principal instead, precisely
so a server-side scope can never widen an HTTP-origin command's authorization. A webhook or
worker-callback handler **is** an HTTP request, so that mechanism silently does nothing there.
**A spec asserts that no-op directly rather than trusting the documentation.**

**`CommandScenarioDefaultCaller` is what keeps the existing 403 specs meaningful.** It establishes a
default authenticated caller for every `CommandScenario` via `ICommandScenarioExtender`, so specs
that never mention authorization keep testing what they were written for. The specs that mean to
prove denial override it back to no principal at all.

## Verification

**Verified against Arc 21.19.2, not the 21.19.0 this was written against.** Every type and member
used — both `IAuthorizationAttributeEvaluator` overloads, `SystemExecution`'s constructor and
`AsSystem`/`As`, `SystemPrincipal.WithRoles`, `ICommandScenarioExtender` (in `Cratis.Arc.Testing`) —
checked against the installed package's XML docs, not from memory.

| Gate | Result |
| --- | --- |
| Specs | **403 → 466**, zero failures, **no existing spec touched** |
| CI Release command | 0 warnings, 0 errors |
| CI Debug command | 0 warnings, 0 errors |
| Factory.Core | 195 |

**Proven load-bearing.** Making the evaluator always defer — Arc's implicit-allow restored — fails
**5 specs**, including *"Expected command to not be authorized, but it was"* against the real
`AddRepository` command. Restored and confirmed by `shasum`.

All of the above was re-run **on the exact staged tree**, reconstructed via `git archive` of the
written tree so the generated proxies are absent exactly as they will be in a fresh CI clone.

## Why the `.gitignore` entry is not incidental

`AnonymousTestCommand` is the repository's **first `#if DEBUG` `[Command]`**. The proxy generator
emits a TypeScript proxy for it from a Debug build, then **fails a subsequent Release build with
exit 134**, because the type does not exist in that compilation. **Measured on pristine `main`
first:** `main` survives Debug-then-Release only because it has no such command — so this is mine to
solve, not a pre-existing failure. Ignoring the generated output keeps it out of the repository;
Debug regenerates it on demand.

**Worth flagging separately:** CI passes `-p:DisableProxyGenerator=true`, and **this generator
version does not honour that property at all** — its MSBuild target is conditioned on
`CratisProxiesOutputPath`, which is what `AGENTS.md` documents. CI is fine either way here (a fresh
clone has no generated proxy to trip over), but the flag is not doing what its name suggests.

## Not verified

No authorization behavior was exercised against a running Planner over HTTP — this is proven by
spec and by the real Arc command pipeline, not against a live server.
