### PR TITLE
Say which repositories the corpus did not reach

### DIFF
--- a/.github/workflows/propagate-copilot-instructions.yml
+++ b/.github/workflows/propagate-copilot-instructions.yml
@@ -14,9 +14,85 @@ on:
       - ".github/hooks/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   propagate:
     uses: Cratis/Workflows/.github/workflows/propagate-copilot-instructions.yml@main
     with:
       event_name: ${{ github.event_name }}
     secrets: inherit
+
+  # The fan-out is a matrix with fail-fast disabled, so one target failing leaves
+  # the other 33 to finish - which is right, but it means a partial failure is
+  # only visible to someone who opens the run and reads 34 job results. Run
+  # 32255505376 propagated to 29 repositories and failed on 7, and the corpus in
+  # those 7 went stale without anyone being told.
+  #
+  # This job says which repositories are behind, by name, in the run summary and
+  # in the log. It reads the conclusions of this same run's matrix jobs through
+  # the Actions API - the caller cannot see them any other way, since a reusable
+  # workflow reports one aggregate result to its caller.
+  report-fan-out:
+    needs: propagate
+    if: ${{ always() && github.repository_owner == 'Cratis' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - name: Report which repositories received the corpus
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # `propagate (<repo>)` is the matrix job name; the reusable workflow
+          # prefixes it, so match on the suffix rather than anchoring the whole
+          # string. Paginated because a 34-way matrix plus its parents exceeds
+          # the default page size.
+          jobs_json=$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs?per_page=100" \
+            --jq '[.jobs[] | select(.name | test("propagate \\(")) | {
+                    repo: (.name | capture("propagate \\((?<r>[^)]+)\\)").r),
+                    conclusion: .conclusion
+                  }]' | jq -sc 'add // []')
+
+          total=$(echo "$jobs_json" | jq 'length')
+          if [ "$total" -eq 0 ]; then
+            # No matrix jobs at all: the fan-out was skipped because nothing
+            # needed propagating. That is a normal outcome, not a failure.
+            echo "No propagation targets ran - nothing to report."
+            echo "No propagation targets ran for this change." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          succeeded=$(echo "$jobs_json" | jq '[.[] | select(.conclusion == "success")] | length')
+          behind=$(echo "$jobs_json" | jq -r '[.[] | select(.conclusion != "success") | .repo] | sort | .[]')
+
+          {
+            echo "## Corpus propagation"
+            echo
+            echo "${succeeded} of ${total} repositories received the corpus."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -z "$behind" ]; then
+            echo "All ${total} repositories received the corpus."
+            exit 0
+          fi
+
+          {
+            echo
+            echo "### These repositories are now behind"
+            echo
+            while IFS= read -r repo; do
+              [ -n "$repo" ] && echo "- ${repo}"
+            done <<< "$behind"
+            echo
+            echo "They kept the corpus they already had. Their agents are working from"
+            echo "older rules until this is resolved and propagation runs again."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "::error::Propagation reached ${succeeded} of ${total} repositories. Behind: $(echo "$behind" | tr '\n' ' ')"
+          exit 1


### PR DESCRIPTION
Closes the other half of #98. Implements **D7(c)**.

# Summary

The fan-out is a matrix with `fail-fast: false` — which is right, one bad target should not stop
the other 33 — but it means **a partial failure is only visible to someone who opens the run and
reads 35 job results.** Run [32255505376](https://github.com/Cratis/AI/actions/runs/32255505376)
propagated to 29 repositories and failed on 7, and the corpus in those 7 went stale with nothing
saying so.

The caller cannot see the matrix directly (a reusable workflow reports one aggregate result), so
this reads its own run's job conclusions through the Actions API, **names the repositories that
are behind** in the run summary and as an error line, and fails the run.

## Verified against three real runs

| Run | Outcome | Result |
| --- | --- | --- |
| `32255505376` | 28 of 35 | exit 1 — names exactly the 7 from #98 |
| `32303740183` | 16 of 35 | exit 1 — names all 19 |
| `32195981283` | no matrix | exit 0 — "nothing to report" |

**The no-matrix case matters.** When nothing needs propagating, the reusable workflow runs
`get-repos` and a skipped `propagate` with no per-repository jobs — treating that as "zero of zero
reached" would fail every unrelated push.

Rendered summary for the failing run:

```
## Corpus propagation

28 of 35 repositories received the corpus.

### These repositories are now behind

- Ante
- Chronicle.Elixir
- Chronicle.Kotlin
- Chronicle.TypeScript
- Fundamentals
- cli
- cratis.no

They kept the corpus they already had. Their agents are working from
older rules until this is resolved and propagation runs again.
```

## It immediately found a fourth cause, which #121 does not fix

Running it against the newest run turned up something nobody would otherwise have noticed:
**propagation has failed on every run since 12:58 today, and the newest failures are not
`BadObjectState` at all.** 19 of 35 targets failed at 21:24 with:

```
##[error]Could not create blob for .ai/agents/backend-developer.md in Lens
  API error: GitHub API rate limit hit; waiting 15 seconds before retry (attempt 1/8)
```

The script creates **one blob per file per target — roughly 255 × 35 API calls per run** — and
exhausts the limit partway through. That is a fourth distinct cause on top of the three in #121,
it affects far more repositories, and **it is exactly the class of thing this job exists to
surface.**

**Not fixed here.** The remedy is fewer API calls — reusing content-addressed blob SHAs that
already exist in the target, since a git blob SHA is identical in every repository — and that is a
change to the script in `Cratis/Workflows`, not to this caller.

## Also

`permissions: actions: read` is scoped to the job rather than the workflow, and the workflow now
states `contents: read` explicitly instead of inheriting the default.

`actionlint` clean at the CI pin, including its shellcheck pass.

## Not verified

This has not run as part of a real propagation — it is proven by executing the exact step script
against three real runs' API data. The next push to `.ai/**` exercises it for real.
