### PR TITLE
Test the Factory in CI, on push as well as on pull requests

### DIFF
--- a/.github/workflows/planner-build.yml
+++ b/.github/workflows/planner-build.yml
@@ -19,6 +19,20 @@ on:
       - "Directory.Packages.props"
       - "package.json"
       - "yarn.lock"
+  # Also on push to main, because not everything that reaches main arrives through a
+  # pull request. The scheduled package update pushes `Directory.Packages.props` directly,
+  # and on 2026-08-20 that shipped a JsonSchema.Net major bump that broke Factory.Core with
+  # nothing to notice: no build workflow runs on push, so the only thing that fired was
+  # Planner Publish, which has no test step and pushed an image from the broken tree.
+  push:
+    branches:
+      - main
+    paths:
+      - "Source/**"
+      - "Directory.Build.props"
+      - "Directory.Packages.props"
+      - "package.json"
+      - "yarn.lock"
 
 permissions:
   contents: read
@@ -45,6 +59,27 @@ jobs:
 
       - name: Run specs
         run: dotnet test Source/Planner/Planner.csproj --configuration Debug --no-build
+
+  factory:
+    name: Factory
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      # Factory.Core was landed by #107 with 195 specs and has never run in CI - the backend
+      # job tests Planner.csproj only. The JsonSchema.Net 8 -> 9 bump in 893e0a9 broke one of
+      # them and nothing said so. These specs are worth watching precisely because they are
+      # cross-language parity vectors: when they fail, the .NET port and the Python oracle
+      # disagree about schema validation, which is the thing Factory.Core exists to guarantee.
+      - name: Run Factory.Core specs
+        run: dotnet test Source/Factory.Core.Specs/Factory.Core.Specs.csproj --configuration Debug
 
   frontend:
     name: Frontend
@@ -88,7 +123,7 @@ jobs:
   artifacts:
     name: Publish build artifacts
     runs-on: ubuntu-latest
-    needs: [backend, frontend]
+    needs: [backend, factory, frontend]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/planner-publish.yml
+++ b/.github/workflows/planner-publish.yml
@@ -26,9 +26,36 @@ permissions:
   contents: read
 
 jobs:
+  # An image should not ship from a tree nobody tested. This workflow ran on 2026-08-20 for
+  # the scheduled package update's direct push to main, succeeded, and published an image
+  # from a commit whose Factory.Core specs were broken by a JsonSchema.Net major bump - there
+  # was no test step here and no build workflow runs on push, so nothing objected.
+  verify:
+    name: Verify before publishing
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Build (Debug - specs compile)
+        run: dotnet build Source/Planner/Planner.csproj --configuration Debug -p:DisableProxyGenerator=true
+
+      - name: Run Planner specs
+        run: dotnet test Source/Planner/Planner.csproj --configuration Debug --no-build
+
+      - name: Run Factory.Core specs
+        run: dotnet test Source/Factory.Core.Specs/Factory.Core.Specs.csproj --configuration Debug
+
   publish-planner:
     name: Publish Planner image
     runs-on: ubuntu-latest
+    needs: verify
 
     steps:
       - name: Checkout code

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,7 +50,17 @@
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.22.0" />
     <!-- JSON Schema -->
-    <PackageVersion Include="JsonSchema.Net" Version="9.4.0" />
+    <!--
+      Pinned to 8.x deliberately. The 2026-08-20 scheduled update took this to 9.4.0 and broke
+      Cratis.Factory.Core's language-neutral validation vectors (195 specs -> 194 passed, 1 failed):
+      `validate-additional-properties-privacy` and `validate-anchor-invalid` stopped matching the
+      Python oracle's material results. Those are cross-language parity vectors, so a mismatch means
+      the .NET port and the oracle disagree about schema validation - the one thing Factory.Core
+      exists to guarantee. Isolated in both directions: 9.4.0 fails, 8.0.5 passes 195, and the Python
+      suite is unaffected at 330 either way. Moving to 9.x needs the vector differences understood
+      and the port reconciled first - tracked in issue 124.
+    -->
+    <PackageVersion Include="JsonSchema.Net" Version="8.0.5" />
     <!-- OpenTelemetry -->
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />


### PR DESCRIPTION
# Summary

The scheduled package update pushed `893e0a9` **straight to `main`** this morning, taking
`JsonSchema.Net` from **8.0.5 to 9.4.0** — a major version — and broke `Cratis.Factory.Core`.
**Nothing said so.** Three gaps had to line up, and each is worth closing on its own.

| Gap | Consequence |
| --- | --- |
| `Factory.Core`'s 195 specs **never ran in CI** | The project Cratis/AI#107 added has been unwatched since it landed |
| The build workflow ran **only on `pull_request`** | A direct push to `main` triggered no build and no tests at all |
| `Planner Publish` had **no test step** | It ran for `893e0a9`, succeeded, and **pushed a Docker image built from the broken tree** |

## What this changes

- **`Factory` job** in `planner-build.yml`, running the 195 `Factory.Core.Specs`. The artifact job
  now waits on it.
- **`push` to `main`** added as a trigger, on the same paths as the PR trigger.
- **`verify` job** in `planner-publish.yml` — Planner specs *and* Factory.Core specs must pass
  before an image is published.

## The pin, and what it does not do

`JsonSchema.Net` is pinned back to **8.0.5**, with the reasoning in the file. **This is a stopgap
and is labelled as one.**

The failing vectors are `validate-additional-properties-privacy` and `validate-anchor-invalid`, and
they are **cross-language parity vectors** — when they fail, the .NET port and the Python oracle
disagree about schema validation, which is the one thing `Factory.Core` exists to guarantee.

Isolated in both directions by changing only that line:

| JsonSchema.Net | Factory.Core | Python oracle |
| --- | --- | --- |
| 9.4.0 | **194 passed, 1 failed** | 330 OK |
| 8.0.5 | **195 passed** | 330 OK |

The oracle is unaffected either way, so the divergence is **entirely on the .NET side** — consistent
with a behavioral change in 9.x rather than anything wrong with the vectors. Moving to 9.x needs the
differences understood and **both implementations moved together**; **#124** tracks that.

**Being plain about the limit: the pin will not hold by itself.** The updater runs
`dotnet package update` with no exclusion mechanism, so tomorrow's 06:00 run will bump it again.
What changes is that **CI will catch it** instead of an image shipping quietly.

## Verification

`actionlint` clean on both workflows · **Factory.Core 195 passed** with the pin · **Planner 470
passed** · Python oracle **330 OK**.

## Not verified

The new `push`-triggered run and the `verify` gate have not executed yet — merging this is what
exercises them for the first time.
