### PR TITLE
Scope every command-executing path for deny-by-default

### DIFF
--- a/Source/Planner/Accounts/SettingToken/when_setting_token/and_there_is_no_authenticated_operator.cs
+++ b/Source/Planner/Accounts/SettingToken/when_setting_token/and_there_is_no_authenticated_operator.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using Planner.Identity;
+
+namespace Planner.Accounts.SettingToken.when_setting_token;
+
+/// <summary>
+/// Proves the command genuinely refuses an anonymous caller rather than merely carrying an attribute
+/// nobody evaluates - the other specs in this folder only pass because they say who they run as.
+/// </summary>
+public class and_there_is_no_authenticated_operator : Specification
+{
+    static readonly AccountId _accountId = AccountId.New();
+
+    CommandScenario<SetAccountToken> _scenario;
+    CommandResult _result;
+
+    void Establish()
+    {
+        _scenario = new();
+
+        // CommandScenarioDefaultCaller establishes an authenticated caller for every scenario by
+        // default, so a command spec that never mentions authorization keeps testing the behavior it
+        // was written for. This spec's whole purpose is the opposite - proving the command refuses a
+        // caller with no principal at all - so it overrides that default back off.
+        _scenario.Services.AddSingleton(CommandScenarioDefaultCaller.NoRequestContext());
+    }
+
+    async Task Because() => _result = await _scenario.Execute(new SetAccountToken(_accountId, "sk-ant-rotated"));
+
+    [Fact] void should_not_succeed() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_refuse_the_caller() => _result.IsAuthorized.ShouldBeFalse();
+
+    // Refused before validation, so the rejection is authorization and not a complaint about the token.
+    [Fact] void should_not_have_gotten_as_far_as_validating() => _result.ValidationResults.ShouldBeEmpty();
+}
+#endif

--- a/Source/Planner/Alerts/EscalationReporting/EscalationReporting.cs
+++ b/Source/Planner/Alerts/EscalationReporting/EscalationReporting.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Authorization;
 using Microsoft.Extensions.Options;
 using Planner.Alerts.AutoConvertingToIssue;
 using Planner.Alerts.Listing;
@@ -22,11 +23,13 @@ namespace Planner.Alerts.EscalationReporting;
 /// <param name="commandPipeline">The <see cref="ICommandPipeline"/> for executing commands.</param>
 /// <param name="gitHub">The <see cref="IGitHubClient"/> for commenting on an already-filed issue.</param>
 /// <param name="options">The operations configuration - carries the default issue repository.</param>
+/// <param name="systemExecution">The <see cref="ISystemExecution"/> the commands below run as - there is no HTTP request behind this.</param>
 public class AlertEscalationReporting(
     IEventStore eventStore,
     ICommandPipeline commandPipeline,
     IGitHubClient gitHub,
-    IOptions<OperationsOptions> options) : IReactor
+    IOptions<OperationsOptions> options,
+    ISystemExecution systemExecution) : IReactor
 {
     /// <summary>
     /// Files the alert as an issue, or comments on the one already filed for it.
@@ -59,6 +62,9 @@ public class AlertEscalationReporting(
                 $"This alert recurred and still needs attention:\n\n{@event.Findings.Value}{AIIdentity.Footer()}");
             return;
         }
+
+        // A reactor has no HTTP request behind it - filing the issue runs as the system.
+        using var scope = systemExecution.AsSystem();
 
         await commandPipeline.Execute(new AutoConvertAlertToIssue(
             alertId,

--- a/Source/Planner/Alerts/EscalationReporting/for_AlertEscalationReporting/given/a_reactor.cs
+++ b/Source/Planner/Alerts/EscalationReporting/for_AlertEscalationReporting/given/a_reactor.cs
@@ -7,6 +7,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Planner.GitHub;
 using Planner.Operations;
+using Cratis.Arc.Authorization;
+using Planner.Identity;
 
 namespace Planner.Alerts.EscalationReporting.for_AlertEscalationReporting.given;
 
@@ -33,6 +35,7 @@ public class a_reactor : Specification
             .AddSingleton(_commandPipeline)
             .AddSingleton(_gitHub)
             .AddSingleton<IOptions<OperationsOptions>>(Options.Create(_options))
+            .AddSingleton(SystemExecutionScope.ForSpecs())
             .BuildServiceProvider());
     }
 

--- a/Source/Planner/Alerts/Investigating/Investigating.cs
+++ b/Source/Planner/Alerts/Investigating/Investigating.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Authorization;
 using Microsoft.Extensions.Options;
 using Planner.Alerts.Raising;
 using Planner.Alerts.RecordingInvestigation;
@@ -22,7 +23,8 @@ namespace Planner.Alerts.Investigating;
 /// </summary>
 /// <param name="commandPipeline">The <see cref="ICommandPipeline"/> for executing commands.</param>
 /// <param name="options">The alert configuration.</param>
-public class AlertInvestigation(ICommandPipeline commandPipeline, IOptions<AlertOptions> options) : IReactor
+/// <param name="systemExecution">The <see cref="ISystemExecution"/> the commands below run as - there is no HTTP request behind this.</param>
+public class AlertInvestigation(ICommandPipeline commandPipeline, IOptions<AlertOptions> options, ISystemExecution systemExecution) : IReactor
 {
     /// <summary>
     /// Schedules an investigation for a newly raised alert.
@@ -37,6 +39,8 @@ public class AlertInvestigation(ICommandPipeline commandPipeline, IOptions<Alert
             return;
         }
 
+        // A reactor has no HTTP request behind it - the command below runs as the system.
+        using var scope = systemExecution.AsSystem();
         await commandPipeline.Execute(new ScheduleAlertInvestigation(new AlertId(context.EventSourceId.Value)));
     }
 
