### PR TITLE
Use Ensemble terminology in investigation agents

### DIFF
--- a/.ai/agents/repository-investigation-reviewer.md
+++ b/.ai/agents/repository-investigation-reviewer.md
@@ -19,7 +19,7 @@ You independently review a completed Cratis repository investigation. Your resul
 
 - Treat the supplied objective, immutable repository snapshot, resolved profile, investigation envelope, and deterministic gate reports as the complete authority for this review.
 - Consume only the classified and sanitized artifacts declared as workflow inputs. Do not discover or read `.agents/PROJECT.md`, credentials, repository-global notes, or undeclared files.
-- Do not modify files, branches, issues, pull requests, package state, runtime state, or Factory definitions. Your granted tools are inspection-only (`Read`, `Glob`, `Grep`) — you have no file-write and no command-execution capability, and this is deliberate. Review the supplied evidence; never try to reproduce, build, or re-run anything yourself.
+- Do not modify files, branches, issues, pull requests, package state, runtime state, or Ensemble definitions. Your granted tools are inspection-only (`Read`, `Glob`, `Grep`) — you have no file-write and no command-execution capability, and this is deliberate. Review the supplied evidence; never try to reproduce, build, or re-run anything yourself.
 - Do not accept a claim merely because the investigating agent made it. Trace every material conclusion to supplied evidence and report unsupported claims.
 - Never approve your own elevated capability or reinterpret a failed or blocked deterministic gate as passing.
 

--- a/.ai/agents/repository-investigator.md
+++ b/.ai/agents/repository-investigator.md
@@ -14,7 +14,7 @@ tools:
 
 # Repository Investigator
 
-You are the read-only investigation agent for the Cratis Software Factory. Your output is consumed by both humans and deterministic software, so every material claim must point to inspectable evidence and fit the supplied output schema.
+You are the read-only investigation agent for Cratis Ensemble. Your output is consumed by both humans and deterministic software, so every material claim must point to inspectable evidence and fit the supplied output schema.
 
 ## Authority and repository mode
 


### PR DESCRIPTION
## Summary

- replace the obsolete product name in the two investigation agent definitions
- keep the AI-owned source vocabulary aligned with the Ensemble product identity

This allows Ensemble to consume an exact, content-addressed snapshot of these agent bytes without reintroducing obsolete product terminology.