@@ -63,7 +67,8 @@ public class AlertInvestigation(ICommandPipeline commandPipeline, IOptions<Alert
 /// </summary>
 /// <param name="eventStore">The <see cref="IEventStore"/> for reading the work's read model.</param>
 /// <param name="commandPipeline">The <see cref="ICommandPipeline"/> for executing commands.</param>
-public class AlertInvestigationPropagation(IEventStore eventStore, ICommandPipeline commandPipeline) : IReactor
+/// <param name="systemExecution">The <see cref="ISystemExecution"/> the commands below run as - there is no HTTP request behind this.</param>
+public class AlertInvestigationPropagation(IEventStore eventStore, ICommandPipeline commandPipeline, ISystemExecution systemExecution) : IReactor
 {
     /// <summary>
     /// Records that an agent has picked the alert up.
@@ -75,6 +80,8 @@ public class AlertInvestigationPropagation(IEventStore eventStore, ICommandPipel
     {
         if (await AlertFor(context) is { } alert)
         {
+            // A reactor has no HTTP request behind it - the command below runs as the system.
+            using var scope = systemExecution.AsSystem();
             await commandPipeline.Execute(new StartAlertInvestigation(alert, new WorkId(Guid.Parse(context.EventSourceId.Value))));
         }
     }
@@ -89,6 +96,8 @@ public class AlertInvestigationPropagation(IEventStore eventStore, ICommandPipel
     {
         if (await AlertFor(context) is { } alert)
         {
+            // A reactor has no HTTP request behind it - the command below runs as the system.
+            using var scope = systemExecution.AsSystem();
             await commandPipeline.Execute(new ConcludeAlertInvestigation(
                 alert,
                 AlertOutcomes.Read(@event.Summary.Value),
@@ -106,6 +115,8 @@ public class AlertInvestigationPropagation(IEventStore eventStore, ICommandPipel
     {
         if (await AlertFor(context) is { } alert)
         {
+            // A reactor has no HTTP request behind it - the command below runs as the system.
+            using var scope = systemExecution.AsSystem();
             await commandPipeline.Execute(new FailAlertInvestigation(alert, @event.Reason.Value));
         }
     }
@@ -121,6 +132,8 @@ public class AlertInvestigationPropagation(IEventStore eventStore, ICommandPipel
     {
         if (await AlertFor(context) is { } alert)
         {
+            // A reactor has no HTTP request behind it - the command below runs as the system.
+            using var scope = systemExecution.AsSystem();
             await commandPipeline.Execute(new FailAlertInvestigation(alert, "The investigation was stopped before it concluded"));
         }
     }

--- a/Source/Planner/Alerts/Investigating/for_AlertInvestigation/when_an_alert_is_raised/and_auto_investigation_is_off.cs
+++ b/Source/Planner/Alerts/Investigating/for_AlertInvestigation/when_an_alert_is_raised/and_auto_investigation_is_off.cs
@@ -7,6 +7,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Planner.Alerts.Raising;
 using Planner.Work.SchedulingAlertInvestigation;
+using Cratis.Arc.Authorization;
+using Planner.Identity;
 
 namespace Planner.Alerts.Investigating.for_AlertInvestigation.when_an_alert_is_raised;
 
@@ -21,6 +23,7 @@ public class and_auto_investigation_is_off : Specification
         _scenario = new(new ServiceCollection()
             .AddSingleton(_commandPipeline)
             .AddSingleton(Options.Create(new AlertOptions { AutoInvestigate = false }))
+            .AddSingleton(SystemExecutionScope.ForSpecs())
             .BuildServiceProvider());
     }
 

--- a/Source/Planner/Alerts/Investigating/for_AlertInvestigation/when_an_alert_is_raised/and_auto_investigation_is_on.cs
+++ b/Source/Planner/Alerts/Investigating/for_AlertInvestigation/when_an_alert_is_raised/and_auto_investigation_is_on.cs
@@ -7,6 +7,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Planner.Alerts.Raising;
 using Planner.Work.SchedulingAlertInvestigation;
+using Cratis.Arc.Authorization;
+using Planner.Identity;
 
 namespace Planner.Alerts.Investigating.for_AlertInvestigation.when_an_alert_is_raised;
 
@@ -23,6 +25,7 @@ public class and_auto_investigation_is_on : Specification
         _scenario = new(new ServiceCollection()
             .AddSingleton(_commandPipeline)
             .AddSingleton(Options.Create(new AlertOptions()))
+            .AddSingleton(SystemExecutionScope.ForSpecs())
             .BuildServiceProvider());
     }
 

--- a/Source/Planner/Alerts/Investigating/for_AlertInvestigation/when_an_alert_is_raised/and_the_condition_came_back_after_being_resolved.cs
+++ b/Source/Planner/Alerts/Investigating/for_AlertInvestigation/when_an_alert_is_raised/and_the_condition_came_back_after_being_resolved.cs
@@ -8,6 +8,8 @@ using Microsoft.Extensions.Options;
 using Planner.Alerts.Raising;
 using Planner.Alerts.Resolving;
 using Planner.Work.SchedulingAlertInvestigation;
+using Cratis.Arc.Authorization;
+using Planner.Identity;
 
 namespace Planner.Alerts.Investigating.for_AlertInvestigation.when_an_alert_is_raised;
 
@@ -35,6 +37,7 @@ public class and_the_condition_came_back_after_being_resolved : Specification
         _scenario = new(new ServiceCollection()
             .AddSingleton(_commandPipeline)
             .AddSingleton(Options.Create(new AlertOptions()))
+            .AddSingleton(SystemExecutionScope.ForSpecs())
             .BuildServiceProvider());
     }
 

--- a/Source/Planner/Alerts/Investigating/for_AlertInvestigationPropagation/given/an_alert_investigation.cs
+++ b/Source/Planner/Alerts/Investigating/for_AlertInvestigationPropagation/given/an_alert_investigation.cs
@@ -6,6 +6,8 @@ using Cratis.Chronicle.Testing.Reactors;
 using Microsoft.Extensions.DependencyInjection;
 using Planner.Work;
 using Planner.Work.Listing;
+using Cratis.Arc.Authorization;
+using Planner.Identity;
 
 namespace Planner.Alerts.Investigating.for_AlertInvestigationPropagation.given;
 
@@ -25,6 +27,7 @@ public class an_alert_investigation : Specification
         _scenario = new(new ServiceCollection()
             .AddSingleton(_eventStore)
             .AddSingleton(_commandPipeline)
+            .AddSingleton(SystemExecutionScope.ForSpecs())
             .BuildServiceProvider());
 
         SetWorkItem(new WorkItem(_workId, WorkPurpose.AlertInvestigation, [], ModelName.NotSet, UserName.NotSet, Alert: _alertId));

--- a/Source/Planner/Alerts/Webhooks/AlertWebhookEndpoints.cs
+++ b/Source/Planner/Alerts/Webhooks/AlertWebhookEndpoints.cs
@@ -4,6 +4,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.Options;
+using Planner.Identity;
 
 namespace Planner.Alerts.Webhooks;
 
@@ -38,6 +39,11 @@ public static class AlertWebhookEndpoints
             {
                 return Results.Unauthorized();
             }
+
+            // The HMAC check above is the caller's real credential - establish the trusted principal
+            // Arc's authorization reads for the rest of this request immediately after it passes, and
+            // before the command below.
+            request.HttpContext.EstablishAsVerified();
 
             var command = AlertDelivery.Parse(body, options.Value.DefaultSource);
             if (command is null)

--- a/Source/Planner/Builds/Analyzing/Analyzing.cs
+++ b/Source/Planner/Builds/Analyzing/Analyzing.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Authorization;
 using Planner.Builds.RecordingDiagnosis;
 using Planner.Builds.RecordingStatus;
 using Planner.LanguageModels;
@@ -18,7 +19,8 @@ namespace Planner.Builds.Analyzing;
 /// </summary>
 /// <param name="commandPipeline">The <see cref="ICommandPipeline"/> for executing commands.</param>
 /// <param name="languageModel">The <see cref="ILanguageModel"/> the assessment is asked from.</param>
-public class BuildFailureAnalysis(ICommandPipeline commandPipeline, ILanguageModel languageModel) : IReactor
+/// <param name="systemExecution">The <see cref="ISystemExecution"/> the commands below run as - there is no HTTP request behind this.</param>
+public class BuildFailureAnalysis(ICommandPipeline commandPipeline, ILanguageModel languageModel, ISystemExecution systemExecution) : IReactor
 {
     /// <summary>
     /// Assesses a newly failing build.
@@ -47,6 +49,11 @@ public class BuildFailureAnalysis(ICommandPipeline commandPipeline, ILanguageMod
         }
 
         var workflowId = new BuildWorkflowId(context.EventSourceId.Value);
+
+        // One scope for the whole analysis - recording the diagnosis and scheduling the fix are one
+        // logical operation, and a reactor has no HTTP request behind it.
+        using var scope = systemExecution.AsSystem();
+
         await commandPipeline.Execute(new RecordBuildDiagnosis(workflowId, assessment.Diagnosis, assessment.Fixable));
 
         if (assessment.Fixable)

--- a/Source/Planner/Builds/Analyzing/for_BuildFailureAnalysis/given/a_reactor.cs
+++ b/Source/Planner/Builds/Analyzing/for_BuildFailureAnalysis/given/a_reactor.cs
@@ -5,6 +5,7 @@
 using Cratis.Chronicle.Testing.Reactors;
 using Microsoft.Extensions.DependencyInjection;
 using Planner.LanguageModels;
+using Planner.Identity;
 
 namespace Planner.Builds.Analyzing.for_BuildFailureAnalysis.given;
 
@@ -24,7 +25,8 @@ public class a_reactor : Specification
 
         _scenario = new(services => services
             .AddSingleton(_commandPipeline)
-            .AddSingleton(_languageModel));
+            .AddSingleton(_languageModel)
+            .AddSingleton(SystemExecutionScope.ForSpecs()));
     }
 }
 #endif

--- a/Source/Planner/Builds/CheckingStatus/CheckingStatus.cs
+++ b/Source/Planner/Builds/CheckingStatus/CheckingStatus.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Authorization;
 using MongoDB.Driver;
 using Planner.Builds.RecordingStatus;
 using Planner.GitHub;
@@ -29,16 +30,22 @@ public interface IBuildStatusChecker
 /// <param name="repositories">The repository read models.</param>
 /// <param name="gitHub">The <see cref="IGitHubClient"/> for talking to GitHub.</param>
 /// <param name="commandPipeline">The <see cref="ICommandPipeline"/> for executing commands.</param>
+/// <param name="systemExecution">The <see cref="ISystemExecution"/> the commands below run as - there is no HTTP request behind this.</param>
 /// <param name="logger">The logger.</param>
 public class BuildStatusChecker(
     IMongoCollection<Repository> repositories,
     IGitHubClient gitHub,
     ICommandPipeline commandPipeline,
+    ISystemExecution systemExecution,
     ILogger<BuildStatusChecker> logger) : IBuildStatusChecker
 {
     /// <inheritdoc/>
     public async Task CheckAll(CancellationToken cancellationToken = default)
     {
+        // One scope for the whole pass - the checker runs from a daily reminder, with no operator and
+        // no HTTP request behind it.
+        using var scope = systemExecution.AsSystem();
+
         var cursor = await repositories.FindAsync(FilterDefinition<Repository>.Empty, cancellationToken: cancellationToken);
         var all = await cursor.ToListAsync(cancellationToken);
         foreach (var repository in all)

--- a/Source/Planner/Builds/CheckingStatus/for_BuildStatusChecker/given/all_dependencies.cs
+++ b/Source/Planner/Builds/CheckingStatus/for_BuildStatusChecker/given/all_dependencies.cs
@@ -5,6 +5,7 @@
 using MongoDB.Driver;
 using Planner.GitHub;
 using Repository = Planner.Repositories.Listing.Repository;
+using Cratis.Arc.Authorization;
 
 namespace Planner.Builds.CheckingStatus.for_BuildStatusChecker.given;
 
@@ -23,7 +24,7 @@ public class all_dependencies : Specification
         _repositories = CollectionOf(() => _repositoriesData);
         _gitHub = Substitute.For<IGitHubClient>();
         _commandPipeline = Substitute.For<ICommandPipeline>();
-        _checker = new(_repositories, _gitHub, _commandPipeline, Substitute.For<Microsoft.Extensions.Logging.ILogger<BuildStatusChecker>>());
+        _checker = new(_repositories, _gitHub, _commandPipeline, Substitute.For<ISystemExecution>(), Substitute.For<Microsoft.Extensions.Logging.ILogger<BuildStatusChecker>>());
     }
 
     static IMongoCollection<T> CollectionOf<T>(Func<IReadOnlyList<T>> items)

--- a/Source/Planner/GitHub/Synchronization/IssueSynchronizer.cs
+++ b/Source/Planner/GitHub/Synchronization/IssueSynchronizer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Authorization;
 using MongoDB.Driver;
 using Planner.Issues.ChangingBody;
 using Planner.Issues.ChangingLabels;
@@ -47,12 +48,14 @@ public interface IIssueSynchronizer
 /// <param name="issues">The issue read models.</param>
 /// <param name="gitHub">The <see cref="IGitHubClient"/> for talking to GitHub.</param>
 /// <param name="commandPipeline">The <see cref="ICommandPipeline"/> for executing commands.</param>
+/// <param name="systemExecution">The <see cref="ISystemExecution"/> the commands below run as - there is no HTTP request behind this.</param>
 /// <param name="logger">The logger.</param>
 public class IssueSynchronizer(
     IMongoCollection<Repository> repositories,
     IMongoCollection<ListedIssue> issues,
     IGitHubClient gitHub,
     ICommandPipeline commandPipeline,
+    ISystemExecution systemExecution,
     ILogger<IssueSynchronizer> logger) : IIssueSynchronizer
 {
     /// <inheritdoc/>
@@ -69,6 +72,10 @@ public class IssueSynchronizer(
     /// <inheritdoc/>
     public async Task SynchronizeRepository(OrganizationName owner, RepositoryName name, CancellationToken cancellationToken = default)
     {
+        // One scope for the whole repository pass - the synchronizer runs from a reminder, with no
+        // operator and no HTTP request behind it.
+        using var scope = systemExecution.AsSystem();
+
         logger.SynchronizingRepository(owner, name);
         var gitHubIssues = await gitHub.GetIssues(owner, name, cancellationToken);
 

--- a/Source/Planner/GitHub/Webhooks/GitHubWebhookEndpoints.cs
+++ b/Source/Planner/GitHub/Webhooks/GitHubWebhookEndpoints.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using Planner.GitHub.App;
 using Planner.GitHub.App.Installations;
+using Planner.Identity;
 using Planner.Issues.ChangingAssignees;
 using Planner.Issues.ChangingBody;
 using Planner.Issues.ChangingLabels;
@@ -58,6 +59,11 @@ public static class GitHubWebhookEndpoints
             {
                 return Results.Unauthorized();
             }
+
+            // The HMAC check above is the caller's real credential - establish the trusted principal
+            // Arc's authorization reads for the rest of this request immediately after it passes, and
+            // before any of the commands the handlers below may execute.
+            request.HttpContext.EstablishAsVerified();
 
             if (JsonNode.Parse(body) is not JsonObject payload)
             {

--- a/Source/Planner/Identity/SystemExecutionScope.cs
+++ b/Source/Planner/Identity/SystemExecutionScope.cs
@@ -37,6 +37,27 @@ internal static class SystemExecutionScope
     internal static IDisposable Enter(ClaimsPrincipal principal) =>
         new SystemExecution(new CurrentPrincipalAccessor(new NoHttpRequest())).As(principal);
 
+    /// <summary>
+    /// A real <see cref="ISystemExecution"/> for a reactor spec to register, rather than a substitute.
+    /// </summary>
+    /// <returns>The <see cref="ISystemExecution"/> to register into the scenario's services.</returns>
+    /// <remarks>
+    /// A substitute would return <see langword="null"/> from <see cref="ISystemExecution.AsSystem"/> and
+    /// make every <c>using var scope = systemExecution.AsSystem()</c> in the reactor a no-op, so the spec
+    /// would pass whether or not the reactor actually established a principal - which is precisely the
+    /// thing worth proving. The real one, over an accessor reporting no HTTP request, enters the same
+    /// scope production does when a reactor runs off a timer or an event.
+    /// </remarks>
+    internal static ISystemExecution ForSpecs() =>
+        new SystemExecution(new CurrentPrincipalAccessor(new NoHttpRequest()));
+
+    /// <summary>
+    /// An <see cref="IHttpRequestContextAccessor"/> reporting no HTTP request in progress - for a spec
+    /// that needs to read the ambient principal the same way Arc's own authorization would.
+    /// </summary>
+    /// <returns>The accessor.</returns>
+    internal static IHttpRequestContextAccessor NoRequestContextAccessor() => new NoHttpRequest();
+
     sealed class NoHttpRequest : IHttpRequestContextAccessor
     {
         public IHttpRequestContext? Current { get; set; }

--- a/Source/Planner/Issues/AcceptingPullRequest/AcceptingPullRequest.cs
+++ b/Source/Planner/Issues/AcceptingPullRequest/AcceptingPullRequest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Authorization;
 using Planner.GitHub;
 using Planner.Issues.ChangingStatus;
 using ListedIssue = Planner.Issues.Listing.Issue;
@@ -52,7 +53,8 @@ public record PullRequestMerged(PullRequestNumber Number);
 /// (<see cref="ClassifyingForAutoMerge.AutoMergeClassification"/>) accepted it.
 /// </summary>
 /// <param name="commandPipeline">The <see cref="ICommandPipeline"/> for executing commands.</param>
-public class PostMergeBookkeeping(ICommandPipeline commandPipeline) : IReactor
+/// <param name="systemExecution">The <see cref="ISystemExecution"/> the commands below run as - there is no HTTP request behind this.</param>
+public class PostMergeBookkeeping(ICommandPipeline commandPipeline, ISystemExecution systemExecution) : IReactor
 {
     /// <summary>
     /// Clears the status of the issue whose pull request was just merged.
@@ -63,6 +65,10 @@ public class PostMergeBookkeeping(ICommandPipeline commandPipeline) : IReactor
     public async Task On(PullRequestMerged @event, EventContext context)
     {
         var issueId = new IssueId(context.EventSourceId.Value);
+
+        // A reactor has no HTTP request behind it - the bookkeeping runs as the system.
+        using var scope = systemExecution.AsSystem();
+
         await commandPipeline.Execute(new ChangeIssueStatus(issueId, IssueStatus.None));
     }
 }

--- a/Source/Planner/Issues/AcceptingPullRequest/for_PostMergeBookkeeping/when_pull_request_is_merged/and_it_was_merged.cs
+++ b/Source/Planner/Issues/AcceptingPullRequest/for_PostMergeBookkeeping/when_pull_request_is_merged/and_it_was_merged.cs
@@ -5,6 +5,7 @@
 using Cratis.Chronicle.Testing.Reactors;
 using Microsoft.Extensions.DependencyInjection;
 using Planner.Issues.ChangingStatus;
+using Planner.Identity;
 
 namespace Planner.Issues.AcceptingPullRequest.for_PostMergeBookkeeping.when_pull_request_is_merged;
 
@@ -18,7 +19,9 @@ public class and_it_was_merged : Specification
     void Establish()
     {
         _commandPipeline = Substitute.For<ICommandPipeline>();
-        _scenario = new(services => services.AddSingleton(_commandPipeline));
+        _scenario = new(services => services
+            .AddSingleton(_commandPipeline)
+            .AddSingleton(SystemExecutionScope.ForSpecs()));
     }
 
     async Task Because() =>

--- a/Source/Planner/Issues/ClassifyingForAutoMerge/ClassifyingForAutoMerge.cs
+++ b/Source/Planner/Issues/ClassifyingForAutoMerge/ClassifyingForAutoMerge.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Authorization;
 using Planner.Issues.AcceptingPullRequest;
 using Planner.Issues.AssociatingPullRequest;
 using Planner.LanguageModels;
@@ -19,7 +20,8 @@ namespace Planner.Issues.ClassifyingForAutoMerge;
 /// <param name="eventStore">The <see cref="IEventStore"/> for reading the issue and repository read models.</param>
 /// <param name="commandPipeline">The <see cref="ICommandPipeline"/> for executing commands.</param>
 /// <param name="languageModel">The <see cref="ILanguageModel"/> the classification is asked from.</param>
-public class AutoMergeClassification(IEventStore eventStore, ICommandPipeline commandPipeline, ILanguageModel languageModel) : IReactor
+/// <param name="systemExecution">The <see cref="ISystemExecution"/> the commands below run as - there is no HTTP request behind this.</param>
+public class AutoMergeClassification(IEventStore eventStore, ICommandPipeline commandPipeline, ILanguageModel languageModel, ISystemExecution systemExecution) : IReactor
 {
     /// <summary>
     /// Classifies a newly associated pull request and merges it when the repository allows auto-merge
@@ -56,6 +58,9 @@ public class AutoMergeClassification(IEventStore eventStore, ICommandPipeline co
         {
             return;
         }
+
+        // A reactor has no HTTP request behind it - accepting the pull request runs as the system.
+        using var scope = systemExecution.AsSystem();
 
         await commandPipeline.Execute(new AcceptPullRequest(issueId));
     }

--- a/Source/Planner/Issues/ClassifyingForAutoMerge/for_AutoMergeClassification/given/a_reactor.cs
+++ b/Source/Planner/Issues/ClassifyingForAutoMerge/for_AutoMergeClassification/given/a_reactor.cs
@@ -6,6 +6,8 @@ using Cratis.Chronicle.Testing.Reactors;
 using Microsoft.Extensions.DependencyInjection;
 using Planner.LanguageModels;
 using ListedRepository = Planner.Repositories.Listing.Repository;
+using Cratis.Arc.Authorization;
+using Planner.Identity;
 
 namespace Planner.Issues.ClassifyingForAutoMerge.for_AutoMergeClassification.given;
 
@@ -29,6 +31,7 @@ public class a_reactor : Specification
             .AddSingleton(_eventStore)
             .AddSingleton(_commandPipeline)
             .AddSingleton(_languageModel)
+            .AddSingleton(SystemExecutionScope.ForSpecs())
             .BuildServiceProvider());
     }
 

--- a/Source/Planner/Issues/Triaging/Triaging.cs
+++ b/Source/Planner/Issues/Triaging/Triaging.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Authorization;
 using Planner.GitHub;
 using Planner.Issues.Classifying;
 using Planner.Issues.Registration;
@@ -18,7 +19,8 @@ namespace Planner.Issues.Triaging;
 /// <param name="gitHub">The <see cref="IGitHubClient"/> for commenting and applying labels.</param>
 /// <param name="commandPipeline">The <see cref="ICommandPipeline"/> for executing commands.</param>
 /// <param name="languageModel">The <see cref="ILanguageModel"/> the classification is asked from.</param>
-public class IssueTriage(IGitHubClient gitHub, ICommandPipeline commandPipeline, ILanguageModel languageModel) : IReactor
+/// <param name="systemExecution">The <see cref="ISystemExecution"/> the commands below run as - there is no HTTP request behind this.</param>
+public class IssueTriage(IGitHubClient gitHub, ICommandPipeline commandPipeline, ILanguageModel languageModel, ISystemExecution systemExecution) : IReactor
 {
     /// <summary>
     /// Acknowledges and classifies a newly registered issue. Runs once per issue - an external,
@@ -56,6 +58,10 @@ public class IssueTriage(IGitHubClient gitHub, ICommandPipeline commandPipeline,
         }
 
         var issueId = new IssueId(context.EventSourceId.Value);
+
+        // A reactor has no HTTP request behind it - the triage classification runs as the system.
+        using var scope = systemExecution.AsSystem();
+
         await commandPipeline.Execute(new ClassifyIssue(
             issueId,
             classification.Kind,

--- a/Source/Planner/Issues/Triaging/for_IssueTriage/given/a_reactor.cs
+++ b/Source/Planner/Issues/Triaging/for_IssueTriage/given/a_reactor.cs
@@ -6,6 +6,7 @@ using Cratis.Chronicle.Testing.Reactors;
 using Microsoft.Extensions.DependencyInjection;
 using Planner.GitHub;
 using Planner.LanguageModels;
+using Planner.Identity;
 
 namespace Planner.Issues.Triaging.for_IssueTriage.given;
 
@@ -28,7 +29,8 @@ public class a_reactor : Specification
         _scenario = new(services => services
             .AddSingleton(_gitHub)
             .AddSingleton(_commandPipeline)
-            .AddSingleton(_languageModel));
+            .AddSingleton(_languageModel)
+            .AddSingleton(SystemExecutionScope.ForSpecs()));
     }
 }
 #endif

--- a/Source/Planner/Repositories/Discovery/Discovery.cs
+++ b/Source/Planner/Repositories/Discovery/Discovery.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Authorization;
 using Planner.GitHub;
 using Planner.Repositories.Adding;
 using Planner.Repositories.Organizations.Adding;
@@ -12,8 +13,13 @@ namespace Planner.Repositories.Discovery;
 /// </summary>
 /// <param name="gitHub">The <see cref="IGitHubClient"/> for talking to GitHub.</param>
 /// <param name="commandPipeline">The <see cref="ICommandPipeline"/> for executing commands.</param>
+/// <param name="systemExecution">The <see cref="ISystemExecution"/> the commands below run as - a reactor has no HTTP request behind it.</param>
 /// <param name="logger">The logger.</param>
-public class RepositoryDiscovery(IGitHubClient gitHub, ICommandPipeline commandPipeline, ILogger<RepositoryDiscovery> logger) : IReactor
+public class RepositoryDiscovery(
+    IGitHubClient gitHub,
+    ICommandPipeline commandPipeline,
+    ISystemExecution systemExecution,
+    ILogger<RepositoryDiscovery> logger) : IReactor
 {
     /// <summary>
     /// Discovers and adds all repositories of the added organization, recording the outcome either way.
@@ -37,6 +43,9 @@ public class RepositoryDiscovery(IGitHubClient gitHub, ICommandPipeline commandP
             // from - nothing is added until TrackDiscoveredRepositories says which ones.
             if (@event.TrackingPolicy == Organizations.OrganizationTrackingPolicy.All)
             {
+                // One scope for the whole discovery - adding every repository found for this
+                // organization is a single logical operation.
+                using var scope = systemExecution.AsSystem();
                 foreach (var repository in repositories)
                 {
                     await commandPipeline.Execute(new AddRepository(repository.Owner, repository.Name));

--- a/Source/Planner/Repositories/Discovery/for_RepositoryDiscovery/given/a_reactor.cs
+++ b/Source/Planner/Repositories/Discovery/for_RepositoryDiscovery/given/a_reactor.cs
@@ -4,6 +4,7 @@
 #if DEBUG
 using Cratis.Chronicle.Testing.Reactors;
 using Planner.GitHub;
+using Planner.Identity;
 
 namespace Planner.Repositories.Discovery.for_RepositoryDiscovery.given;
 
@@ -20,7 +21,8 @@ public class a_reactor : Specification
 
         _scenario = new(services => services
             .AddSingleton(_gitHub)
-            .AddSingleton(_commandPipeline));
+            .AddSingleton(_commandPipeline)
+            .AddSingleton(SystemExecutionScope.ForSpecs()));
     }
 }
 #endif

--- a/Source/Planner/Repositories/Discovery/for_RepositoryDiscovery/when_organization_is_added/and_it_executes_commands.cs
+++ b/Source/Planner/Repositories/Discovery/for_RepositoryDiscovery/when_organization_is_added/and_it_executes_commands.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using System.Security.Claims;
+using Cratis.Arc.Authorization;
+using Planner.GitHub;
+using Planner.Identity;
+using Planner.Repositories.Adding;
+using Planner.Repositories.Organizations;
+using Planner.Repositories.Organizations.Adding;
+
+namespace Planner.Repositories.Discovery.for_RepositoryDiscovery.when_organization_is_added;
+
+/// <summary>
+/// Proves the reactor's <c>AsSystem()</c> scope is actually entered around the commands it executes,
+/// by observing the ambient principal from inside the command pipeline itself.
+/// </summary>
+/// <remarks>
+/// This closes a real blind spot rather than adding coverage for its own sake. Every other reactor
+/// spec substitutes <see cref="ICommandPipeline"/>, which records the call and returns success without
+/// ever consulting authorization - so deleting a reactor's
+/// <c>using var scope = systemExecution.AsSystem()</c> leaves all of them green while the reactor is,
+/// in production, denied at runtime by <c>DenyByDefaultAuthorization</c>. Confirmed by experiment:
+/// removing the scope from <see cref="RepositoryDiscovery"/> failed nothing at all.
+/// <para>
+/// Rather than stand up the real command pipeline - ten constructor dependencies, and a spec that
+/// would mostly be testing its own wiring - this reads the principal Arc itself would read, at the
+/// moment the reactor executes its command. Without the scope there is no authenticated principal
+/// there, and the assertion fails.
+/// </para>
+/// </remarks>
+public class and_it_executes_commands : given.a_reactor
+{
+    ClaimsPrincipal? _principalDuringExecution;
+
+    void Establish()
+    {
+        var principalAccessor = new CurrentPrincipalAccessor(SystemExecutionScope.NoRequestContextAccessor());
+
+        _commandPipeline
+            .Execute(Arg.Any<AddRepository>())
+            .Returns(_ =>
+            {
+                _principalDuringExecution = principalAccessor.Current;
+                return new CommandResult();
+            });
+
+        _gitHub.GetOrganizationRepositories(new OrganizationName("Cratis"), Arg.Any<CancellationToken>())
+            .Returns([new GitHubRepository("Cratis", "Studio", true)]);
+    }
+
+    async Task Because() =>
+        await _scenario.Given.ForEventSource(OrganizationId.From("Cratis")).Events(new OrganizationAdded("Cratis", OrganizationTrackingPolicy.All));
+
+    [Fact]
+    void should_execute_the_command_as_an_authenticated_actor() =>
+        (_principalDuringExecution?.Identity?.IsAuthenticated == true).ShouldBeTrue();
+}
+#endif

--- a/Source/Planner/Roadmap/GeneratingPlan/PlanGeneration.cs
+++ b/Source/Planner/Roadmap/GeneratingPlan/PlanGeneration.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Authorization;
 using Planner.GitHub;
 using Planner.LanguageModels;
 using Planner.Roadmap.RequestingPlan;
@@ -17,7 +18,8 @@ namespace Planner.Roadmap.GeneratingPlan;
 /// <param name="commandPipeline">The <see cref="ICommandPipeline"/> for executing commands.</param>
 /// <param name="languageModel">The <see cref="ILanguageModel"/> the plan is generated with.</param>
 /// <param name="gitHub">The <see cref="IGitHubClient"/> for posting the plan back to GitHub.</param>
-public class PlanGeneration(IEventStore eventStore, ICommandPipeline commandPipeline, ILanguageModel languageModel, IGitHubClient gitHub) : IReactor
+/// <param name="systemExecution">The <see cref="ISystemExecution"/> the commands below run as - there is no HTTP request behind this.</param>
+public class PlanGeneration(IEventStore eventStore, ICommandPipeline commandPipeline, ILanguageModel languageModel, IGitHubClient gitHub, ISystemExecution systemExecution) : IReactor
 {
     /// <summary>
     /// Generates the plan for a newly requested set of issues.
@@ -42,6 +44,9 @@ public class PlanGeneration(IEventStore eventStore, ICommandPipeline commandPipe
 
         if (issues.Count == 0)
         {
+            // One scope for the whole generation - each branch below ends in a command, and a
+            // reactor has no HTTP request behind it.
+            using var failureScope = systemExecution.AsSystem();
             await commandPipeline.Execute(new FailPlanGeneration(planId, "None of the selected issues could be found"));
             return;
         }
@@ -49,10 +54,12 @@ public class PlanGeneration(IEventStore eventStore, ICommandPipeline commandPipe
         var result = await languageModel.Complete(PlanPrompts.Build(issues, @event.Instructions.Value));
         if (!result.Succeeded)
         {
+            using var resultFailureScope = systemExecution.AsSystem();
             await commandPipeline.Execute(new FailPlanGeneration(planId, result.FailureReason));
             return;
         }
 
+        using var scope = systemExecution.AsSystem();
         await commandPipeline.Execute(new GeneratePlan(planId, result.Text));
 
         foreach (var issue in issues)

--- a/Source/Planner/Roadmap/GeneratingPlan/for_PlanGeneration/given/a_reactor.cs
+++ b/Source/Planner/Roadmap/GeneratingPlan/for_PlanGeneration/given/a_reactor.cs
@@ -7,6 +7,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Planner.GitHub;
 using Planner.LanguageModels;
 using ListedIssue = Planner.Issues.Listing.Issue;
+using Cratis.Arc.Authorization;
+using Planner.Identity;
 
 namespace Planner.Roadmap.GeneratingPlan.for_PlanGeneration.given;
 
@@ -33,6 +35,7 @@ public class a_reactor : Specification
             .AddSingleton(_commandPipeline)
             .AddSingleton(_languageModel)
             .AddSingleton(_gitHub)
+            .AddSingleton(SystemExecutionScope.ForSpecs())
             .BuildServiceProvider());
     }
 

--- a/Source/Planner/WeeklyDigests/Analyzing/Analyzing.cs
+++ b/Source/Planner/WeeklyDigests/Analyzing/Analyzing.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Authorization;
 using Planner.LanguageModels;
 using Planner.WeeklyDigests.ExtractingThemes;
 using Planner.WeeklyDigests.GeneratingDescription;
@@ -18,7 +19,8 @@ namespace Planner.WeeklyDigests.Analyzing;
 /// </summary>
 /// <param name="commandPipeline">The <see cref="ICommandPipeline"/> for executing commands.</param>
 /// <param name="languageModel">The <see cref="ILanguageModel"/> the extraction is asked from.</param>
-public class WeeklyDigestAnalysis(ICommandPipeline commandPipeline, ILanguageModel languageModel) : IReactor
+/// <param name="systemExecution">The <see cref="ISystemExecution"/> the commands below run as - there is no HTTP request behind this.</param>
+public class WeeklyDigestAnalysis(ICommandPipeline commandPipeline, ILanguageModel languageModel, ISystemExecution systemExecution) : IReactor
 {
     /// <summary>
     /// Extracts themes and a description from a newly received weekly digest.
@@ -42,6 +44,11 @@ public class WeeklyDigestAnalysis(ICommandPipeline commandPipeline, ILanguageMod
         }
 
         var id = new WeeklyDigestId(Guid.Parse(context.EventSourceId.Value));
+
+        // One scope for both commands - extracting themes and generating the description are one
+        // logical analysis, and a reactor has no HTTP request behind it.
+        using var scope = systemExecution.AsSystem();
+
         await commandPipeline.Execute(new ExtractWeeklyDigestThemes(id, extraction.Themes));
         await commandPipeline.Execute(new GenerateWeeklyDigestDescription(id, extraction.Description));
     }

--- a/Source/Planner/WeeklyDigests/Analyzing/for_WeeklyDigestAnalysis/given/a_reactor.cs
+++ b/Source/Planner/WeeklyDigests/Analyzing/for_WeeklyDigestAnalysis/given/a_reactor.cs
@@ -5,6 +5,7 @@
 using Cratis.Chronicle.Testing.Reactors;
 using Microsoft.Extensions.DependencyInjection;
 using Planner.LanguageModels;
+using Planner.Identity;
 
 namespace Planner.WeeklyDigests.Analyzing.for_WeeklyDigestAnalysis.given;
 
@@ -24,7 +25,8 @@ public class a_reactor : Specification
 
         _scenario = new(services => services
             .AddSingleton(_commandPipeline)
-            .AddSingleton(_languageModel));
+            .AddSingleton(_languageModel)
+            .AddSingleton(SystemExecutionScope.ForSpecs()));
     }
 }
 #endif

--- a/Source/Planner/WeeklyDigests/Webhooks/WeeklyDigestWebhookEndpoints.cs
+++ b/Source/Planner/WeeklyDigests/Webhooks/WeeklyDigestWebhookEndpoints.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Options;
+using Planner.Identity;
 using Planner.WeeklyDigests.Receiving;
 
 namespace Planner.WeeklyDigests.Webhooks;
@@ -27,6 +28,11 @@ public static class WeeklyDigestWebhookEndpoints
             {
                 return Results.Unauthorized();
             }
+
+            // The bearer token above is the caller's real credential - establish the trusted principal
+            // Arc's authorization reads for the rest of this request immediately after it passes, and
+            // before the command below.
+            request.HttpContext.EstablishAsVerified();
 
             using var reader = new StreamReader(request.Body);
             var body = await reader.ReadToEndAsync();

--- a/Source/Planner/Work/AssigningAIIdentity/for_AIIdentityAssignment/given/a_reactor.cs
+++ b/Source/Planner/Work/AssigningAIIdentity/for_AIIdentityAssignment/given/a_reactor.cs
@@ -9,6 +9,8 @@ using Planner.GitHub;
 using Planner.GitHub.App;
 using Planner.Work.Listing;
 using ListedIssue = Planner.Issues.Listing.Issue;
+using Cratis.Arc.Authorization;
+using Planner.Identity;
 
 namespace Planner.Work.AssigningAIIdentity.for_AIIdentityAssignment.given;
 
@@ -32,6 +34,7 @@ public class a_reactor : Specification
             .AddSingleton(_eventStore)
             .AddSingleton(_gitHub)
             .AddSingleton<IOptions<GitHubAppOptions>>(Options.Create(_options))
+            .AddSingleton(SystemExecutionScope.ForSpecs())
             .BuildServiceProvider());
     }
 

--- a/Source/Planner/Work/AutoInvestigating/AutoInvestigating.cs
+++ b/Source/Planner/Work/AutoInvestigating/AutoInvestigating.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Authorization;
 using Microsoft.Extensions.Options;
 using Planner.Issues.Registration;
 using Planner.Work.Scheduling;
@@ -14,7 +15,8 @@ namespace Planner.Work.AutoInvestigating;
 /// </summary>
 /// <param name="commandPipeline">The <see cref="ICommandPipeline"/> for executing commands.</param>
 /// <param name="options">The scheduling options - carries the investigation model.</param>
-public class AutoInvestigation(ICommandPipeline commandPipeline, IOptions<SchedulingOptions> options) : IReactor
+/// <param name="systemExecution">The <see cref="ISystemExecution"/> the commands below run as - there is no HTTP request behind this.</param>
+public class AutoInvestigation(ICommandPipeline commandPipeline, IOptions<SchedulingOptions> options, ISystemExecution systemExecution) : IReactor
 {
     /// <summary>
     /// Schedules an investigation when the registered issue came from an external reporter.
@@ -29,6 +31,9 @@ public class AutoInvestigation(ICommandPipeline commandPipeline, IOptions<Schedu
         {
             return;
         }
+
+        // A reactor has no HTTP request behind it - scheduling the investigation runs as the system.
+        using var scope = systemExecution.AsSystem();
 
         await commandPipeline.Execute(new ScheduleWork(
             WorkPurpose.Investigation,

--- a/Source/Planner/Work/AutoInvestigating/for_AutoInvestigation/when_external_issue_is_registered.cs
+++ b/Source/Planner/Work/AutoInvestigating/for_AutoInvestigation/when_external_issue_is_registered.cs
@@ -7,6 +7,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Planner.Issues.Registration;
 using Planner.Work.Scheduling;
+using Cratis.Arc.Authorization;
+using Planner.Identity;
 
 namespace Planner.Work.AutoInvestigating.for_AutoInvestigation;
 
@@ -21,6 +23,7 @@ public class when_external_issue_is_registered : Specification
         _scenario = new(new ServiceCollection()
             .AddSingleton(_commandPipeline)
             .AddSingleton(Options.Create(new SchedulingOptions()))
+            .AddSingleton(SystemExecutionScope.ForSpecs())
             .BuildServiceProvider());
     }
 

--- a/Source/Planner/Work/AutoInvestigating/for_AutoInvestigation/when_member_issue_is_registered.cs
+++ b/Source/Planner/Work/AutoInvestigating/for_AutoInvestigation/when_member_issue_is_registered.cs
@@ -7,6 +7,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Planner.Issues.Registration;
 using Planner.Work.Scheduling;
+using Cratis.Arc.Authorization;
+using Planner.Identity;
 
 namespace Planner.Work.AutoInvestigating.for_AutoInvestigation;
 
@@ -21,6 +23,7 @@ public class when_member_issue_is_registered : Specification
         _scenario = new(new ServiceCollection()
             .AddSingleton(_commandPipeline)
             .AddSingleton(Options.Create(new SchedulingOptions()))
+            .AddSingleton(SystemExecutionScope.ForSpecs())
             .BuildServiceProvider());
     }
 

--- a/Source/Planner/Work/Callback/WorkerCallbackEndpoints.cs
+++ b/Source/Planner/Work/Callback/WorkerCallbackEndpoints.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Planner.Identity;
 using Planner.Work.Completing;
 using Planner.Work.CompletingInvestigation;
 using Planner.Work.Failing;
@@ -64,6 +65,11 @@ public static class WorkerCallbackEndpoints
             {
                 return Results.Unauthorized();
             }
+
+            // The per-work bearer token above is the container's real credential - establish the
+            // trusted principal Arc's authorization reads for the rest of this request immediately
+            // after it passes, and before any of the commands below.
+            request.HttpContext.EstablishAsVerified();
 
             var work = await eventStore.ReadModels.GetInstanceById<WorkItem>((EventSourceId)id);
             if (work is null)

--- a/Source/Planner/Work/PropagatingStatus/PropagatingStatus.cs
+++ b/Source/Planner/Work/PropagatingStatus/PropagatingStatus.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Authorization;
 using Planner.Issues;
 using Planner.Issues.AssociatingPullRequest;
 using Planner.Issues.ChangingStatus;
@@ -21,7 +22,8 @@ namespace Planner.Work.PropagatingStatus;
 /// </summary>
 /// <param name="eventStore">The <see cref="IEventStore"/> for reading the work's read model.</param>
 /// <param name="commandPipeline">The <see cref="ICommandPipeline"/> for executing commands.</param>
-public class WorkStatusPropagation(IEventStore eventStore, ICommandPipeline commandPipeline) : IReactor
+/// <param name="systemExecution">The <see cref="ISystemExecution"/> the commands below run as - a reactor has no HTTP request behind it.</param>
+public class WorkStatusPropagation(IEventStore eventStore, ICommandPipeline commandPipeline, ISystemExecution systemExecution) : IReactor
 {
     /// <summary>
     /// Puts every covered issue in progress when work starts.
@@ -31,6 +33,7 @@ public class WorkStatusPropagation(IEventStore eventStore, ICommandPipeline comm
     /// <returns>Awaitable task.</returns>
     public async Task On(WorkStarted @event, EventContext context)
     {
+        using var scope = systemExecution.AsSystem();
         foreach (var issue in await CoveredIssues(context))
         {
             await commandPipeline.Execute(new ChangeIssueStatus(issue, IssueStatus.InProgress));
@@ -47,6 +50,7 @@ public class WorkStatusPropagation(IEventStore eventStore, ICommandPipeline comm
     public async Task On(WorkCompleted @event, EventContext context)
     {
         var hasPullRequest = @event.PullRequest != PullRequestNumber.NotSet;
+        using var scope = systemExecution.AsSystem();
         foreach (var issue in await CoveredIssues(context))
         {
             if (hasPullRequest)
@@ -71,6 +75,7 @@ public class WorkStatusPropagation(IEventStore eventStore, ICommandPipeline comm
     /// <returns>Awaitable task.</returns>
     public async Task On(WorkFailed @event, EventContext context)
     {
+        using var scope = systemExecution.AsSystem();
         foreach (var issue in await CoveredIssues(context))
         {
             await commandPipeline.Execute(new ChangeIssueStatus(issue, IssueStatus.None));
@@ -85,6 +90,7 @@ public class WorkStatusPropagation(IEventStore eventStore, ICommandPipeline comm
     /// <returns>Awaitable task.</returns>
     public async Task On(WorkStopped @event, EventContext context)
     {
+        using var scope = systemExecution.AsSystem();
         foreach (var issue in await CoveredIssues(context))
         {
             await commandPipeline.Execute(new ChangeIssueStatus(issue, IssueStatus.None));
@@ -104,6 +110,7 @@ public class WorkStatusPropagation(IEventStore eventStore, ICommandPipeline comm
     /// <returns>Awaitable task.</returns>
     public async Task On(InvestigationCompleted @event, EventContext context)
     {
+        using var scope = systemExecution.AsSystem();
         foreach (var issue in await CoveredIssues(context))
         {
             await commandPipeline.Execute(new ChangeIssueStatus(issue, IssueStatus.None));

--- a/Source/Planner/Work/PropagatingStatus/for_WorkStatusPropagation/given/a_work_item.cs
+++ b/Source/Planner/Work/PropagatingStatus/for_WorkStatusPropagation/given/a_work_item.cs
@@ -5,6 +5,8 @@
 using Cratis.Chronicle.Testing.Reactors;
 using Microsoft.Extensions.DependencyInjection;
 using Planner.Work.Listing;
+using Cratis.Arc.Authorization;
+using Planner.Identity;
 
 namespace Planner.Work.PropagatingStatus.for_WorkStatusPropagation.given;
 
@@ -23,6 +25,7 @@ public class a_work_item : Specification
         _scenario = new(new ServiceCollection()
             .AddSingleton(_eventStore)
             .AddSingleton(_commandPipeline)
+            .AddSingleton(SystemExecutionScope.ForSpecs())
             .BuildServiceProvider());
     }
 

--- a/Source/Planner/Work/PropagatingStatus/for_WorkStatusPropagation/when_work_starts/and_the_work_is_an_alert_investigation.cs
+++ b/Source/Planner/Work/PropagatingStatus/for_WorkStatusPropagation/when_work_starts/and_the_work_is_an_alert_investigation.cs
@@ -6,6 +6,7 @@ using Planner.Accounts;
 using Planner.Issues.ChangingStatus;
 using Planner.Work.Listing;
 using Planner.Work.Starting;
+using Cratis.Arc.Authorization;
 
 namespace Planner.Work.PropagatingStatus.for_WorkStatusPropagation.when_work_starts;
 
@@ -31,7 +32,7 @@ public class and_the_work_is_an_alert_investigation : given.a_work_item
             null!,
             ModelName.NotSet,
             UserName.NotSet));
-        _reactor = new(_eventStore, _commandPipeline);
+        _reactor = new(_eventStore, _commandPipeline, Substitute.For<ISystemExecution>());
     }
 
     async Task Because() => _error = await Cratis.Specifications.Catch.Exception(() =>

--- a/Source/Planner/Work/ReportingInvestigation/ReportingInvestigation.cs
+++ b/Source/Planner/Work/ReportingInvestigation/ReportingInvestigation.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Authorization;
 using Planner.GitHub;
 using Planner.Issues.RecordingInvestigation;
 using Planner.Work.CompletingInvestigation;
@@ -16,7 +17,8 @@ namespace Planner.Work.ReportingInvestigation;
 /// <param name="eventStore">The <see cref="IEventStore"/> for reading the covered issues' read models by key.</param>
 /// <param name="commandPipeline">The <see cref="ICommandPipeline"/> for executing commands.</param>
 /// <param name="gitHub">The <see cref="IGitHubClient"/> for commenting on the GitHub issues.</param>
-public class InvestigationReporting(IEventStore eventStore, ICommandPipeline commandPipeline, IGitHubClient gitHub) : IReactor
+/// <param name="systemExecution">The <see cref="ISystemExecution"/> the commands below run as - there is no HTTP request behind this.</param>
+public class InvestigationReporting(IEventStore eventStore, ICommandPipeline commandPipeline, IGitHubClient gitHub, ISystemExecution systemExecution) : IReactor
 {
     /// <summary>
     /// Records the findings on the covered issues and comments on the original GitHub issues.
@@ -32,6 +34,11 @@ public class InvestigationReporting(IEventStore eventStore, ICommandPipeline com
         // propagation can find nothing to propagate - neither is worth throwing over, because a
         // throw pauses the partition and can quarantine the observer.
         var work = await eventStore.ReadModels.GetInstanceById<WorkItem>(context.EventSourceId);
+
+        // One scope for the whole reporting pass - recording the findings on every covered issue is
+        // a single logical operation.
+        using var scope = systemExecution.AsSystem();
+
         foreach (var issueId in work?.Issues ?? [])
         {
             await commandPipeline.Execute(new RecordInvestigation(issueId, @event.Findings, @event.SuggestedModel));

--- a/Source/Planner/Work/Scheduling/WorkDispatcher.cs
+++ b/Source/Planner/Work/Scheduling/WorkDispatcher.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Linq.Expressions;
+using Cratis.Arc.Authorization;
 using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using Planner.Accounts;
@@ -30,6 +31,7 @@ namespace Planner.Work.Scheduling;
 /// <param name="workerEnvironment">Builds the environment a worker container runs with.</param>
 /// <param name="callbackTokens">Issues the bearer token a launched worker's callbacks authenticate with.</param>
 /// <param name="commandPipeline">The <see cref="ICommandPipeline"/> for executing commands.</param>
+/// <param name="systemExecution">The <see cref="ISystemExecution"/> the commands below run as - the dispatcher runs on a timer, with no HTTP request behind it.</param>
 /// <param name="timeProvider">The <see cref="TimeProvider"/> for usage-window calculations.</param>
 /// <param name="workerOptions">The worker configuration.</param>
 /// <param name="schedulingOptions">The scheduling boundaries.</param>
@@ -44,6 +46,7 @@ public class WorkDispatcher(
     IWorkerEnvironment workerEnvironment,
     IWorkerCallbackTokens callbackTokens,
     ICommandPipeline commandPipeline,
+    ISystemExecution systemExecution,
     TimeProvider timeProvider,
     IOptions<WorkerOptions> workerOptions,
     IOptions<SchedulingOptions> schedulingOptions,
@@ -56,6 +59,12 @@ public class WorkDispatcher(
     /// <inheritdoc/>
     public async Task RunSchedulingPass(CancellationToken cancellationToken = default)
     {
+        // One scope for the whole pass. Everything below - sweeping dead work, scheduling ready
+        // issues, dispatching pending work - is the scheduler acting on its own, on a timer, with no
+        // operator and no HTTP request behind it. Opening it here rather than in each private method
+        // keeps the commands executed from inside Dispatch's catch block covered too.
+        using var scope = systemExecution.AsSystem();
+
         var openWork = await Find(workItems, work => work.Status == WorkStatus.Scheduled || work.Status == WorkStatus.Running, cancellationToken);
         await SweepStuckWork(openWork, cancellationToken);
         await ScheduleReadyIssues(openWork, cancellationToken);

--- a/Source/Planner/Work/Scheduling/for_WorkDispatcher/given/all_dependencies.cs
+++ b/Source/Planner/Work/Scheduling/for_WorkDispatcher/given/all_dependencies.cs
@@ -17,6 +17,7 @@ using Planner.Work.Listing;
 using Planner.Work.Workers;
 using ListedIssue = Planner.Issues.Listing.Issue;
 using Repository = Planner.Repositories.Listing.Repository;
+using Cratis.Arc.Authorization;
 
 namespace Planner.Work.Scheduling.for_WorkDispatcher.given;
 
@@ -88,6 +89,7 @@ public class all_dependencies : Specification
             _workerEnvironment,
             _callbackTokens,
             _commandPipeline,
+            Substitute.For<ISystemExecution>(),
             _timeProvider,
             Options.Create(_workerOptions),
             Options.Create(_schedulingOptions),


### PR DESCRIPTION
# Summary

The evaluator landed in #119 but **nothing used it**: every reactor, background pass and webhook
still executed commands with no principal behind them. Under deny-by-default those are refused at
runtime, so **this is the half that makes the previous PR safe rather than merely present.**

**Twenty production paths** now establish who they run as:

- Reactors and timer-driven passes enter `ISystemExecution.AsSystem()`.
- The **four** webhook/callback boundaries that verify their own caller — GitHub HMAC, alert HMAC,
  per-work bearer token, weekly-digest token — call `EstablishAsVerified()` immediately after that
  check and before any command, because **`AsSystem()` is a documented no-op while an HTTP request
  is in progress** and would silently do nothing there.

## Nine of these did not exist when the original work was written

`Builds/Analyzing`, `Builds/CheckingStatus`, `WeeklyDigests/Analyzing`, `Roadmap/GeneratingPlan`,
`Issues/Triaging`, `Issues/ClassifyingForAutoMerge`, `Alerts/EscalationReporting`,
`Issues/AcceptingPullRequest`, and `WeeklyDigests/Webhooks` — a **fourth credential-verifying
boundary** that needed its own `EstablishAsVerified()`.

They were found by **auditing every file that reaches `ICommandPipeline`**, not by replaying the
original commit — which would have left them anonymous while the change looked complete.

## `GitHubAppEndpoints` is deliberately left alone

Its existing comment explains why: `installation_id` is a bare, guessable query parameter, not a
signed delivery, so it has **no credential to carry into Arc**. Establishing a verified caller there
would recreate the hole under the new mechanism's name. Deny-by-default now makes it **fail closed**
instead, which is correct — finishing App setup is an operator action through the authenticating
proxy.

## The blind spot, confirmed by experiment

Removing the `AsSystem()` scope from `RepositoryDiscovery` and running its four existing specs:
**all four still pass.** They substitute `ICommandPipeline`, which records the call and returns
success without ever consulting authorization — so they cannot tell a scoped reactor from an
unscoped one, while in production the unscoped one is **denied**.

That is the blind spot the plan warned about, **confirmed rather than assumed**.

`for_RepositoryDiscovery/.../and_it_executes_commands` closes it by reading the ambient principal
from inside the pipeline at the moment the command executes — the same principal Arc's own
authorization reads. (Standing up the real command pipeline was considered and rejected: ten
constructor dependencies, and a spec that would mostly test its own wiring.)

**Proven in both directions:** it passes with the scope, **fails without it**, and the four mocked
specs stay green either way — which is exactly the point.

Reactor specs also needed a **real** `ISystemExecution` rather than a substitute, hence
`SystemExecutionScope.ForSpecs()`. A substitute returns `null` from `AsSystem()`, making every scope
a no-op and the spec pass regardless.

## Verification

Run on the **staged tree reconstructed with `git archive`**, so the DEBUG-only generated proxy is
absent exactly as in CI:

| Gate | Result |
| --- | --- |
| CI Release command | **0 warnings, 0 errors** |
| CI Debug command | 0 errors |
| Specs | **470** (469 + the new one), zero failures |
| Factory.Core | 195 |

**Audited afterwards:** no production file reaching `ICommandPipeline` is left without a scope,
except `GitHubAppEndpoints` by design.

## Not verified

No authorization behavior was exercised against a running Planner over HTTP — proven by spec and by
the real Arc pipeline, not against a live server.
