### PR TITLE
Extend catalog v2 capability contracts

### DIFF
--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
@@ -328,3 +328,87 @@ immediate delivery order is:
 4. implement and evaluate clean-room navigator, diagnostics, review, and
    event-modeling pilots;
 5. continue through the remaining autonomous plan phases.
+
+## 16. Capability-model checkpoint — 2026-08-21
+
+### Merged foundation
+
+Pull request [`Cratis/AI#130`](https://github.com/Cratis/AI/pull/130) merged with
+merge commit `569d478efb3ad64b77ed65c4e60dfab39f97695d`. Its CI passed and the
+`no-release` label correctly produced no package or product release. AI#126 and
+Workflows#68 remain open with comments that record what landed and what remains.
+The foundation branch and worktree were removed through normal merged-branch
+cleanup; the protected dirty main worktree remains untouched.
+
+### Active isolated branch
+
+Work now continues in `../AI-capability-model` on
+`feat/catalog-v2-capability-model`, based on the merged foundation. The active
+scope is a safety-local hybrid inside catalog v2:
+
+- authored closed taxonomy;
+- authored product/client source contracts that start unverified;
+- explicit non-publishable review bundles;
+- upstream companion metadata with `bytesIncluded: false`;
+- target-local capability kind, invocation, lifecycle, applicability, trust,
+  effects, dependency classification, and source-contract fields;
+- semantic validators and regression specifications;
+- capability-model documentation.
+
+The migration deliberately uses `unclassified` for decisions that do not yet
+have reviewed evidence. It does not infer architecture, persona, surface,
+invocation, dependency strength, effects, or product authority from legacy
+names. All 43 targets remain candidates and runtime-ineligible.
+
+### Current uncommitted delivery state
+
+New authored files:
+
+- `catalog/v2/taxonomy.json`;
+- `catalog/v2/source-contracts.json`;
+- `catalog/v2/bundles.json`;
+- `catalog/v2/upstream-companions.json`;
+- `Documentation/capability-catalog-v2.md`.
+
+Modified source files include the v2 schema, generator, semantic validator,
+repository-inventory generator, validation entry point, and catalog specs.
+`tooling/catalog-ordering.mjs` and its specification now provide one
+locale-independent ordering contract.
+
+Two Fusion panels were reviewed. Their safety-local normalization, explicit
+unassessed states, deterministic generation, and bounded audit principles were
+accepted. Their proposed parallel Python toolchain, monolithic replacement
+catalog, category-prefixed IDs, v3 cutover, and bundling of the authoring/human
+catalog work into this pull request were rejected because they conflict with
+the merged Node foundation, existing v2 IDs, and the accepted reversible PR
+sequence.
+
+Independent correctness review found authorization, non-target dependency,
+migration-equivalence, source-authority proof/coverage, and optional-bundle
+reachability gaps. Independent performance review found serial Git subprocess,
+recursive cycle, quadratic membership, and locale-ordering risks. The active
+branch now addresses all of them with authorization evidence, typed target/tool/
+internal/project-context edges, inverse migration checks, product/subject source
+coverage, reachable optional selection, revision snapshot batching, iterative
+cycle detection, set membership, and ordinal ordering.
+
+Current fresh signals:
+
+- catalog validation: 3 legacy plus 11 v2 catalogs and 4 schemas passed;
+- Node specifications: 56/56 passed in about 0.34 seconds after provenance
+  batching, down from multi-second repeated subprocess validation;
+- 43 targets remain candidates; zero are approved or runtime-included;
+- 6 bundles remain draft and non-publishable;
+- all source contracts remain unverified and distribution-disabled;
+- both upstream companions retain `bytesIncluded: false`;
+- Markdown lint, primary LSP, and documentation link validation passed before
+  the latest review fixes and will be rerun at the delivery gate.
+
+Exact next actions:
+
+1. run focused security and correctness rereview over the closed review gaps;
+2. regenerate the self-excluding repository inventory and run the complete
+   validator/spec/LSP/lint/link/diff/protected-hash suite;
+3. commit and push the coherent capability-model unit, open a separate
+   `no-release` pull request, monitor CI, merge, and record the result;
+4. start the separate skill-authoring and generated human-catalog contract PR.

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
@@ -468,9 +468,12 @@ The program is complete only when:
   semantic tamper check.
 - [x] Recorded the accepted architecture while retaining the unapproved-target
   materialization block.
-- [ ] Land the autonomous authority, research, and foundation delivery unit.
-- [ ] Implement the normalized Phase 1 catalog/schema extensions.
-- [ ] Implement the skill-authoring and human-catalog contracts.
+- [x] Land the autonomous authority, research, and foundation delivery unit in
+  [`Cratis/AI#130`](https://github.com/Cratis/AI/pull/130).
+- [ ] Implement the normalized Phase 1 catalog/schema extensions — active on
+  `feat/catalog-v2-capability-model`.
+- [ ] Implement the skill-authoring and human-catalog contracts in the next
+  independent delivery unit.
 
 Evidence and exact next actions are in
-[`AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md`](./AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md#15-autonomous-execution-update--2026-08-20).
+[`AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md`](./AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md#16-capability-model-checkpoint--2026-08-21).

--- a/Documentation/capability-catalog-v2.md
+++ b/Documentation/capability-catalog-v2.md
@@ -1,0 +1,116 @@
+# Capability catalog v2 model
+
+**Status:** Authoring and review contract; no runtime approval
+
+## Purpose
+
+Catalog v2 separates shared ecosystem vocabulary from target-local behavior and
+safety decisions. Shared facts are normalized once. A resolved target still
+contains every fact needed to review its invocation, applicability, trust,
+effects, dependencies, source authority, evidence, and approval.
+
+This is a safety-local hybrid: normalization must not make a reviewer traverse a
+large graph to discover whether a capability can write, publish, use a
+credential, or run code.
+
+## Authored registries
+
+The following files are manually reviewed source:
+
+- `catalog/v2/taxonomy.json` — closed identifiers for products, languages,
+  architectures, personas, surfaces, repository profiles, trust, effects, and
+  dependency behavior;
+- `catalog/v2/source-contracts.json` — product repositories that may become
+  authoritative for exact subjects after revision and digest verification;
+- `catalog/v2/bundles.json` — explicit review-bundle roots and known capability
+  gaps;
+- `catalog/v2/upstream-companions.json` — direct-upstream companion metadata
+  whose `bytesIncluded` value is always `false`.
+
+Generated targets, evidence, coverage, migrations, artifacts, sources, and
+repository inventory remain derived from the existing generators. Authored
+registries are never overwritten by generation.
+
+## Target-local safety fields
+
+Every target records:
+
+- capability kind and invocation class;
+- lifecycle;
+- explicit architecture, persona, surface, and repository-profile
+  applicability;
+- passive or executable trust plus assessed effects, confirmation, and
+  independently evidenced authorization;
+- typed hard, soft, or optional target, tool, internal-artifact, and
+  project-context dependencies with explicit missing behavior;
+- authoritative source-contract references and required authority subjects;
+- existing trigger, collision, security, evaluation, approval, and runtime
+  fields.
+
+Capability kind, invocation, trust, approval, publication, and runtime
+permission are independent. None implies another.
+
+## Migration without guesses
+
+Current targets are migrated with explicit `unclassified` values for every new
+decision that lacks reviewed evidence. They remain candidates, carry no typed
+dependency edge or source-contract claim, and stay runtime-ineligible.
+
+An approved target must classify every new field, assess trust and effects,
+classify dependency edges, bind source contracts, pass existing evaluation and
+security gates, and carry exact approval evidence. Empty or unclassified values
+never mean “all,” “none,” or “safe.”
+
+## Dependency behavior
+
+Typed dependency combinations are closed:
+
+| Strength | Missing behavior |
+| --- | --- |
+| hard | block |
+| soft | degrade or substitute |
+| optional | omit |
+
+Hard target dependencies and substitute chains cannot cycle. Substitution cannot
+select the missing dependency, the owning target, or an upstream companion.
+Bundles contain explicit target IDs; taxonomy selectors cannot expand them
+silently. Hard closure must be listed, and selected soft or optional targets
+must be reachable from bundle roots. Draft review bundles may name candidates
+but are never publishable. A publishable bundle requires approved runtime
+targets and no unresolved capability gap.
+
+## Product source contracts
+
+Cratis AI owns capability composition, evaluation, approval, and generation.
+Product and client repositories own their current APIs, versions, examples, and
+contributor facts.
+
+A source contract begins `unverified` and cannot supply distribution input. It
+must later bind an immutable revision, content digest, verification date, and
+revision-matching repository evidence before that flag can change. Verified
+contracts cannot overlap for the same product/subject authority. A classified
+target names required authority subjects, and its selected contracts must cover
+every target product and subject. Private Studio implementation is not a source
+contract.
+
+## Upstream companions
+
+Companion records preserve URL, revision, version, license, owner, host, trust,
+dependencies, collisions, and review expiry. They cannot satisfy a Cratis target
+dependency, establish Cratis source authority, enter a bundle file list, or
+contribute bytes. Installation remains an explicit direct relationship between
+the user and upstream owner.
+
+## Determinism and scale
+
+Catalog ordering uses one ordinal comparator rather than process locale. Hard
+and substitute cycle detection is iterative, including deep graphs. Immutable
+source provenance loads each Git revision once and resolves its blobs through a
+single batch process, keeping validation practical as the catalog grows.
+Repository inventory uses set membership for bounded path checks.
+
+## Claims
+
+This model proves representability and fail-closed migration only. It does not
+approve a capability, create a public artifact, validate a plugin or package,
+or authorize runtime execution.

--- a/catalog/schemas/v2/catalog-v2.schema.json
+++ b/catalog/schemas/v2/catalog-v2.schema.json
@@ -58,6 +58,100 @@
         }
       }
     },
+    "applicability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "ids", "reason"],
+      "properties": {
+        "state": { "enum": ["applicable", "not-applicable", "unclassified"] },
+        "ids": { "$ref": "#/$defs/idArray" },
+        "reason": { "$ref": "#/$defs/nonEmptyString" }
+      }
+    },
+    "effect": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "operation",
+        "resourceBoundary",
+        "scope",
+        "dataClassifications",
+        "reversible",
+        "confirmation",
+        "authorization",
+        "evidenceIds"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "operation": { "enum": ["read", "create", "modify", "delete", "execute", "transmit", "publish"] },
+        "resourceBoundary": { "$ref": "#/$defs/nonEmptyString" },
+        "scope": { "$ref": "#/$defs/nonEmptyString" },
+        "dataClassifications": { "$ref": "#/$defs/idArray" },
+        "reversible": { "type": "boolean" },
+        "rollbackOrCompensation": { "$ref": "#/$defs/nonEmptyString" },
+        "confirmation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["required", "timing", "reason"],
+          "properties": {
+            "required": { "type": "boolean" },
+            "timing": { "enum": ["none", "before-invocation", "before-effect"] },
+            "reason": { "$ref": "#/$defs/nonEmptyString" }
+          }
+        },
+        "authorization": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["required", "authority", "evidenceIds"],
+          "properties": {
+            "required": { "type": "boolean" },
+            "authority": { "$ref": "#/$defs/nonEmptyString" },
+            "evidenceIds": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": { "$ref": "#/$defs/id" }
+            }
+          }
+        },
+        "evidenceIds": { "$ref": "#/$defs/evidenceIds" }
+      }
+    },
+    "dependencyEdge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["dependencyId", "category", "strength", "reason", "missingBehavior"],
+      "properties": {
+        "dependencyId": { "$ref": "#/$defs/nonEmptyString" },
+        "category": { "enum": ["target", "tool", "internal-artifact", "project-context"] },
+        "strength": { "enum": ["hard", "soft", "optional"] },
+        "reason": { "$ref": "#/$defs/nonEmptyString" },
+        "missingBehavior": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["action", "description"],
+          "properties": {
+            "action": { "enum": ["block", "degrade", "omit", "substitute"] },
+            "description": { "$ref": "#/$defs/nonEmptyString" },
+            "substituteDependencyId": { "$ref": "#/$defs/nonEmptyString" }
+          }
+        }
+      }
+    },
+    "trustAssessment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["class", "assessmentState", "effects"],
+      "properties": {
+        "class": { "enum": ["passive", "executable"] },
+        "assessmentState": { "enum": ["unclassified", "assessed"] },
+        "effects": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/effect" }
+        }
+      }
+    },
     "source": {
       "type": "object",
       "additionalProperties": false,
@@ -120,6 +214,19 @@
         "audience",
         "products",
         "languages",
+        "capabilityKind",
+        "invocation",
+        "lifecycle",
+        "architectures",
+        "personas",
+        "surfaces",
+        "repositoryProfiles",
+        "trust",
+        "dependencyClassificationState",
+        "dependencyEdges",
+        "sourceContractState",
+        "sourceContractIds",
+        "sourceAuthoritySubjects",
         "capability",
         "positiveTriggerIntent",
         "nearMissExclusions",
@@ -155,6 +262,25 @@
           "uniqueItems": true,
           "items": { "$ref": "#/$defs/id" }
         },
+        "capabilityKind": {
+          "enum": ["unclassified", "primitive", "router", "journey", "gate", "explanation", "adapter"]
+        },
+        "invocation": { "enum": ["unclassified", "user", "model", "both"] },
+        "lifecycle": { "enum": ["candidate", "experimental", "approved", "deprecated", "retired"] },
+        "architectures": { "$ref": "#/$defs/applicability" },
+        "personas": { "$ref": "#/$defs/applicability" },
+        "surfaces": { "$ref": "#/$defs/applicability" },
+        "repositoryProfiles": { "$ref": "#/$defs/applicability" },
+        "trust": { "$ref": "#/$defs/trustAssessment" },
+        "dependencyClassificationState": { "enum": ["unclassified", "classified"] },
+        "dependencyEdges": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/dependencyEdge" }
+        },
+        "sourceContractState": { "enum": ["unclassified", "classified"] },
+        "sourceContractIds": { "$ref": "#/$defs/idArray" },
+        "sourceAuthoritySubjects": { "$ref": "#/$defs/idArray" },
         "capability": { "$ref": "#/$defs/nonEmptyString" },
         "positiveTriggerIntent": { "$ref": "#/$defs/nonEmptyString" },
         "nearMissExclusions": {
@@ -244,6 +370,220 @@
           "minItems": 1,
           "uniqueItems": true,
           "items": { "$ref": "#/$defs/target" }
+        }
+      }
+    },
+    "taxonomyEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "description"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "name": { "$ref": "#/$defs/nonEmptyString" },
+        "description": { "$ref": "#/$defs/nonEmptyString" }
+      }
+    },
+    "taxonomyEntries": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/taxonomyEntry" }
+    },
+    "taxonomyCatalog": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schemaVersion", "authorityPolicy", "dimensions"],
+      "properties": {
+        "schemaVersion": { "const": 2 },
+        "authorityPolicy": { "const": "closed-explicit-identifiers" },
+        "dimensions": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "capabilityKinds",
+            "invocations",
+            "products",
+            "languages",
+            "architectures",
+            "personas",
+            "surfaces",
+            "repositoryProfiles",
+            "trustClasses",
+            "effectOperations",
+            "dataClassifications",
+            "dependencyStrengths",
+            "missingDependencyActions"
+          ],
+          "properties": {
+            "capabilityKinds": { "$ref": "#/$defs/taxonomyEntries" },
+            "invocations": { "$ref": "#/$defs/taxonomyEntries" },
+            "products": { "$ref": "#/$defs/taxonomyEntries" },
+            "languages": { "$ref": "#/$defs/taxonomyEntries" },
+            "architectures": { "$ref": "#/$defs/taxonomyEntries" },
+            "personas": { "$ref": "#/$defs/taxonomyEntries" },
+            "surfaces": { "$ref": "#/$defs/taxonomyEntries" },
+            "repositoryProfiles": { "$ref": "#/$defs/taxonomyEntries" },
+            "trustClasses": { "$ref": "#/$defs/taxonomyEntries" },
+            "effectOperations": { "$ref": "#/$defs/taxonomyEntries" },
+            "dataClassifications": { "$ref": "#/$defs/taxonomyEntries" },
+            "dependencyStrengths": { "$ref": "#/$defs/taxonomyEntries" },
+            "missingDependencyActions": { "$ref": "#/$defs/taxonomyEntries" }
+          }
+        }
+      }
+    },
+    "sourceContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "productIds",
+        "subjectKinds",
+        "owner",
+        "repositoryUrl",
+        "verificationState",
+        "distributionInputAllowed",
+        "evidenceIds"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "productIds": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/id" }
+        },
+        "subjectKinds": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/id" }
+        },
+        "owner": { "$ref": "#/$defs/nonEmptyString" },
+        "repositoryUrl": { "type": "string", "format": "uri" },
+        "verificationState": { "enum": ["unverified", "verified", "rejected"] },
+        "immutableRevision": { "type": "string", "pattern": "^[a-f0-9]{40}$" },
+        "verifiedOn": { "type": "string", "format": "date" },
+        "contentDigest": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        "distributionInputAllowed": { "type": "boolean" },
+        "evidenceIds": { "$ref": "#/$defs/evidenceIds" }
+      }
+    },
+    "sourceContractsCatalog": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schemaVersion", "defaultPolicy", "contracts"],
+      "properties": {
+        "schemaVersion": { "const": 2 },
+        "defaultPolicy": { "const": "deny" },
+        "contracts": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/sourceContract" }
+        }
+      }
+    },
+    "bundle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "state",
+        "audience",
+        "rootTargetIds",
+        "selectedSoftOrOptionalTargetIds",
+        "missingCapabilityIds",
+        "publishable",
+        "evidenceIds"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "name": { "$ref": "#/$defs/nonEmptyString" },
+        "state": { "enum": ["draft", "approved", "deprecated", "retired"] },
+        "audience": { "enum": ["public", "cratis-engineering"] },
+        "rootTargetIds": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/id" }
+        },
+        "selectedSoftOrOptionalTargetIds": { "$ref": "#/$defs/idArray" },
+        "missingCapabilityIds": { "$ref": "#/$defs/idArray" },
+        "publishable": { "type": "boolean" },
+        "evidenceIds": { "$ref": "#/$defs/evidenceIds" }
+      }
+    },
+    "bundlesCatalog": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schemaVersion", "defaultPolicy", "bundles"],
+      "properties": {
+        "schemaVersion": { "const": 2 },
+        "defaultPolicy": { "const": "deny" },
+        "bundles": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/bundle" }
+        }
+      }
+    },
+    "upstreamCompanion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "upstreamUrl",
+        "immutableRevision",
+        "upstreamVersion",
+        "license",
+        "owner",
+        "supportedHosts",
+        "directInstallRoute",
+        "trust",
+        "projectWrites",
+        "externalDependencies",
+        "knownCollisionTargetIds",
+        "testedCratisVersion",
+        "reviewedOn",
+        "expiresOn",
+        "bytesIncluded",
+        "evidenceIds"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "upstreamUrl": { "type": "string", "format": "uri" },
+        "immutableRevision": { "type": "string", "pattern": "^[a-f0-9]{40}$" },
+        "upstreamVersion": { "$ref": "#/$defs/nonEmptyString" },
+        "license": { "$ref": "#/$defs/nonEmptyString" },
+        "owner": { "$ref": "#/$defs/nonEmptyString" },
+        "supportedHosts": { "$ref": "#/$defs/idArray" },
+        "directInstallRoute": { "$ref": "#/$defs/nonEmptyString" },
+        "trust": { "$ref": "#/$defs/nonEmptyString" },
+        "projectWrites": { "type": "boolean" },
+        "externalDependencies": { "$ref": "#/$defs/idArray" },
+        "knownCollisionTargetIds": { "$ref": "#/$defs/idArray" },
+        "testedCratisVersion": { "$ref": "#/$defs/nonEmptyString" },
+        "reviewedOn": { "type": "string", "format": "date" },
+        "expiresOn": { "type": "string", "format": "date" },
+        "bytesIncluded": { "const": false },
+        "evidenceIds": { "$ref": "#/$defs/evidenceIds" }
+      }
+    },
+    "upstreamCompanionsCatalog": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schemaVersion", "defaultPolicy", "companions"],
+      "properties": {
+        "schemaVersion": { "const": 2 },
+        "defaultPolicy": { "const": "direct-upstream-install-only" },
+        "companions": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/upstreamCompanion" }
         }
       }
     },

--- a/catalog/v2/bundles.json
+++ b/catalog/v2/bundles.json
@@ -1,0 +1,114 @@
+{
+  "schemaVersion": 2,
+  "defaultPolicy": "deny",
+  "bundles": [
+    {
+      "id": "cratis-core-review",
+      "name": "Cratis core review bundle",
+      "state": "draft",
+      "audience": "public",
+      "rootTargetIds": [
+        "cratis-chronicle-event-modeling",
+        "cratis-fundamentals-concept",
+        "cratis-fundamentals-type-discovery"
+      ],
+      "selectedSoftOrOptionalTargetIds": [],
+      "missingCapabilityIds": [],
+      "publishable": false,
+      "evidenceIds": ["ecosystem-use-cases"]
+    },
+    {
+      "id": "cratis-arc-backend-review",
+      "name": "Arc backend review bundle",
+      "state": "draft",
+      "audience": "public",
+      "rootTargetIds": [
+        "cratis-arc-authentication-authorization-and-identity",
+        "cratis-arc-command",
+        "cratis-arc-command-execution",
+        "cratis-arc-command-validation",
+        "cratis-arc-ef-core-migration",
+        "cratis-arc-query-paging"
+      ],
+      "selectedSoftOrOptionalTargetIds": [],
+      "missingCapabilityIds": ["arc-query", "arc-validation", "arc-authorization"],
+      "publishable": false,
+      "evidenceIds": ["ecosystem-use-cases"]
+    },
+    {
+      "id": "cratis-chronicle-dotnet-review",
+      "name": "Chronicle .NET review bundle",
+      "state": "draft",
+      "audience": "public",
+      "rootTargetIds": [
+        "cratis-chronicle-event-constraints",
+        "cratis-chronicle-event-metadata",
+        "cratis-chronicle-event-type-migration",
+        "cratis-chronicle-multi-tenancy",
+        "cratis-chronicle-projection",
+        "cratis-chronicle-reactor",
+        "cratis-chronicle-read-model",
+        "cratis-chronicle-reducer"
+      ],
+      "selectedSoftOrOptionalTargetIds": [],
+      "missingCapabilityIds": ["chronicle-dotnet-client", "chronicle-compliance"],
+      "publishable": false,
+      "evidenceIds": ["ecosystem-use-cases"]
+    },
+    {
+      "id": "cratis-application-full-stack-review",
+      "name": "Arc, Chronicle, React, and Components review bundle",
+      "state": "draft",
+      "audience": "public",
+      "rootTargetIds": [
+        "cratis-application-react-specifications",
+        "cratis-application-slice-diagnostics",
+        "cratis-application-slice-specifications",
+        "cratis-application-vertical-slice",
+        "cratis-arc-react-feature-scaffolding",
+        "cratis-arc-react-page",
+        "cratis-components-stepper-command-dialog",
+        "cratis-components-toolbar"
+      ],
+      "selectedSoftOrOptionalTargetIds": [],
+      "missingCapabilityIds": ["arc-react-client", "components-dialog", "components-data-page"],
+      "publishable": false,
+      "evidenceIds": ["ecosystem-use-cases"]
+    },
+    {
+      "id": "cratis-review-capabilities",
+      "name": "Cratis review capability bundle",
+      "state": "draft",
+      "audience": "public",
+      "rootTargetIds": [
+        "cratis-code-review",
+        "cratis-performance-review",
+        "cratis-security-review"
+      ],
+      "selectedSoftOrOptionalTargetIds": [],
+      "missingCapabilityIds": [],
+      "publishable": false,
+      "evidenceIds": ["third-party-skills-evaluation"]
+    },
+    {
+      "id": "cratis-engineering-review",
+      "name": "Cratis engineering review bundle",
+      "state": "draft",
+      "audience": "cratis-engineering",
+      "rootTargetIds": [
+        "cratis-engineering-chronicle-kernel-tracing",
+        "cratis-engineering-csharp-conventions",
+        "cratis-engineering-docs-add-page",
+        "cratis-engineering-docs-authoring",
+        "cratis-engineering-docs-edit-page",
+        "cratis-engineering-docs-visual-qa",
+        "cratis-engineering-ship-changes",
+        "skill-creator"
+      ],
+      "selectedSoftOrOptionalTargetIds": [],
+      "missingCapabilityIds": [],
+      "publishable": false,
+      "evidenceIds": ["option-a-plus-authority"]
+    }
+  ]
+}

--- a/catalog/v2/evidence.json
+++ b/catalog/v2/evidence.json
@@ -61,6 +61,28 @@
       "digest": "d0e76cea34145717ae8874a252b7d4468c43ef102cb9ddc3f2241c0960aa70d5"
     },
     {
+      "id": "ecosystem-use-cases",
+      "officialUrl": "https://github.com/Cratis/AI",
+      "sourceKind": "local-evidence-report",
+      "verifiedOn": "2026-08-20",
+      "expiresOn": "2026-11-18",
+      "applicableVersion": "content-digest-bound",
+      "confidence": "medium",
+      "repositoryPath": "AI-REPOSITORY-REDESIGN-ECOSYSTEM-USE-CASES.md",
+      "digest": "3b6fa1b0458eaf6c7305f68fc475e16e9ad2dd78f25cf0db3dea7bedd505f8f1"
+    },
+    {
+      "id": "third-party-skills-evaluation",
+      "officialUrl": "https://github.com/Cratis/AI",
+      "sourceKind": "local-evidence-report",
+      "verifiedOn": "2026-08-20",
+      "expiresOn": "2026-11-18",
+      "applicableVersion": "content-digest-bound",
+      "confidence": "medium",
+      "repositoryPath": "AI-REPOSITORY-REDESIGN-THIRD-PARTY-SKILLS-EVALUATION.md",
+      "digest": "cc9dcc93365dcfc2721b5aff837ace9d941db7251f68ab732b0285b063c2272c"
+    },
+    {
       "id": "option-a-plus-authority",
       "officialUrl": "https://github.com/Cratis/Workflows/issues/68#issuecomment-5363284054",
       "sourceKind": "organization-authority",

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "2cd06a70aa2ed2b425ffe6a685185aba4f6568332a38f776f1ecc9811f77494b",
+  "indexDigest": "8ac6f0660e84a14a5e051db2f0b0b18a4a9bd803df86ced9a3654ac7fcf4eca9",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -63,59 +63,11 @@
       "status": "added"
     },
     {
-      "path": "catalog/ecosystem-versions.json",
+      "path": "Documentation/capability-catalog-v2.md",
       "status": "added"
     },
     {
-      "path": "catalog/product-coverage.yml",
-      "status": "added"
-    },
-    {
-      "path": "catalog/public-skills.yml",
-      "status": "added"
-    },
-    {
-      "path": "catalog/schemas/ecosystem-versions.schema.json",
-      "status": "added"
-    },
-    {
-      "path": "catalog/schemas/product-coverage.schema.json",
-      "status": "added"
-    },
-    {
-      "path": "catalog/schemas/public-skills.schema.json",
-      "status": "added"
-    },
-    {
-      "path": "catalog/schemas/v2/catalog-v2.schema.json",
-      "status": "added"
-    },
-    {
-      "path": "catalog/v2/artifacts.json",
-      "status": "added"
-    },
-    {
-      "path": "catalog/v2/evidence.json",
-      "status": "added"
-    },
-    {
-      "path": "catalog/v2/migrations.json",
-      "status": "added"
-    },
-    {
-      "path": "catalog/v2/product-coverage.json",
-      "status": "added"
-    },
-    {
-      "path": "catalog/v2/repository-inventory.json",
-      "status": "added"
-    },
-    {
-      "path": "catalog/v2/sources.json",
-      "status": "added"
-    },
-    {
-      "path": "catalog/v2/targets.json",
+      "path": "Documentation/evidence/redesign-autonomous-execution-2026-08-20/README.md",
       "status": "added"
     },
     {
@@ -144,10 +96,6 @@
     },
     {
       "path": "Documentation/evidence/redesign-autonomous-execution-2026-08-20/ignored-paths.txt",
-      "status": "added"
-    },
-    {
-      "path": "Documentation/evidence/redesign-autonomous-execution-2026-08-20/README.md",
       "status": "added"
     },
     {
@@ -203,6 +151,82 @@
       "status": "added"
     },
     {
+      "path": "catalog/ecosystem-versions.json",
+      "status": "added"
+    },
+    {
+      "path": "catalog/product-coverage.yml",
+      "status": "added"
+    },
+    {
+      "path": "catalog/public-skills.yml",
+      "status": "added"
+    },
+    {
+      "path": "catalog/schemas/ecosystem-versions.schema.json",
+      "status": "added"
+    },
+    {
+      "path": "catalog/schemas/product-coverage.schema.json",
+      "status": "added"
+    },
+    {
+      "path": "catalog/schemas/public-skills.schema.json",
+      "status": "added"
+    },
+    {
+      "path": "catalog/schemas/v2/catalog-v2.schema.json",
+      "status": "added"
+    },
+    {
+      "path": "catalog/v2/artifacts.json",
+      "status": "added"
+    },
+    {
+      "path": "catalog/v2/bundles.json",
+      "status": "added"
+    },
+    {
+      "path": "catalog/v2/evidence.json",
+      "status": "added"
+    },
+    {
+      "path": "catalog/v2/migrations.json",
+      "status": "added"
+    },
+    {
+      "path": "catalog/v2/product-coverage.json",
+      "status": "added"
+    },
+    {
+      "path": "catalog/v2/repository-inventory.json",
+      "status": "added"
+    },
+    {
+      "path": "catalog/v2/source-contracts.json",
+      "status": "added"
+    },
+    {
+      "path": "catalog/v2/sources.json",
+      "status": "added"
+    },
+    {
+      "path": "catalog/v2/targets.json",
+      "status": "added"
+    },
+    {
+      "path": "catalog/v2/taxonomy.json",
+      "status": "added"
+    },
+    {
+      "path": "catalog/v2/upstream-companions.json",
+      "status": "added"
+    },
+    {
+      "path": "tooling/catalog-ordering.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/catalog-v2-validation.mjs",
       "status": "added"
     },
@@ -251,19 +275,19 @@
       "status": "added"
     },
     {
-      "path": "tooling/fixtures/public-artifact/valid-source/skills/cratis-example/assets/example.txt",
-      "status": "added"
-    },
-    {
       "path": "tooling/fixtures/public-artifact/valid-source/skills/cratis-example/LICENSE",
       "status": "added"
     },
     {
-      "path": "tooling/fixtures/public-artifact/valid-source/skills/cratis-example/references/guide.md",
+      "path": "tooling/fixtures/public-artifact/valid-source/skills/cratis-example/SKILL.md",
       "status": "added"
     },
     {
-      "path": "tooling/fixtures/public-artifact/valid-source/skills/cratis-example/SKILL.md",
+      "path": "tooling/fixtures/public-artifact/valid-source/skills/cratis-example/assets/example.txt",
+      "status": "added"
+    },
+    {
+      "path": "tooling/fixtures/public-artifact/valid-source/skills/cratis-example/references/guide.md",
       "status": "added"
     },
     {
@@ -280,6 +304,10 @@
     },
     {
       "path": "tooling/public-artifact-materializer.mjs",
+      "status": "added"
+    },
+    {
+      "path": "tooling/specs/catalog-ordering.spec.mjs",
       "status": "added"
     },
     {
@@ -524,7 +552,7 @@
         "ai-126"
       ],
       "expectedPathCount": 14,
-      "expectedPathsDigest": "bacd720113a371e382ce67ae40b9612a76a7fe900d80139ce70f706ea9021daf"
+      "expectedPathsDigest": "bad82a4ca327684526057da05d262423e0d6ce94e2f711c68c334f9094556cd9"
     },
     {
       "excludePathPatterns": [],
@@ -609,7 +637,7 @@
         "reevaluation-authority"
       ],
       "expectedPathCount": 62,
-      "expectedPathsDigest": "7b7ce0c400d7a6818d4b3f069b5a1fec4cdc34dced0ff2afa22f8c64f32e32a3"
+      "expectedPathsDigest": "4d6d81d603857bc6c534a7417e2e3413051118387141b76ebfefd19564de8156"
     },
     {
       "excludePathPatterns": [
@@ -642,7 +670,7 @@
         "reevaluation-authority"
       ],
       "expectedPathCount": 29,
-      "expectedPathsDigest": "913915055b0455f3768146ed7515a890ba7574da1a23a98ea70369ff1e2b343f"
+      "expectedPathsDigest": "f30f6bcc4ea06e345cb4e2d91835dc2b90719b7483b408d5ad322660dbea0f7c"
     },
     {
       "excludePathPatterns": [],
@@ -691,7 +719,7 @@
       ],
       "generator": "legacy-manual-adapter-model",
       "expectedPathCount": 57,
-      "expectedPathsDigest": "06aee74161e908fd6d22a17bfbe3d1fa331c286d337802378cf8cd6ae73c6aa8"
+      "expectedPathsDigest": "8df9cc32a0bf05818a3bdb16823d6231d4c1ca5d7b4658fc0a6841e524d0b8f0"
     },
     {
       "excludePathPatterns": [],
@@ -1022,7 +1050,7 @@
         "organization-option-a-plus-authority"
       ],
       "expectedPathCount": 16,
-      "expectedPathsDigest": "f4f99ed78267398e3e6db6eb99fcfd307d5bb7e3a55806c48b893ff9d6c42255"
+      "expectedPathsDigest": "39af5a952ad3752f64bc7a5474560c9eac0b2cd4bca09ae43d899959b7e87f93"
     },
     {
       "excludePathPatterns": [],
@@ -1088,6 +1116,32 @@
     },
     {
       "excludePathPatterns": [],
+      "id": "capability-model-documentation",
+      "sourcePathPatterns": [
+        "Documentation/capability-catalog-v2.md"
+      ],
+      "artifactType": "documentation",
+      "currentOwner": "repository-only authoring/release tooling",
+      "targetOwner": "repository-only authoring/release tooling",
+      "runtimeEligibility": "repository-only",
+      "generatedStatus": "source",
+      "adapterStatus": "none",
+      "dependencies": [
+        "catalog/v2/bundles.json",
+        "catalog/v2/source-contracts.json",
+        "catalog/v2/taxonomy.json",
+        "catalog/v2/upstream-companions.json"
+      ],
+      "risk": "medium",
+      "migrationState": "retain",
+      "evidenceIds": [
+        "option-a-plus-authority"
+      ],
+      "expectedPathCount": 1,
+      "expectedPathsDigest": "368dbe32574523305797d2250728c509c934c842c4e07b607d7b0ad95f400e98"
+    },
+    {
+      "excludePathPatterns": [],
       "id": "catalog-v1-scaffold",
       "sourcePathPatterns": [
         "catalog/ecosystem-versions.json",
@@ -1116,6 +1170,39 @@
     },
     {
       "excludePathPatterns": [],
+      "id": "catalog-v2-authored-registries",
+      "sourcePathPatterns": [
+        "catalog/v2/bundles.json",
+        "catalog/v2/source-contracts.json",
+        "catalog/v2/taxonomy.json",
+        "catalog/v2/upstream-companions.json"
+      ],
+      "artifactType": "catalog-schema",
+      "currentOwner": "repository-only authoring/release tooling",
+      "targetOwner": "repository-only authoring/release tooling",
+      "runtimeEligibility": "repository-only",
+      "generatedStatus": "source",
+      "adapterStatus": "none",
+      "dependencies": [
+        "catalog/schemas/v2/catalog-v2.schema.json",
+        "tooling/catalog-v2-validation.mjs"
+      ],
+      "risk": "high",
+      "migrationState": "retain",
+      "evidenceIds": [
+        "ecosystem-use-cases",
+        "third-party-skills-evaluation"
+      ],
+      "expectedPathCount": 4,
+      "expectedPathsDigest": "ec3ac58212de700f909cb30e4e3761dc16a1eed0d6a0c210fd8b625ba2761a95"
+    },
+    {
+      "excludePathPatterns": [
+        "catalog/v2/bundles.json",
+        "catalog/v2/source-contracts.json",
+        "catalog/v2/taxonomy.json",
+        "catalog/v2/upstream-companions.json"
+      ],
       "id": "catalog-v2-generated-surfaces",
       "sourcePathPatterns": [
         "catalog/v2/**"
@@ -1182,8 +1269,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 7,
-      "expectedPathsDigest": "5d124b5352835c22157025b12fb8620fbaec919f2f3b17a3e35dfe615e65d536"
+      "expectedPathCount": 8,
+      "expectedPathsDigest": "ba097e98690b3dbb288c3b2cacc6d4ab1418572db214c07253c91863537f1958"
     },
     {
       "excludePathPatterns": [],
@@ -1206,8 +1293,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 4,
-      "expectedPathsDigest": "47ac458d9402ffed38dbd659cf0febcf4110ee1d134d6bbc65bae321e3cb2534"
+      "expectedPathCount": 5,
+      "expectedPathsDigest": "dd3f31be67af69b280aa4b2b10008d8dac30af7199aaaab3e3b0351583111c73"
     },
     {
       "excludePathPatterns": [],
@@ -1231,7 +1318,7 @@
         "reevaluation-authority"
       ],
       "expectedPathCount": 14,
-      "expectedPathsDigest": "396592906ce042e4400f7247e956e9c75fa79283d83ac180536df429abda8d23"
+      "expectedPathsDigest": "cb002190b3cf88b3fd07c0ff21024015838a4299c67318eac3b0605f7d04f602"
     }
   ]
 }

--- a/catalog/v2/source-contracts.json
+++ b/catalog/v2/source-contracts.json
@@ -1,0 +1,146 @@
+{
+  "schemaVersion": 2,
+  "defaultPolicy": "deny",
+  "contracts": [
+    {
+      "id": "cratis-ai-composition",
+      "productIds": ["application", "cross-product", "cratis-engineering"],
+      "subjectKinds": ["capability-composition", "approval", "evaluation", "generation"],
+      "owner": "Cratis AI maintainers",
+      "repositoryUrl": "https://github.com/Cratis/AI",
+      "verificationState": "unverified",
+      "distributionInputAllowed": false,
+      "evidenceIds": ["option-a-plus-authority"]
+    },
+    {
+      "id": "cratis-arc-source",
+      "productIds": ["arc", "arc-react", "entity-framework-core"],
+      "subjectKinds": ["api", "documentation", "examples", "versions"],
+      "owner": "Cratis Arc maintainers",
+      "repositoryUrl": "https://github.com/Cratis/Arc",
+      "verificationState": "unverified",
+      "distributionInputAllowed": false,
+      "evidenceIds": ["ecosystem-use-cases"]
+    },
+    {
+      "id": "cratis-chronicle-source",
+      "productIds": ["chronicle"],
+      "subjectKinds": ["api", "documentation", "examples", "versions"],
+      "owner": "Cratis Chronicle maintainers",
+      "repositoryUrl": "https://github.com/Cratis/Chronicle",
+      "verificationState": "unverified",
+      "distributionInputAllowed": false,
+      "evidenceIds": ["ecosystem-use-cases"]
+    },
+    {
+      "id": "cratis-components-source",
+      "productIds": ["components"],
+      "subjectKinds": ["api", "documentation", "examples", "versions"],
+      "owner": "Cratis Components maintainers",
+      "repositoryUrl": "https://github.com/Cratis/Components",
+      "verificationState": "unverified",
+      "distributionInputAllowed": false,
+      "evidenceIds": ["ecosystem-use-cases"]
+    },
+    {
+      "id": "cratis-fundamentals-source",
+      "productIds": ["fundamentals"],
+      "subjectKinds": ["api", "documentation", "examples", "versions"],
+      "owner": "Cratis Fundamentals maintainers",
+      "repositoryUrl": "https://github.com/Cratis/Fundamentals",
+      "verificationState": "unverified",
+      "distributionInputAllowed": false,
+      "evidenceIds": ["ecosystem-use-cases"]
+    },
+    {
+      "id": "cratis-specifications-source",
+      "productIds": ["specifications"],
+      "subjectKinds": ["api", "documentation", "examples", "versions"],
+      "owner": "Cratis Specifications maintainers",
+      "repositoryUrl": "https://github.com/Cratis/Specifications",
+      "verificationState": "unverified",
+      "distributionInputAllowed": false,
+      "evidenceIds": ["ecosystem-use-cases"]
+    },
+    {
+      "id": "cratis-cli-source",
+      "productIds": ["cli"],
+      "subjectKinds": ["api", "commands", "documentation", "versions"],
+      "owner": "Cratis CLI maintainers",
+      "repositoryUrl": "https://github.com/Cratis/cli",
+      "verificationState": "unverified",
+      "distributionInputAllowed": false,
+      "evidenceIds": ["ecosystem-use-cases"]
+    },
+    {
+      "id": "cratis-chronicle-kotlin-source",
+      "productIds": ["chronicle"],
+      "subjectKinds": ["kotlin-client-api", "java-client-api", "kotlin-java-client-documentation", "kotlin-java-client-examples", "kotlin-java-client-versions"],
+      "owner": "Chronicle Kotlin and Java client maintainers",
+      "repositoryUrl": "https://github.com/Cratis/Chronicle.Kotlin",
+      "verificationState": "unverified",
+      "distributionInputAllowed": false,
+      "evidenceIds": ["ecosystem-use-cases"]
+    },
+    {
+      "id": "cratis-chronicle-elixir-source",
+      "productIds": ["chronicle"],
+      "subjectKinds": ["elixir-client-api", "elixir-client-documentation", "elixir-client-examples", "elixir-client-versions"],
+      "owner": "Chronicle Elixir client maintainers",
+      "repositoryUrl": "https://github.com/Cratis/Chronicle.Elixir",
+      "verificationState": "unverified",
+      "distributionInputAllowed": false,
+      "evidenceIds": ["ecosystem-use-cases"]
+    },
+    {
+      "id": "cratis-chronicle-typescript-source",
+      "productIds": ["chronicle"],
+      "subjectKinds": ["typescript-client-api", "typescript-client-documentation", "typescript-client-examples", "typescript-client-versions"],
+      "owner": "Chronicle TypeScript client maintainers",
+      "repositoryUrl": "https://github.com/Cratis/Chronicle.TypeScript",
+      "verificationState": "unverified",
+      "distributionInputAllowed": false,
+      "evidenceIds": ["ecosystem-use-cases"]
+    },
+    {
+      "id": "cratis-chronicle-mcp-source",
+      "productIds": ["chronicle-mcp"],
+      "subjectKinds": ["tools", "schemas", "credentials", "mutations", "versions"],
+      "owner": "Chronicle.Mcp maintainers",
+      "repositoryUrl": "https://github.com/Cratis/Chronicle.Mcp",
+      "verificationState": "unverified",
+      "distributionInputAllowed": false,
+      "evidenceIds": ["ecosystem-use-cases"]
+    },
+    {
+      "id": "cratis-screenplay-source",
+      "productIds": ["screenplay"],
+      "subjectKinds": ["language", "compiler", "editor", "documentation", "versions"],
+      "owner": "Cratis Screenplay maintainers",
+      "repositoryUrl": "https://github.com/Cratis/Screenplay",
+      "verificationState": "unverified",
+      "distributionInputAllowed": false,
+      "evidenceIds": ["ecosystem-use-cases"]
+    },
+    {
+      "id": "cratis-stage-source",
+      "productIds": ["stage"],
+      "subjectKinds": ["runtime", "specifications", "workbench", "documentation", "versions"],
+      "owner": "Cratis Stage maintainers",
+      "repositoryUrl": "https://github.com/Cratis/Stage",
+      "verificationState": "unverified",
+      "distributionInputAllowed": false,
+      "evidenceIds": ["ecosystem-use-cases"]
+    },
+    {
+      "id": "cratis-studio-public-source",
+      "productIds": ["studio"],
+      "subjectKinds": ["public-onboarding", "public-support", "public-issues"],
+      "owner": "Cratis Studio public maintainers",
+      "repositoryUrl": "https://github.com/Cratis/StudioIssues",
+      "verificationState": "unverified",
+      "distributionInputAllowed": false,
+      "evidenceIds": ["ecosystem-use-cases"]
+    }
+  ]
+}

--- a/catalog/v2/targets.json
+++ b/catalog/v2/targets.json
@@ -20,6 +20,39 @@
         "react",
         "typescript"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Application React specifications",
       "positiveTriggerIntent": "Use for React or TypeScript behavior in a Cratis application slice.",
       "nearMissExclusions": [
@@ -116,6 +149,39 @@
         "csharp",
         "typescript"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Application slice diagnostics",
       "positiveTriggerIntent": "Use when a Cratis slice misbehaves and source-level cause is unclear.",
       "nearMissExclusions": [
@@ -216,6 +282,39 @@
       "languages": [
         "csharp"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Application slice specifications",
       "positiveTriggerIntent": "Use to route event-sourced application backend behavior to the correct in-process scenario family.",
       "nearMissExclusions": [
@@ -316,6 +415,39 @@
         "react",
         "typescript"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Cratis application vertical slices",
       "positiveTriggerIntent": "Use for vertical-slice architecture selection or end-to-end implementation after the merge experiment passes.",
       "nearMissExclusions": [
@@ -414,6 +546,39 @@
         "csharp",
         "react"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Arc authentication, authorization, and identity",
       "positiveTriggerIntent": "Use for Arc identity providers, endpoint protection, roles, or frontend identity integration.",
       "nearMissExclusions": [
@@ -512,6 +677,39 @@
         "csharp",
         "react"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Arc command definition",
       "positiveTriggerIntent": "Use when defining an Arc command and its generated full-stack proxy workflow.",
       "nearMissExclusions": [
@@ -607,6 +805,39 @@
       "languages": [
         "csharp"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Arc command pipeline execution",
       "positiveTriggerIntent": "Use when backend code must execute an existing Arc command through ICommandPipeline.",
       "nearMissExclusions": [
@@ -699,6 +930,39 @@
       "languages": [
         "csharp"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Arc command validation",
       "positiveTriggerIntent": "Use when adding validation or state-dependent rejection to an existing Arc command.",
       "nearMissExclusions": [
@@ -793,6 +1057,39 @@
       "languages": [
         "csharp"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Arc EF Core migrations",
       "positiveTriggerIntent": "Use when adding or changing an EF Core schema in a Cratis application.",
       "nearMissExclusions": [
@@ -884,6 +1181,39 @@
       "languages": [
         "shell"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Arc observable-query HTTP diagnostics",
       "positiveTriggerIntent": "Use when inspecting Arc observable query SSE or streaming behavior with curl or HTTP tools.",
       "nearMissExclusions": [
@@ -977,6 +1307,39 @@
         "react",
         "typescript"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Arc query paging",
       "positiveTriggerIntent": "Use when adding server-side paging and sorting to an Arc read-model query.",
       "nearMissExclusions": [
@@ -1074,6 +1437,39 @@
         "react",
         "typescript"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Arc React feature scaffolding",
       "positiveTriggerIntent": "Use when creating an empty route, navigation entry, and feature composition shell.",
       "nearMissExclusions": [
@@ -1168,6 +1564,39 @@
         "react",
         "typescript"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Arc React pages",
       "positiveTriggerIntent": "Use when building a DataPage or MVVM React page backed by generated Arc queries.",
       "nearMissExclusions": [
@@ -1263,6 +1692,39 @@
       "languages": [
         "shell"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Chronicle CLI operations",
       "positiveTriggerIntent": "Use to inspect a running Chronicle store and, only with explicit confirmation, perform recovery operations.",
       "nearMissExclusions": [
@@ -1358,6 +1820,39 @@
       "languages": [
         "csharp"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Chronicle event constraints",
       "positiveTriggerIntent": "Use when enforcing append-time uniqueness, concurrency, or event-store constraints.",
       "nearMissExclusions": [
@@ -1451,6 +1946,39 @@
       "languages": [
         "csharp"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Chronicle event metadata",
       "positiveTriggerIntent": "Use when attaching audit, actor, tenant, or correlation metadata outside domain event payloads.",
       "nearMissExclusions": [
@@ -1542,6 +2070,39 @@
       "languages": [
         "language-agnostic"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Chronicle event modeling",
       "positiveTriggerIntent": "Use before implementation when commands, events, streams, read models, or reactions are unsettled.",
       "nearMissExclusions": [
@@ -1635,6 +2196,39 @@
       "languages": [
         "csharp"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Chronicle event specifications",
       "positiveTriggerIntent": "Use for EventScenario append, constraint, concurrency, or sequence behavior.",
       "nearMissExclusions": [
@@ -1725,6 +2319,39 @@
       "languages": [
         "csharp"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Chronicle event type migration",
       "positiveTriggerIntent": "Use when a stored event schema needs a new generation and migration.",
       "nearMissExclusions": [
@@ -1816,6 +2443,39 @@
       "languages": [
         "csharp"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Chronicle multi-tenancy",
       "positiveTriggerIntent": "Use when isolating tenants through Chronicle namespaces and Arc tenant resolution.",
       "nearMissExclusions": [
@@ -1908,6 +2568,39 @@
       "languages": [
         "csharp"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Chronicle projections",
       "positiveTriggerIntent": "Use when adding projection behavior to an existing Chronicle read model.",
       "nearMissExclusions": [
@@ -2002,6 +2695,39 @@
       "languages": [
         "csharp"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Chronicle reactors",
       "positiveTriggerIntent": "Use when implementing an automation or translation that reacts to events.",
       "nearMissExclusions": [
@@ -2099,6 +2825,39 @@
         "csharp",
         "typescript"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Chronicle read models",
       "positiveTriggerIntent": "Use when creating a Chronicle read model and model-bound query surface.",
       "nearMissExclusions": [
@@ -2197,6 +2956,39 @@
       "languages": [
         "csharp"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Chronicle read-model specifications",
       "positiveTriggerIntent": "Use for ReadModelScenario projection or reducer behavior.",
       "nearMissExclusions": [
@@ -2290,6 +3082,39 @@
       "languages": [
         "csharp"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Chronicle reducers",
       "positiveTriggerIntent": "Use when a current-state-plus-event transition cannot be expressed as a projection.",
       "nearMissExclusions": [
@@ -2384,6 +3209,39 @@
         "csharp",
         "typescript"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Cratis code review",
       "positiveTriggerIntent": "Use for a general correctness and maintainability review of Cratis code.",
       "nearMissExclusions": [
@@ -2478,6 +3336,39 @@
         "react",
         "typescript"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Cratis Components stepper command dialogs",
       "positiveTriggerIntent": "Use when a command requires a multi-step wizard dialog.",
       "nearMissExclusions": [
@@ -2569,6 +3460,39 @@
         "react",
         "typescript"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Cratis Components toolbar",
       "positiveTriggerIntent": "Use when building a canvas-style icon toolbar with active tools or fan-out controls.",
       "nearMissExclusions": [
@@ -2658,6 +3582,39 @@
       "languages": [
         "language-agnostic"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Chronicle Kernel tracing maintenance",
       "positiveTriggerIntent": "Use by Chronicle framework maintainers to add generated OpenTelemetry traces.",
       "nearMissExclusions": [
@@ -2734,6 +3691,39 @@
       "languages": [
         "language-agnostic"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Cratis C# engineering conventions",
       "positiveTriggerIntent": "Use for Cratis-maintainer C# house standards and review policy.",
       "nearMissExclusions": [
@@ -2812,6 +3802,39 @@
       "languages": [
         "language-agnostic"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Cratis documentation page creation",
       "positiveTriggerIntent": "Use by Cratis maintainers to add a source-owned product documentation page.",
       "nearMissExclusions": [
@@ -2891,6 +3914,39 @@
       "languages": [
         "language-agnostic"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Cratis documentation authoring",
       "positiveTriggerIntent": "Use by Cratis maintainers to apply Diátaxis and documentation writing guidance.",
       "nearMissExclusions": [
@@ -2970,6 +4026,39 @@
       "languages": [
         "language-agnostic"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Cratis documentation page editing",
       "positiveTriggerIntent": "Use by Cratis maintainers to edit the source-owned copy of an existing documentation page.",
       "nearMissExclusions": [
@@ -3049,6 +4138,39 @@
       "languages": [
         "language-agnostic"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Cratis documentation visual QA",
       "positiveTriggerIntent": "Use by Cratis maintainers to render and inspect documentation in light and dark modes.",
       "nearMissExclusions": [
@@ -3127,6 +4249,39 @@
       "languages": [
         "language-agnostic"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Cratis change shipping",
       "positiveTriggerIntent": "Use only after an explicit request to commit, push, open, or merge a Cratis pull request.",
       "nearMissExclusions": [
@@ -3204,6 +4359,39 @@
       "languages": [
         "markdown"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Event-model diagrams",
       "positiveTriggerIntent": "Use when creating or maintaining a Mermaid EventModel.md diagram for settled behavior.",
       "nearMissExclusions": [
@@ -3293,6 +4481,39 @@
       "languages": [
         "csharp"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Strongly typed Cratis concepts",
       "positiveTriggerIntent": "Use when creating a ConceptAs<T> value or EventSourceId<T> identity.",
       "nearMissExclusions": [
@@ -3379,6 +4600,39 @@
       "languages": [
         "csharp"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Cratis implementation discovery",
       "positiveTriggerIntent": "Use when a service must enumerate all implementations through IInstancesOf<T>.",
       "nearMissExclusions": [
@@ -3467,6 +4721,39 @@
         "csharp",
         "typescript"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Cratis performance review",
       "positiveTriggerIntent": "Use for focused Chronicle, database, .NET, or React scalability analysis.",
       "nearMissExclusions": [
@@ -3561,6 +4848,39 @@
         "csharp",
         "typescript"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Cratis security review",
       "positiveTriggerIntent": "Use for focused authentication, authorization, data exposure, event-sourcing, and frontend security review.",
       "nearMissExclusions": [
@@ -3653,6 +4973,39 @@
       "languages": [
         "csharp"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Cratis C# specification foundations",
       "positiveTriggerIntent": "Use for framework or library C# Specification by Example tests.",
       "nearMissExclusions": [
@@ -3745,6 +5098,39 @@
       "languages": [
         "typescript"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Cratis TypeScript specification foundations",
       "positiveTriggerIntent": "Use for framework or package TypeScript Specification by Example tests.",
       "nearMissExclusions": [
@@ -3834,6 +5220,39 @@
       "languages": [
         "language-agnostic"
       ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
       "capability": "Skill authoring and evaluation",
       "positiveTriggerIntent": "Use by trusted maintainers to create, improve, and evaluate Agent Skills.",
       "nearMissExclusions": [

--- a/catalog/v2/taxonomy.json
+++ b/catalog/v2/taxonomy.json
@@ -1,0 +1,121 @@
+{
+  "schemaVersion": 2,
+  "authorityPolicy": "closed-explicit-identifiers",
+  "dimensions": {
+    "capabilityKinds": [
+      { "id": "primitive", "name": "Primitive", "description": "A focused foundational capability used directly or by composed workflows." },
+      { "id": "router", "name": "Router", "description": "Selects the correct narrower capability without duplicating its procedure." },
+      { "id": "journey", "name": "Journey", "description": "Composes multiple capabilities into an end-to-end user outcome." },
+      { "id": "gate", "name": "Gate", "description": "Evaluates evidence and blocks progress when required criteria fail." },
+      { "id": "explanation", "name": "Explanation", "description": "Builds understanding without performing an implementation workflow." },
+      { "id": "adapter", "name": "Adapter", "description": "Projects approved behavior into a host- or surface-specific form without creating a behavior fork." }
+    ],
+    "invocations": [
+      { "id": "user", "name": "User invoked", "description": "Runs only after explicit user selection or request." },
+      { "id": "model", "name": "Model invoked", "description": "May be selected by the model from trigger intent." },
+      { "id": "both", "name": "User or model invoked", "description": "Supports both explicit and model-selected invocation." }
+    ],
+    "products": [
+      { "id": "application", "name": "Cratis application architecture", "description": "Composition guidance for applications built on Cratis products." },
+      { "id": "arc", "name": "Cratis Arc", "description": "Arc backend commands, queries, validation, authorization, and integrations." },
+      { "id": "arc-react", "name": "Arc React", "description": "Generated Arc React clients and observable frontend behavior." },
+      { "id": "chronicle", "name": "Cratis Chronicle", "description": "Chronicle event sourcing, clients, projections, reactions, and operations." },
+      { "id": "chronicle-mcp", "name": "Chronicle MCP", "description": "Chronicle.Mcp installation, selection, safety, and interpretation guidance." },
+      { "id": "cli", "name": "Cratis CLI", "description": "Cratis CLI setup, inspection, automation, and separately authorized operations." },
+      { "id": "components", "name": "Cratis Components", "description": "Cratis React component workflows and interaction patterns." },
+      { "id": "cross-product", "name": "Cross-product", "description": "Capabilities that apply across more than one Cratis product." },
+      { "id": "cratis-engineering", "name": "Cratis engineering", "description": "Separately trusted contributor and maintainer behavior." },
+      { "id": "entity-framework-core", "name": "Entity Framework Core", "description": "Arc and application EF Core integration." },
+      { "id": "fundamentals", "name": "Cratis Fundamentals", "description": "Strongly typed concepts and implementation discovery." },
+      { "id": "screenplay", "name": "Cratis Screenplay", "description": "Model authoring, compilation, diagnostics, and editor workflows." },
+      { "id": "specifications", "name": "Cratis Specifications", "description": "Specification by Example foundations and scenario families." },
+      { "id": "stage", "name": "Cratis Stage", "description": "Model runtime, workbench, and executable specification workflows." },
+      { "id": "studio", "name": "Cratis Studio", "description": "Public Studio onboarding, modeling, support, and issue-preparation workflows." }
+    ],
+    "languages": [
+      { "id": "csharp", "name": "C#", "description": "C# and .NET-specific APIs and toolchains." },
+      { "id": "elixir", "name": "Elixir", "description": "Elixir and OTP-specific APIs and toolchains." },
+      { "id": "java", "name": "Java", "description": "Java-specific APIs and toolchains." },
+      { "id": "kotlin", "name": "Kotlin", "description": "Kotlin and coroutine-specific APIs and toolchains." },
+      { "id": "language-agnostic", "name": "Language agnostic", "description": "Conceptual behavior independent of a programming language." },
+      { "id": "markdown", "name": "Markdown and Mermaid", "description": "Markdown documents and Mermaid models." },
+      { "id": "react", "name": "React", "description": "React-specific application and component workflows." },
+      { "id": "shell", "name": "Shell and HTTP", "description": "Terminal, shell, curl, and protocol-level workflows." },
+      { "id": "typescript", "name": "TypeScript", "description": "TypeScript and Node-specific APIs and toolchains." }
+    ],
+    "architectures": [
+      { "id": "arc-chronicle", "name": "Arc plus Chronicle", "description": "Arc application surfaces composed with Chronicle event sourcing." },
+      { "id": "arc-only", "name": "Arc only", "description": "Arc behavior without Chronicle assumptions." },
+      { "id": "chronicle-only", "name": "Chronicle only", "description": "Chronicle client behavior without Arc assumptions." },
+      { "id": "code-first", "name": "Code first", "description": "Implementation starts from product source code." },
+      { "id": "mixed", "name": "Mixed", "description": "A deliberate composition of model-first and code-first behavior." },
+      { "id": "model-first", "name": "Model first", "description": "Behavior starts from an explicit model before runtime or code." },
+      { "id": "product-neutral", "name": "Product neutral", "description": "Cross-product concepts and routing." }
+    ],
+    "personas": [
+      { "id": "architect", "name": "Architect", "description": "Designs system and product boundaries." },
+      { "id": "compliance", "name": "Compliance", "description": "Evaluates audit, privacy, subject, and retention concerns." },
+      { "id": "consultant", "name": "Consultant", "description": "Works across controlled client repositories." },
+      { "id": "contributor", "name": "Contributor", "description": "Contributes to a Cratis product or client repository." },
+      { "id": "developer", "name": "Developer", "description": "Builds software with Cratis products." },
+      { "id": "domain-expert", "name": "Domain expert", "description": "Contributes domain language, facts, scenarios, and decisions." },
+      { "id": "maintainer", "name": "Maintainer", "description": "Maintains Cratis products, source, and releases." },
+      { "id": "operator", "name": "Operator", "description": "Inspects and operates running product surfaces." },
+      { "id": "product-owner", "name": "Product owner", "description": "Clarifies outcomes, scope, and acceptance behavior." },
+      { "id": "qa", "name": "QA", "description": "Designs and verifies behavioral evidence." },
+      { "id": "support", "name": "Support", "description": "Collects evidence, diagnoses, and prepares escalations." }
+    ],
+    "surfaces": [
+      { "id": "backend", "name": "Backend", "description": "Backend source and runtime behavior." },
+      { "id": "browser", "name": "Browser", "description": "Browser-first product and assistant workflows." },
+      { "id": "ci", "name": "CI", "description": "Non-interactive validation and automation." },
+      { "id": "cli", "name": "CLI", "description": "Terminal and command-line workflows." },
+      { "id": "direct-agent-skills", "name": "Direct Agent Skills", "description": "Direct standards-based skill installation and use." },
+      { "id": "frontend", "name": "Frontend", "description": "React and browser application source." },
+      { "id": "generated-artifact", "name": "Generated artifact", "description": "Generated packages, manifests, archives, or catalogs." },
+      { "id": "ide", "name": "IDE", "description": "IDE and editor assistant workflows." },
+      { "id": "mcp", "name": "MCP", "description": "Model Context Protocol tools and resources." },
+      { "id": "pi", "name": "Pi", "description": "Pi package and optional extension surfaces." }
+    ],
+    "repositoryProfiles": [
+      { "id": "application", "name": "Application", "description": "A product application consuming Cratis." },
+      { "id": "client", "name": "Client library", "description": "A Chronicle or product client-library repository." },
+      { "id": "consuming-project", "name": "Consuming project", "description": "A project that owns local context and verification facts." },
+      { "id": "corpus", "name": "Corpus", "description": "The Cratis AI authoring and evaluation repository." },
+      { "id": "framework", "name": "Framework", "description": "A Cratis framework or product repository." },
+      { "id": "product-neutral", "name": "Product neutral", "description": "No repository architecture assumption." }
+    ],
+    "trustClasses": [
+      { "id": "passive", "name": "Passive", "description": "Contains no executable package or tool implementation." },
+      { "id": "executable", "name": "Executable", "description": "Runs code with host or system permissions." }
+    ],
+    "effectOperations": [
+      { "id": "create", "name": "Create", "description": "Creates local or remote state." },
+      { "id": "delete", "name": "Delete", "description": "Deletes local or remote state." },
+      { "id": "execute", "name": "Execute", "description": "Executes code, commands, or tools." },
+      { "id": "modify", "name": "Modify", "description": "Changes existing local or remote state." },
+      { "id": "publish", "name": "Publish", "description": "Makes an artifact or record externally available." },
+      { "id": "read", "name": "Read", "description": "Reads local, remote, or live-store state." },
+      { "id": "transmit", "name": "Transmit", "description": "Sends data across a trust boundary." }
+    ],
+    "dataClassifications": [
+      { "id": "confidential", "name": "Confidential", "description": "Non-public organization or client information." },
+      { "id": "credential", "name": "Credential", "description": "Secrets, tokens, keys, or authentication material." },
+      { "id": "internal", "name": "Internal", "description": "Organization-internal but non-secret information." },
+      { "id": "operational", "name": "Operational", "description": "Runtime, environment, telemetry, or infrastructure information." },
+      { "id": "personal", "name": "Personal", "description": "Personal or compliance-subject information." },
+      { "id": "public", "name": "Public", "description": "Information approved for public disclosure." }
+    ],
+    "dependencyStrengths": [
+      { "id": "hard", "name": "Hard", "description": "Absence blocks the capability." },
+      { "id": "optional", "name": "Optional", "description": "Absence omits an explicitly optional enhancement." },
+      { "id": "soft", "name": "Soft", "description": "Absence permits disclosed degradation or substitution." }
+    ],
+    "missingDependencyActions": [
+      { "id": "block", "name": "Block", "description": "Deny execution or completion." },
+      { "id": "degrade", "name": "Degrade", "description": "Continue with an explicitly disclosed reduction." },
+      { "id": "omit", "name": "Omit", "description": "Omit optional behavior." },
+      { "id": "substitute", "name": "Substitute", "description": "Use a named approved substitute." }
+    ]
+  }
+}

--- a/catalog/v2/upstream-companions.json
+++ b/catalog/v2/upstream-companions.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 2,
+  "defaultPolicy": "direct-upstream-install-only",
+  "companions": [
+    {
+      "id": "matt-pocock-skills",
+      "upstreamUrl": "https://github.com/mattpocock/skills",
+      "immutableRevision": "0ab1b63a410a03d3627979a109c8695de27af954",
+      "upstreamVersion": "1.2.3",
+      "license": "MIT",
+      "owner": "Matt Pocock",
+      "supportedHosts": ["claude-code"],
+      "directInstallRoute": "Install selected capabilities directly from the upstream repository under the upstream support and update model.",
+      "trust": "Includes model-reachable skills and optional workflows that can write project or remote state.",
+      "projectWrites": true,
+      "externalDependencies": ["git", "github"],
+      "knownCollisionTargetIds": [
+        "cratis-application-slice-diagnostics",
+        "cratis-chronicle-event-modeling",
+        "cratis-code-review",
+        "cratis-engineering-ship-changes"
+      ],
+      "testedCratisVersion": "unverified",
+      "reviewedOn": "2026-08-20",
+      "expiresOn": "2026-11-18",
+      "bytesIncluded": false,
+      "evidenceIds": ["third-party-skills-evaluation"]
+    },
+    {
+      "id": "pstack",
+      "upstreamUrl": "https://github.com/cursor/plugins/tree/51a96e0dd838404da19ba83dc70aa21eef71f868/pstack",
+      "immutableRevision": "51a96e0dd838404da19ba83dc70aa21eef71f868",
+      "upstreamVersion": "0.14.1",
+      "license": "MIT",
+      "owner": "Lauren Tan",
+      "supportedHosts": ["cursor"],
+      "directInstallRoute": "Install directly through the upstream Cursor plugin route in a disposable repository before broader use.",
+      "trust": "Includes skills, agents, scripts, transcript access, external dependencies, and high-trust shipping or cleanup behavior.",
+      "projectWrites": true,
+      "externalDependencies": ["bun", "cursor", "cursor-team-kit", "github", "graphite"],
+      "knownCollisionTargetIds": [
+        "cratis-application-slice-diagnostics",
+        "cratis-chronicle-event-modeling",
+        "cratis-code-review",
+        "cratis-engineering-ship-changes",
+        "cratis-performance-review",
+        "cratis-security-review"
+      ],
+      "testedCratisVersion": "unverified",
+      "reviewedOn": "2026-08-20",
+      "expiresOn": "2026-11-18",
+      "bytesIncluded": false,
+      "evidenceIds": ["third-party-skills-evaluation"]
+    }
+  ]
+}

--- a/tooling/catalog-ordering.mjs
+++ b/tooling/catalog-ordering.mjs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export function compareOrdinal(left, right) {
+    if (left < right) return -1;
+    if (left > right) return 1;
+    return 0;
+}
+
+export function sortedOrdinal(values) {
+    return [...values].sort(compareOrdinal);
+}

--- a/tooling/catalog-v2-validation.mjs
+++ b/tooling/catalog-v2-validation.mjs
@@ -11,6 +11,7 @@ import {
     realpathSync,
 } from "node:fs";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { compareOrdinal, sortedOrdinal } from "./catalog-ordering.mjs";
 import {
     defaultRepositoryRoot,
     readCatalog,
@@ -26,6 +27,10 @@ export const v2CatalogPaths = {
     evidence: "catalog/v2/evidence.json",
     productCoverage: "catalog/v2/product-coverage.json",
     repositoryInventory: "catalog/v2/repository-inventory.json",
+    taxonomy: "catalog/v2/taxonomy.json",
+    sourceContracts: "catalog/v2/source-contracts.json",
+    bundles: "catalog/v2/bundles.json",
+    upstreamCompanions: "catalog/v2/upstream-companions.json",
 };
 
 export const v2SchemaPath = "catalog/schemas/v2/catalog-v2.schema.json";
@@ -38,6 +43,10 @@ const schemaDefinitionByCatalog = {
     evidence: "evidenceCatalog",
     productCoverage: "productCoverageCatalog",
     repositoryInventory: "repositoryInventoryCatalog",
+    taxonomy: "taxonomyCatalog",
+    sourceContracts: "sourceContractsCatalog",
+    bundles: "bundlesCatalog",
+    upstreamCompanions: "upstreamCompanionsCatalog",
 };
 
 function duplicates(values) {
@@ -50,7 +59,7 @@ function duplicates(values) {
 }
 
 function sorted(values) {
-    return [...values].sort((left, right) => left.localeCompare(right));
+    return sortedOrdinal(values);
 }
 
 function equalStringSets(left, right) {
@@ -106,28 +115,94 @@ function listRegularSourceFiles(root, sourcePath) {
     return sorted(files);
 }
 
+const revisionSnapshots = new Map();
+
+function readRevisionBlobs(root, objectIds) {
+    if (objectIds.length === 0) return new Map();
+    const output = execFileSync("git", ["cat-file", "--batch"], {
+        cwd: root,
+        encoding: null,
+        input: `${objectIds.join("\n")}\n`,
+        maxBuffer: 128 * 1024 * 1024,
+        stdio: ["pipe", "pipe", "pipe"],
+    });
+    const blobs = new Map();
+    let offset = 0;
+    for (const expectedId of objectIds) {
+        const newline = output.indexOf(10, offset);
+        if (newline < 0)
+            throw new Error("Git returned an incomplete blob header");
+        const header = output.subarray(offset, newline).toString("utf8");
+        const [objectId, type, sizeText] = header.split(" ");
+        const size = Number(sizeText);
+        if (
+            objectId !== expectedId ||
+            type !== "blob" ||
+            !Number.isSafeInteger(size) ||
+            size < 0
+        ) {
+            throw new Error(`Git returned an invalid blob header: ${header}`);
+        }
+        const start = newline + 1;
+        const end = start + size;
+        if (end >= output.length || output[end] !== 10)
+            throw new Error(`Git returned an incomplete blob: ${objectId}`);
+        blobs.set(objectId, output.subarray(start, end));
+        offset = end + 1;
+    }
+    if (offset !== output.length)
+        throw new Error("Git returned unexpected trailing blob data");
+    return blobs;
+}
+
+function revisionSnapshot(root, revision) {
+    const key = `${realpathSync(root)}\0${revision}`;
+    const cached = revisionSnapshots.get(key);
+    if (cached) return cached;
+    const treeOutput = execFileSync(
+        "git",
+        ["ls-tree", "-r", "-z", revision],
+        {
+            cwd: root,
+            encoding: "utf8",
+            maxBuffer: 32 * 1024 * 1024,
+            stdio: ["ignore", "pipe", "pipe"],
+        },
+    );
+    const entries = treeOutput
+        .split("\0")
+        .filter(Boolean)
+        .map((entry) => {
+            const match = entry.match(
+                /^(?<mode>[0-7]+) blob (?<objectId>[a-f0-9]+)\t(?<path>.+)$/,
+            );
+            if (!match?.groups)
+                throw new Error(`Git returned an invalid tree entry: ${entry}`);
+            return match.groups;
+        });
+    const objectIds = [...new Set(entries.map((entry) => entry.objectId))];
+    const blobs = readRevisionBlobs(root, objectIds);
+    const files = new Map(
+        entries.map((entry) => [entry.path, blobs.get(entry.objectId)]),
+    );
+    const snapshot = { files };
+    revisionSnapshots.set(key, snapshot);
+    return snapshot;
+}
+
 function revisionSourceFiles(root, revision, sourcePath) {
     return sorted(
-        execFileSync(
-            "git",
-            ["ls-tree", "-r", "--name-only", "-z", revision, "--", sourcePath],
-            {
-                cwd: root,
-                encoding: "utf8",
-                stdio: ["ignore", "pipe", "pipe"],
-            },
-        )
-            .split("\0")
-            .filter(Boolean),
+        [...revisionSnapshot(root, revision).files.keys()].filter(
+            (path) => path.startsWith(`${sourcePath}/`),
+        ),
     );
 }
 
 function revisionFile(root, revision, path) {
-    return execFileSync("git", ["show", `${revision}:${path}`], {
-        cwd: root,
-        encoding: null,
-        stdio: ["ignore", "pipe", "pipe"],
-    });
+    const content = revisionSnapshot(root, revision).files.get(path);
+    if (!content)
+        throw new Error(`Source revision does not contain ${path}`);
+    return content;
 }
 
 export function validateSources(catalogs, root) {
@@ -226,6 +301,52 @@ function approvalFields() {
     return ["reviewer", "approvedOn", "sourceRevision", "contentDigest"];
 }
 
+function taxonomyIds(catalogs, dimension) {
+    return new Set(
+        catalogs.taxonomy.dimensions[dimension].map((entry) => entry.id),
+    );
+}
+
+export function graphHasCycle(adjacency) {
+    const nodes = new Set(adjacency.keys());
+    for (const dependencies of adjacency.values()) {
+        for (const dependency of dependencies) nodes.add(dependency);
+    }
+    const incoming = new Map([...nodes].map((node) => [node, 0]));
+    for (const dependencies of adjacency.values()) {
+        for (const dependency of dependencies)
+            incoming.set(dependency, incoming.get(dependency) + 1);
+    }
+    const pending = [...nodes].filter((node) => incoming.get(node) === 0);
+    let visited = 0;
+    while (pending.length > 0) {
+        const node = pending.pop();
+        visited += 1;
+        for (const dependency of adjacency.get(node) ?? []) {
+            const remaining = incoming.get(dependency) - 1;
+            incoming.set(dependency, remaining);
+            if (remaining === 0) pending.push(dependency);
+        }
+    }
+    return visited !== nodes.size;
+}
+
+function validateApplicability(target, field, knownIds, errors) {
+    const applicability = target[field];
+    if (applicability.state === "applicable") {
+        if (applicability.ids.length === 0)
+            errors.push(`${target.id}: applicable ${field} needs explicit ids`);
+        for (const id of applicability.ids) {
+            if (!knownIds.has(id))
+                errors.push(`${target.id}: unknown ${field} id ${id}`);
+        }
+    } else if (applicability.ids.length > 0) {
+        errors.push(
+            `${target.id}: ${field} ids require applicable state`,
+        );
+    }
+}
+
 export function validateTargets(catalogs) {
     const errors = [];
     const sourceIds = new Set(
@@ -236,10 +357,243 @@ export function validateTargets(catalogs) {
     const evidenceIds = new Set(
         catalogs.evidence.evidence.map((evidence) => evidence.id),
     );
+    const sourceContractsById = new Map(
+        catalogs.sourceContracts.contracts.map((contract) => [
+            contract.id,
+            contract,
+        ]),
+    );
+    const companionIds = new Set(
+        catalogs.upstreamCompanions.companions.map(
+            (companion) => companion.id,
+        ),
+    );
+    const productIds = taxonomyIds(catalogs, "products");
+    const languageIds = taxonomyIds(catalogs, "languages");
+    const architectureIds = taxonomyIds(catalogs, "architectures");
+    const personaIds = taxonomyIds(catalogs, "personas");
+    const surfaceIds = taxonomyIds(catalogs, "surfaces");
+    const repositoryProfileIds = taxonomyIds(
+        catalogs,
+        "repositoryProfiles",
+    );
+    const effectOperationIds = taxonomyIds(catalogs, "effectOperations");
+    const dataClassificationIds = taxonomyIds(
+        catalogs,
+        "dataClassifications",
+    );
     addDuplicateErrors(errors, "targets", targetIdList);
     for (const target of catalogs.targets.targets) {
         if (target.semanticName !== target.id)
             errors.push(`${target.id}: semanticName must equal id`);
+        for (const productId of target.products) {
+            if (!productIds.has(productId))
+                errors.push(`${target.id}: unknown product ${productId}`);
+        }
+        for (const languageId of target.languages) {
+            if (!languageIds.has(languageId))
+                errors.push(`${target.id}: unknown language ${languageId}`);
+        }
+        validateApplicability(
+            target,
+            "architectures",
+            architectureIds,
+            errors,
+        );
+        validateApplicability(target, "personas", personaIds, errors);
+        validateApplicability(target, "surfaces", surfaceIds, errors);
+        validateApplicability(
+            target,
+            "repositoryProfiles",
+            repositoryProfileIds,
+            errors,
+        );
+        if (
+            (target.trust.class === "executable") !==
+            target.security.executable
+        )
+            errors.push(
+                `${target.id}: trust class must match executable security classification`,
+            );
+        addDuplicateErrors(
+            errors,
+            `${target.id} effects`,
+            target.trust.effects.map((effect) => effect.id),
+        );
+        for (const effect of target.trust.effects) {
+            if (!effectOperationIds.has(effect.operation))
+                errors.push(
+                    `${target.id}: unknown effect operation ${effect.operation}`,
+                );
+            for (const dataClassification of effect.dataClassifications) {
+                if (!dataClassificationIds.has(dataClassification))
+                    errors.push(
+                        `${target.id}: unknown data classification ${dataClassification}`,
+                    );
+            }
+            if (
+                effect.confirmation.required ===
+                (effect.confirmation.timing === "none")
+            ) {
+                errors.push(
+                    `${target.id}: effect confirmation timing contradicts its requirement`,
+                );
+            }
+            if (effect.authorization.required) {
+                if (
+                    effect.authorization.authority === "not-required" ||
+                    effect.authorization.evidenceIds.length === 0
+                ) {
+                    errors.push(
+                        `${target.id}: required effect authorization needs authority and evidence`,
+                    );
+                }
+            } else if (
+                effect.authorization.authority !== "not-required" ||
+                effect.authorization.evidenceIds.length > 0
+            ) {
+                errors.push(
+                    `${target.id}: optional effect authorization must use not-required with no evidence`,
+                );
+            }
+            const requiresEffectConfirmation =
+                [
+                    "create",
+                    "modify",
+                    "delete",
+                    "execute",
+                    "transmit",
+                    "publish",
+                ].includes(effect.operation) ||
+                effect.dataClassifications.includes("credential");
+            if (
+                requiresEffectConfirmation &&
+                (!effect.confirmation.required ||
+                    effect.confirmation.timing === "none")
+            ) {
+                errors.push(
+                    `${target.id}: effect ${effect.id} requires explicit confirmation`,
+                );
+            }
+            if (
+                requiresEffectConfirmation &&
+                !effect.authorization.required
+            ) {
+                errors.push(
+                    `${target.id}: effect ${effect.id} requires explicit authorization`,
+                );
+            }
+            if (
+                ["delete", "transmit", "publish"].includes(
+                    effect.operation,
+                ) && effect.confirmation.timing !== "before-effect"
+            ) {
+                errors.push(
+                    `${target.id}: high-impact effect ${effect.id} requires confirmation before effect`,
+                );
+            }
+            if (effect.reversible && !effect.rollbackOrCompensation)
+                errors.push(
+                    `${target.id}: reversible effect needs rollback or compensation`,
+                );
+        }
+        if (
+            target.security.destructive &&
+            target.trust.assessmentState === "assessed" &&
+            target.trust.effects.length === 0
+        ) {
+            errors.push(
+                `${target.id}: destructive guidance requires an explicit effect assessment`,
+            );
+        }
+        if (
+            target.dependencyClassificationState === "unclassified" &&
+            target.dependencyEdges.length > 0
+        ) {
+            errors.push(
+                `${target.id}: dependency edges require classified state`,
+            );
+        }
+        if (target.dependencyClassificationState === "classified") {
+            const legacyByCategory = new Map([
+                ["target", target.dependencies.targets],
+                ["tool", target.dependencies.externalTools],
+                ["internal-artifact", target.dependencies.internalArtifacts],
+            ]);
+            for (const [category, legacyIds] of legacyByCategory) {
+                const classifiedIds = target.dependencyEdges
+                    .filter((edge) => edge.category === category)
+                    .map((edge) => edge.dependencyId);
+                if (!equalStringSets(legacyIds, classifiedIds))
+                    errors.push(
+                        `${target.id}: classified ${category} dependencies must preserve legacy membership`,
+                    );
+            }
+        }
+        if (
+            target.sourceContractState === "unclassified" &&
+            (target.sourceContractIds.length > 0 ||
+                target.sourceAuthoritySubjects.length > 0)
+        ) {
+            errors.push(
+                `${target.id}: source contracts and subjects require classified state`,
+            );
+        }
+        if (
+            target.sourceContractState === "classified" &&
+            (target.sourceContractIds.length === 0 ||
+                target.sourceAuthoritySubjects.length === 0)
+        ) {
+            errors.push(
+                `${target.id}: classified source authority needs contracts and subjects`,
+            );
+        }
+        const selectedSourceContracts = [];
+        for (const sourceContractId of target.sourceContractIds) {
+            const sourceContract = sourceContractsById.get(sourceContractId);
+            if (!sourceContract) {
+                errors.push(
+                    `${target.id}: unknown source contract ${sourceContractId}`,
+                );
+                continue;
+            }
+            selectedSourceContracts.push(sourceContract);
+            if (
+                !sourceContract.productIds.some((productId) =>
+                    target.products.includes(productId),
+                )
+            ) {
+                errors.push(
+                    `${target.id}: source contract ${sourceContractId} does not cover a target product`,
+                );
+            }
+            if (
+                target.approval.state === "approved" &&
+                (sourceContract.verificationState !== "verified" ||
+                    !sourceContract.distributionInputAllowed)
+            ) {
+                errors.push(
+                    `${target.id}: approved target needs verified distribution source contract ${sourceContractId}`,
+                );
+            }
+        }
+        if (target.sourceContractState === "classified") {
+            for (const productId of target.products) {
+                for (const subject of target.sourceAuthoritySubjects) {
+                    if (
+                        !selectedSourceContracts.some(
+                            (contract) =>
+                                contract.productIds.includes(productId) &&
+                                contract.subjectKinds.includes(subject),
+                        )
+                    ) {
+                        errors.push(
+                            `${target.id}: source authority does not cover ${productId}/${subject}`,
+                        );
+                    }
+                }
+            }
+        }
         for (const sourceId of target.sourceSkillIds) {
             if (!sourceIds.has(sourceId))
                 errors.push(`${target.id}: unknown source ${sourceId}`);
@@ -260,12 +614,113 @@ export function validateTargets(catalogs) {
                     `${target.id}: unknown target dependency ${dependency}`,
                 );
         }
+        addDuplicateErrors(
+            errors,
+            `${target.id} dependency edges`,
+            target.dependencyEdges.map(
+                (edge) => `${edge.category}:${edge.dependencyId}`,
+            ),
+        );
+        for (const edge of target.dependencyEdges) {
+            if (companionIds.has(edge.dependencyId))
+                errors.push(
+                    `${target.id}: upstream companion cannot satisfy a dependency`,
+                );
+            if (
+                edge.category === "target" &&
+                !targetIds.has(edge.dependencyId)
+            )
+                errors.push(
+                    `${target.id}: unknown dependency edge target ${edge.dependencyId}`,
+                );
+            if (edge.category === "target" && edge.dependencyId === target.id)
+                errors.push(`${target.id}: dependency edge cannot target itself`);
+            const action = edge.missingBehavior.action;
+            const validAction =
+                (edge.strength === "hard" && action === "block") ||
+                (edge.strength === "soft" &&
+                    ["degrade", "substitute"].includes(action)) ||
+                (edge.strength === "optional" && action === "omit");
+            if (!validAction)
+                errors.push(
+                    `${target.id}: ${edge.strength} dependency has invalid ${action} behavior`,
+                );
+            if (action === "substitute") {
+                const substitute =
+                    edge.missingBehavior.substituteDependencyId;
+                if (!substitute)
+                    errors.push(
+                        `${target.id}: substitute dependency needs a substitute id`,
+                    );
+                if (substitute && companionIds.has(substitute))
+                    errors.push(
+                        `${target.id}: upstream companion cannot be a dependency substitute`,
+                    );
+                if (substitute === edge.dependencyId)
+                    errors.push(
+                        `${target.id}: substitute dependency cannot select the missing dependency`,
+                    );
+                if (
+                    edge.category === "target" &&
+                    substitute &&
+                    !targetIds.has(substitute)
+                )
+                    errors.push(
+                        `${target.id}: substitute dependency needs a known target`,
+                    );
+                if (edge.category === "target" && substitute === target.id)
+                    errors.push(
+                        `${target.id}: substitute dependency cannot select itself`,
+                    );
+            } else if (edge.missingBehavior.substituteDependencyId) {
+                errors.push(
+                    `${target.id}: substitute id requires substitute behavior`,
+                );
+            }
+        }
         if (target.approval.state !== "approved" && target.includeInRuntime) {
             errors.push(
                 `${target.id}: only approved targets can enter runtime`,
             );
         }
         if (target.approval.state === "approved") {
+            if (target.capabilityKind === "unclassified")
+                errors.push(`${target.id}: approved target needs capability kind`);
+            if (target.invocation === "unclassified")
+                errors.push(`${target.id}: approved target needs invocation`);
+            if (target.lifecycle !== "approved")
+                errors.push(`${target.id}: approved target needs approved lifecycle`);
+            for (const field of [
+                "architectures",
+                "personas",
+                "surfaces",
+                "repositoryProfiles",
+            ]) {
+                if (target[field].state === "unclassified")
+                    errors.push(
+                        `${target.id}: approved target needs classified ${field}`,
+                    );
+            }
+            if (target.trust.assessmentState !== "assessed")
+                errors.push(
+                    `${target.id}: approved target needs assessed trust and effects`,
+                );
+            if (target.dependencyClassificationState !== "classified")
+                errors.push(
+                    `${target.id}: approved target needs classified dependencies`,
+                );
+            if (target.sourceContractState !== "classified")
+                errors.push(
+                    `${target.id}: approved target needs classified source contracts`,
+                );
+            if (
+                target.audience === "public" &&
+                target.dependencies.internalArtifacts.length > 0
+            ) {
+                errors.push(
+                    `${target.id}: approved public target cannot depend on internal artifacts`,
+                );
+            }
             for (const field of approvalFields(target.approval)) {
                 if (!target.approval[field])
                     errors.push(
@@ -301,10 +756,22 @@ export function validateTargets(catalogs) {
                     `${target.id}: approved target must explicitly enter runtime`,
                 );
         }
+        if (
+            target.approval.state !== "approved" &&
+            target.lifecycle === "approved"
+        ) {
+            errors.push(
+                `${target.id}: approved lifecycle requires target approval`,
+            );
+        }
         for (const evidenceId of [
             ...target.evidenceIds,
             ...target.approval.evidenceIds,
             ...target.security.evidenceIds,
+            ...target.trust.effects.flatMap((effect) => [
+                ...effect.evidenceIds,
+                ...effect.authorization.evidenceIds,
+            ]),
             ...Object.values(target.evaluations).flatMap(
                 (evaluation) => evaluation.evidenceIds,
             ),
@@ -313,6 +780,36 @@ export function validateTargets(catalogs) {
                 errors.push(`${target.id}: unknown evidence ${evidenceId}`);
         }
     }
+    const hardDependencies = new Map(
+        catalogs.targets.targets.map((target) => [
+            target.id,
+            target.dependencyEdges
+                .filter(
+                    (edge) =>
+                        edge.category === "target" && edge.strength === "hard",
+                )
+                .map((edge) => edge.dependencyId),
+        ]),
+    );
+    if (graphHasCycle(hardDependencies))
+        errors.push("hard target dependencies must form a directed acyclic graph");
+    const substitutes = new Map(
+        catalogs.targets.targets.map((target) => [
+            target.id,
+            target.dependencyEdges
+                .filter(
+                    (edge) =>
+                        edge.category === "target" &&
+                        edge.missingBehavior.action === "substitute",
+                )
+                .map(
+                    (edge) =>
+                        edge.missingBehavior.substituteDependencyId,
+                ),
+        ]),
+    );
+    if (graphHasCycle(substitutes))
+        errors.push("substitute target dependencies must not cycle");
     return errors;
 }
 
@@ -338,6 +835,23 @@ export function validateMigrations(catalogs) {
     addDuplicateErrors(errors, "migration source accounting", migratedSources);
     if (!equalStringSets(migratedSources, sourceIds))
         errors.push("migrations must account for every source exactly once");
+    const migratedTargets = catalogs.migrations.migrations.flatMap(
+        (migration) => migration.targetIds,
+    );
+    addDuplicateErrors(errors, "migration target accounting", migratedTargets);
+    if (!equalStringSets(migratedTargets, targetIds))
+        errors.push("migrations must produce every target exactly once");
+    const targetSources = new Map();
+    for (const migration of catalogs.migrations.migrations) {
+        for (const targetId of migration.targetIds)
+            targetSources.set(targetId, migration.sourceIds);
+    }
+    for (const target of catalogs.targets.targets) {
+        if (!equalStringSets(target.sourceSkillIds, targetSources.get(target.id) ?? []))
+            errors.push(
+                `${target.id}: target source skills must equal its migration inputs`,
+            );
+    }
     for (const migration of catalogs.migrations.migrations) {
         for (const sourceId of migration.sourceIds) {
             if (!sourceIds.has(sourceId))
@@ -533,6 +1047,255 @@ export function validateEvidenceAndCoverage(
     return errors;
 }
 
+export function validateTaxonomy(catalogs) {
+    const errors = [];
+    const fixedDimensions = new Map([
+        [
+            "capabilityKinds",
+            ["primitive", "router", "journey", "gate", "explanation", "adapter"],
+        ],
+        ["invocations", ["user", "model", "both"]],
+        ["trustClasses", ["passive", "executable"]],
+        [
+            "effectOperations",
+            ["read", "create", "modify", "delete", "execute", "transmit", "publish"],
+        ],
+        ["dependencyStrengths", ["hard", "soft", "optional"]],
+        [
+            "missingDependencyActions",
+            ["block", "degrade", "omit", "substitute"],
+        ],
+    ]);
+    for (const [dimension, entries] of Object.entries(
+        catalogs.taxonomy.dimensions,
+    )) {
+        const ids = entries.map((entry) => entry.id);
+        addDuplicateErrors(errors, `taxonomy ${dimension}`, ids);
+        const expected = fixedDimensions.get(dimension);
+        if (expected && !equalStringSets(ids, expected))
+            errors.push(
+                `taxonomy ${dimension} must match the closed contract`,
+            );
+    }
+    return errors;
+}
+
+export function validateSourceContracts(catalogs) {
+    const errors = [];
+    const evidenceById = new Map(
+        catalogs.evidence.evidence.map((evidence) => [evidence.id, evidence]),
+    );
+    const evidenceIds = new Set(evidenceById.keys());
+    const productIds = taxonomyIds(catalogs, "products");
+    addDuplicateErrors(
+        errors,
+        "source contracts",
+        catalogs.sourceContracts.contracts.map((contract) => contract.id),
+    );
+    const verifiedAuthority = new Map();
+    for (const contract of catalogs.sourceContracts.contracts) {
+        if (!contract.repositoryUrl.startsWith("https://"))
+            errors.push(`${contract.id}: repository URL must use HTTPS`);
+        for (const productId of contract.productIds) {
+            if (!productIds.has(productId))
+                errors.push(`${contract.id}: unknown product ${productId}`);
+            for (const subjectKind of contract.subjectKinds) {
+                if (contract.verificationState !== "verified") continue;
+                const key = `${productId}/${subjectKind}`;
+                const existing = verifiedAuthority.get(key);
+                if (existing)
+                    errors.push(
+                        `${contract.id}: verified authority overlaps ${existing} for ${key}`,
+                    );
+                verifiedAuthority.set(key, contract.id);
+            }
+        }
+        if (contract.verificationState === "verified") {
+            for (const field of [
+                "immutableRevision",
+                "verifiedOn",
+                "contentDigest",
+            ]) {
+                if (!contract[field])
+                    errors.push(
+                        `${contract.id}: verified source contract is missing ${field}`,
+                    );
+            }
+            const revisionBoundEvidence = contract.evidenceIds.some(
+                (evidenceId) => {
+                    const evidence = evidenceById.get(evidenceId);
+                    return (
+                        evidence?.officialUrl.startsWith(
+                            contract.repositoryUrl,
+                        ) &&
+                        evidence.immutableRevision ===
+                            contract.immutableRevision &&
+                        evidence.digest === contract.contentDigest
+                    );
+                },
+            );
+            if (!revisionBoundEvidence)
+                errors.push(
+                    `${contract.id}: verified source contract lacks revision-bound evidence`,
+                );
+        }
+        if (
+            contract.distributionInputAllowed &&
+            contract.verificationState !== "verified"
+        ) {
+            errors.push(
+                `${contract.id}: only verified source contracts can supply distribution input`,
+            );
+        }
+        for (const evidenceId of contract.evidenceIds) {
+            if (!evidenceIds.has(evidenceId))
+                errors.push(`${contract.id}: unknown evidence ${evidenceId}`);
+        }
+    }
+    return errors;
+}
+
+export function validateBundles(catalogs) {
+    const errors = [];
+    const evidenceIds = new Set(
+        catalogs.evidence.evidence.map((evidence) => evidence.id),
+    );
+    const targetsById = new Map(
+        catalogs.targets.targets.map((target) => [target.id, target]),
+    );
+    addDuplicateErrors(
+        errors,
+        "bundles",
+        catalogs.bundles.bundles.map((bundle) => bundle.id),
+    );
+    for (const bundle of catalogs.bundles.bundles) {
+        const selectedTargetIds = [
+            ...bundle.rootTargetIds,
+            ...bundle.selectedSoftOrOptionalTargetIds,
+        ];
+        if (new Set(selectedTargetIds).size !== selectedTargetIds.length)
+            errors.push(`${bundle.id}: target selection contains duplicates`);
+        const selectedTargets = new Set(selectedTargetIds);
+        for (const targetId of selectedTargetIds) {
+            const target = targetsById.get(targetId);
+            if (!target) {
+                errors.push(`${bundle.id}: unknown target ${targetId}`);
+                continue;
+            }
+            if (bundle.audience === "public" && target.audience !== "public")
+                errors.push(
+                    `${bundle.id}: public bundle cannot select engineering target ${targetId}`,
+                );
+        }
+        for (const targetId of selectedTargetIds) {
+            const target = targetsById.get(targetId);
+            if (target?.dependencyClassificationState !== "classified")
+                continue;
+            for (const edge of target.dependencyEdges) {
+                if (
+                    edge.category === "target" &&
+                    edge.strength === "hard" &&
+                    !selectedTargets.has(edge.dependencyId)
+                ) {
+                    errors.push(
+                        `${bundle.id}: missing hard dependency ${edge.dependencyId} for ${targetId}`,
+                    );
+                }
+            }
+        }
+        const optionalCandidates = new Set();
+        const visited = new Set();
+        const pending = [...bundle.rootTargetIds];
+        while (pending.length > 0) {
+            const targetId = pending.pop();
+            if (visited.has(targetId)) continue;
+            visited.add(targetId);
+            const target = targetsById.get(targetId);
+            if (target?.dependencyClassificationState !== "classified")
+                continue;
+            for (const edge of target.dependencyEdges) {
+                if (edge.category !== "target") continue;
+                if (edge.strength === "hard") {
+                    if (selectedTargets.has(edge.dependencyId))
+                        pending.push(edge.dependencyId);
+                } else {
+                    optionalCandidates.add(edge.dependencyId);
+                }
+            }
+        }
+        for (const targetId of bundle.selectedSoftOrOptionalTargetIds) {
+            if (!optionalCandidates.has(targetId))
+                errors.push(
+                    `${bundle.id}: selected optional target ${targetId} is not reachable from bundle roots`,
+                );
+        }
+        if (bundle.publishable) {
+            if (bundle.state !== "approved")
+                errors.push(`${bundle.id}: publishable bundle must be approved`);
+            if (bundle.missingCapabilityIds.length > 0)
+                errors.push(
+                    `${bundle.id}: publishable bundle cannot retain capability gaps`,
+                );
+            for (const targetId of [
+                ...bundle.rootTargetIds,
+                ...bundle.selectedSoftOrOptionalTargetIds,
+            ]) {
+                const target = targetsById.get(targetId);
+                if (
+                    !target ||
+                    target.approval.state !== "approved" ||
+                    !target.includeInRuntime
+                ) {
+                    errors.push(
+                        `${bundle.id}: publishable bundle contains unapproved target ${targetId}`,
+                    );
+                }
+            }
+        }
+        for (const evidenceId of bundle.evidenceIds) {
+            if (!evidenceIds.has(evidenceId))
+                errors.push(`${bundle.id}: unknown evidence ${evidenceId}`);
+        }
+    }
+    return errors;
+}
+
+export function validateUpstreamCompanions(catalogs) {
+    const errors = [];
+    const evidenceIds = new Set(
+        catalogs.evidence.evidence.map((evidence) => evidence.id),
+    );
+    const targetIds = new Set(
+        catalogs.targets.targets.map((target) => target.id),
+    );
+    addDuplicateErrors(
+        errors,
+        "upstream companions",
+        catalogs.upstreamCompanions.companions.map((companion) => companion.id),
+    );
+    for (const companion of catalogs.upstreamCompanions.companions) {
+        if (targetIds.has(companion.id))
+            errors.push(
+                `${companion.id}: companion id cannot equal a Cratis target id`,
+            );
+        if (!companion.upstreamUrl.startsWith("https://"))
+            errors.push(`${companion.id}: upstream URL must use HTTPS`);
+        if (companion.expiresOn < catalogs.evidence.asOf)
+            errors.push(`${companion.id}: companion review has expired`);
+        for (const targetId of companion.knownCollisionTargetIds) {
+            if (!targetIds.has(targetId))
+                errors.push(
+                    `${companion.id}: unknown collision target ${targetId}`,
+                );
+        }
+        for (const evidenceId of companion.evidenceIds) {
+            if (!evidenceIds.has(evidenceId))
+                errors.push(`${companion.id}: unknown evidence ${evidenceId}`);
+        }
+    }
+    return errors;
+}
+
 export function validateArtifacts(catalogs) {
     const errors = [];
     const decision = catalogs.artifacts.distributionDecision;
@@ -661,7 +1424,7 @@ function indexDigest(root, excludedPaths) {
             const separator = entry.indexOf("\t");
             return separator >= 0 && !excluded.has(entry.slice(separator + 1));
         })
-        .sort((left, right) => left.localeCompare(right));
+        .sort(compareOrdinal);
     const hash = createHash("sha256");
     for (const entry of entries) {
         hash.update(entry);
@@ -695,7 +1458,9 @@ function changesSinceBase(root, baseRevision) {
         if (!path) throw new Error("Git returned an incomplete change record");
         changes.push({ path, status });
     }
-    return changes.sort((left, right) => left.path.localeCompare(right.path));
+    return changes.sort((left, right) =>
+        compareOrdinal(left.path, right.path),
+    );
 }
 
 export function expandInventoryRecord(record, universe) {
@@ -758,6 +1523,7 @@ export function validateRepositoryInventory(catalogs, root) {
             );
     }
     const universe = [...tracked, ...inventory.admittedUntracked];
+    const universeSet = new Set(universe);
     const assignments = new Map();
     for (const record of inventory.records) {
         const paths = expandInventoryRecord(record, universe);
@@ -792,7 +1558,7 @@ export function validateRepositoryInventory(catalogs, root) {
             );
     }
     for (const path of assignments.keys()) {
-        if (!universe.includes(path))
+        if (!universeSet.has(path))
             errors.push(
                 `repository inventory expanded path outside the repository universe: ${path}`,
             );
@@ -825,10 +1591,14 @@ export function validateV2Catalogs(root = defaultRepositoryRoot) {
         );
     }
     if (errors.length > 0) return errors;
+    errors.push(...validateTaxonomy(catalogs));
     errors.push(...validateSources(catalogs, root));
     errors.push(...validateTargets(catalogs));
     errors.push(...validateMigrations(catalogs));
     errors.push(...validateEvidenceAndCoverage(catalogs));
+    errors.push(...validateSourceContracts(catalogs));
+    errors.push(...validateBundles(catalogs));
+    errors.push(...validateUpstreamCompanions(catalogs));
     errors.push(...validateArtifacts(catalogs));
     errors.push(...validateRepositoryInventory(catalogs, root));
     return errors;

--- a/tooling/generate-catalog-v2.mjs
+++ b/tooling/generate-catalog-v2.mjs
@@ -13,6 +13,7 @@ import {
 } from "node:fs";
 import { join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { compareOrdinal } from "./catalog-ordering.mjs";
 import { readCatalog } from "./catalog-validation.mjs";
 
 const repositoryRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
@@ -558,7 +559,7 @@ function listFiles(root, current = root) {
                 `Source capability contains a non-regular path: ${relative(repositoryRoot, path)}`,
             );
     }
-    return files.sort();
+    return files.sort(compareOrdinal);
 }
 
 function digestFiles(paths) {
@@ -606,7 +607,7 @@ const internalNames = new Set(internalTargets.keys());
 const allSkillNames = [
     ...v1Public.skills.map((skill) => skill.currentName),
     ...internalTargets.keys(),
-].sort();
+].sort(compareOrdinal);
 const sources = allSkillNames.map((name) => {
     const path = `.ai/skills/${name}`;
     const files = listFiles(join(repositoryRoot, path));
@@ -645,7 +646,15 @@ const v1BySource = new Map(
 );
 const allTargetIds = [
     ...new Set([...targetIdsBySource.values()].flat()),
-].sort();
+].sort(compareOrdinal);
+function unclassifiedApplicability(dimension) {
+    return {
+        state: "unclassified",
+        ids: [],
+        reason: `${dimension} requires reviewed target classification.`,
+    };
+}
+
 const targets = allTargetIds.map((targetId) => {
     const profile = profiles[targetId];
     if (!profile) throw new Error(`Missing target profile: ${targetId}`);
@@ -658,10 +667,10 @@ const targets = allTargetIds.map((targetId) => {
         .filter(Boolean);
     const products = [
         ...new Set(sourceEntries.flatMap((entry) => entry.products)),
-    ].sort();
+    ].sort(compareOrdinal);
     const languages = [
         ...new Set(sourceEntries.flatMap((entry) => entry.languages)),
-    ].sort();
+    ].sort(compareOrdinal);
     const targetDependencies = [
         ...new Set(
             sourceEntries
@@ -670,19 +679,19 @@ const targets = allTargetIds.map((targetId) => {
         ),
     ]
         .filter((dependency) => dependency !== targetId)
-        .sort();
+        .sort(compareOrdinal);
     const internalArtifacts = [
         ...new Set(
             sourceEntries.flatMap(
                 (entry) => entry.dependencies.internalArtifacts,
             ),
         ),
-    ].sort();
+    ].sort(compareOrdinal);
     const externalTools = [
         ...new Set(
             sourceEntries.flatMap((entry) => entry.dependencies.externalTools),
         ),
-    ].sort();
+    ].sort(compareOrdinal);
     const hasLegacyBehaviorEvals = sourceSkillIds.some((source) =>
         existsSync(join(repositoryRoot, `.ai/skills/${source}/evals`)),
     );
@@ -694,6 +703,23 @@ const targets = allTargetIds.map((targetId) => {
         audience: publicTarget ? "public" : "cratis-engineering",
         products: publicTarget ? products : ["cratis-engineering"],
         languages: publicTarget ? languages : ["language-agnostic"],
+        capabilityKind: "unclassified",
+        invocation: "unclassified",
+        lifecycle: "candidate",
+        architectures: unclassifiedApplicability("Architecture"),
+        personas: unclassifiedApplicability("Persona"),
+        surfaces: unclassifiedApplicability("Surface"),
+        repositoryProfiles: unclassifiedApplicability("Repository profile"),
+        trust: {
+            class: "passive",
+            assessmentState: "unclassified",
+            effects: [],
+        },
+        dependencyClassificationState: "unclassified",
+        dependencyEdges: [],
+        sourceContractState: "unclassified",
+        sourceContractIds: [],
+        sourceAuthoritySubjects: [],
         capability: profile[0],
         positiveTriggerIntent: profile[1],
         nearMissExclusions: profile[2],
@@ -798,7 +824,7 @@ for (const [source, target] of internalTargets) {
         evidenceIds: ["reevaluation-authority"],
     });
 }
-migrations.sort((left, right) => left.id.localeCompare(right.id));
+migrations.sort((left, right) => compareOrdinal(left.id, right.id));
 writeJson("migrations.json", {
     schemaVersion: 2,
     generatedBy: "tooling/generate-catalog-v2.mjs",
@@ -962,6 +988,33 @@ const evidence = [
         digest: digestFile("AI-REPOSITORY-REDESIGN-REEVALUATION.md"),
     },
     {
+        id: "ecosystem-use-cases",
+        officialUrl: "https://github.com/Cratis/AI",
+        sourceKind: "local-evidence-report",
+        verifiedOn: "2026-08-20",
+        expiresOn: "2026-11-18",
+        applicableVersion: "content-digest-bound",
+        confidence: "medium",
+        repositoryPath: "AI-REPOSITORY-REDESIGN-ECOSYSTEM-USE-CASES.md",
+        digest: digestFile(
+            "AI-REPOSITORY-REDESIGN-ECOSYSTEM-USE-CASES.md",
+        ),
+    },
+    {
+        id: "third-party-skills-evaluation",
+        officialUrl: "https://github.com/Cratis/AI",
+        sourceKind: "local-evidence-report",
+        verifiedOn: "2026-08-20",
+        expiresOn: "2026-11-18",
+        applicableVersion: "content-digest-bound",
+        confidence: "medium",
+        repositoryPath:
+            "AI-REPOSITORY-REDESIGN-THIRD-PARTY-SKILLS-EVALUATION.md",
+        digest: digestFile(
+            "AI-REPOSITORY-REDESIGN-THIRD-PARTY-SKILLS-EVALUATION.md",
+        ),
+    },
+    {
         id: "option-a-plus-authority",
         officialUrl:
             "https://github.com/Cratis/Workflows/issues/68#issuecomment-5363284054",
@@ -1034,7 +1087,7 @@ const coverageProducts = v1Coverage.products.map((product) => {
                         (source) => targetIdsBySource.get(source) ?? [],
                     ),
                 ),
-            ].sort(),
+            ].sort(compareOrdinal),
             evidenceIds: ["repo-main-b795d53", "reevaluation-authority"],
         };
         if (capability.notes) record.notes = capability.notes;

--- a/tooling/generate-repository-inventory.mjs
+++ b/tooling/generate-repository-inventory.mjs
@@ -7,6 +7,7 @@ import { execFileSync } from "node:child_process";
 import { writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { compareOrdinal, sortedOrdinal } from "./catalog-ordering.mjs";
 import { readCatalog } from "./catalog-validation.mjs";
 import { expandInventoryRecord } from "./catalog-v2-validation.mjs";
 
@@ -32,7 +33,7 @@ function gitPaths(args) {
 function pathDigest(paths) {
     return createHash("sha256")
         .update(
-            `${[...paths].sort((left, right) => left.localeCompare(right)).join("\n")}\n`,
+            `${sortedOrdinal(paths).join("\n")}\n`,
         )
         .digest("hex");
 }
@@ -44,7 +45,7 @@ function indexDigest(excludedPaths) {
             const separator = entry.indexOf("\t");
             return separator >= 0 && !excluded.has(entry.slice(separator + 1));
         })
-        .sort((left, right) => left.localeCompare(right));
+        .sort(compareOrdinal);
     const hash = createHash("sha256");
     for (const entry of entries) {
         hash.update(entry);
@@ -78,7 +79,9 @@ function changesSinceBase(baseRevision) {
         if (!path) throw new Error("Git returned an incomplete change record");
         changes.push({ path, status });
     }
-    return changes.sort((left, right) => left.path.localeCompare(right.path));
+    return changes.sort((left, right) =>
+        compareOrdinal(left.path, right.path),
+    );
 }
 
 const excludedRuntimePrefixes = [".pi/delegate/", ".pi/fusion/", ".pi/tasks/"];
@@ -93,12 +96,12 @@ const admittedUntracked = gitPaths([
         (path) =>
             !excludedRuntimePrefixes.some((prefix) => path.startsWith(prefix)),
     )
-    .sort();
+    .sort(compareOrdinal);
 const unexpectedUntracked = admittedUntracked.filter(
     (path) =>
         !(
             /^AI-REPOSITORY-REDESIGN-[A-Z0-9-]+\.md$/.test(path) ||
-            /^Documentation\/(?:phase-0-verification|public-product-architecture|skill-classification-audit|project-context-bootstrap|redesign-foundation-validation)\.md$/.test(
+            /^Documentation\/(?:capability-catalog-v2|phase-0-verification|public-product-architecture|skill-classification-audit|project-context-bootstrap|redesign-foundation-validation)\.md$/.test(
                 path,
             ) ||
             /^Documentation\/evidence\/redesign-autonomous-execution-2026-08-20\//.test(
@@ -625,6 +628,25 @@ const definitions = [
         ],
     },
     {
+        id: "capability-model-documentation",
+        sourcePathPatterns: ["Documentation/capability-catalog-v2.md"],
+        artifactType: "documentation",
+        currentOwner: repositoryOwner,
+        targetOwner: repositoryOwner,
+        runtimeEligibility: "repository-only",
+        generatedStatus: "source",
+        adapterStatus: "none",
+        dependencies: [
+            "catalog/v2/bundles.json",
+            "catalog/v2/source-contracts.json",
+            "catalog/v2/taxonomy.json",
+            "catalog/v2/upstream-companions.json",
+        ],
+        risk: "medium",
+        migrationState: "retain",
+        evidenceIds: ["option-a-plus-authority"],
+    },
+    {
         id: "catalog-v1-scaffold",
         sourcePathPatterns: [
             "catalog/ecosystem-versions.json",
@@ -646,8 +668,39 @@ const definitions = [
         evidenceIds: ["reevaluation-authority"],
     },
     {
+        id: "catalog-v2-authored-registries",
+        sourcePathPatterns: [
+            "catalog/v2/bundles.json",
+            "catalog/v2/source-contracts.json",
+            "catalog/v2/taxonomy.json",
+            "catalog/v2/upstream-companions.json",
+        ],
+        artifactType: "catalog-schema",
+        currentOwner: repositoryOwner,
+        targetOwner: repositoryOwner,
+        runtimeEligibility: "repository-only",
+        generatedStatus: "source",
+        adapterStatus: "none",
+        dependencies: [
+            "catalog/schemas/v2/catalog-v2.schema.json",
+            "tooling/catalog-v2-validation.mjs",
+        ],
+        risk: "high",
+        migrationState: "retain",
+        evidenceIds: [
+            "ecosystem-use-cases",
+            "third-party-skills-evaluation",
+        ],
+    },
+    {
         id: "catalog-v2-generated-surfaces",
         sourcePathPatterns: ["catalog/v2/**"],
+        excludePathPatterns: [
+            "catalog/v2/bundles.json",
+            "catalog/v2/source-contracts.json",
+            "catalog/v2/taxonomy.json",
+            "catalog/v2/upstream-companions.json",
+        ],
         artifactType: "catalog-schema",
         currentOwner: repositoryOwner,
         targetOwner: repositoryOwner,

--- a/tooling/specs/catalog-ordering.spec.mjs
+++ b/tooling/specs/catalog-ordering.spec.mjs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { compareOrdinal, sortedOrdinal } from "../catalog-ordering.mjs";
+
+test("catalog ordering is ordinal and independent of process locale", () => {
+    const values = ["z", "Z", "é", "e", "_", "a-10", "a-2"];
+    assert.deepEqual(sortedOrdinal(values), [
+        "Z",
+        "_",
+        "a-10",
+        "a-2",
+        "e",
+        "z",
+        "é",
+    ]);
+    assert.equal(compareOrdinal("same", "same"), 0);
+    assert.equal(compareOrdinal("A", "a"), -1);
+    assert.equal(compareOrdinal("é", "z"), 1);
+});

--- a/tooling/specs/catalog-v2-validation.spec.mjs
+++ b/tooling/specs/catalog-v2-validation.spec.mjs
@@ -11,14 +11,19 @@ import {
     validateSchemaVocabulary,
 } from "../catalog-validation.mjs";
 import {
+    graphHasCycle,
     v2CatalogPaths,
     v2SchemaPath,
     validateArtifacts,
+    validateBundles,
     validateEvidenceAndCoverage,
     validateMigrations,
     validateRepositoryInventory,
+    validateSourceContracts,
     validateSources,
     validateTargets,
+    validateTaxonomy,
+    validateUpstreamCompanions,
     validateV2Catalogs,
 } from "../catalog-v2-validation.mjs";
 
@@ -71,6 +76,48 @@ test("catalog v2 preserves all 43 sources while split and merge targets are inde
     );
 });
 
+test("catalog v2 exposes closed shared taxonomies without broadening targets", () => {
+    const catalogs = loadCatalogs();
+    assert.deepEqual(validateTaxonomy(catalogs), []);
+    const productIds = new Set(
+        catalogs.taxonomy.dimensions.products.map((entry) => entry.id),
+    );
+    const languageIds = new Set(
+        catalogs.taxonomy.dimensions.languages.map((entry) => entry.id),
+    );
+    for (const target of catalogs.targets.targets) {
+        assert(target.products.every((id) => productIds.has(id)));
+        assert(target.languages.every((id) => languageIds.has(id)));
+    }
+});
+
+test("legacy targets remain explicitly unclassified and runtime ineligible", () => {
+    const catalogs = loadCatalogs();
+    for (const target of catalogs.targets.targets) {
+        assert.equal(target.capabilityKind, "unclassified");
+        assert.equal(target.invocation, "unclassified");
+        assert.equal(target.lifecycle, "candidate");
+        assert.equal(target.trust.class, "passive");
+        assert.equal(target.trust.assessmentState, "unclassified");
+        assert.deepEqual(target.trust.effects, []);
+        assert.equal(target.dependencyClassificationState, "unclassified");
+        assert.deepEqual(target.dependencyEdges, []);
+        assert.equal(target.sourceContractState, "unclassified");
+        assert.deepEqual(target.sourceContractIds, []);
+        for (const field of [
+            "architectures",
+            "personas",
+            "surfaces",
+            "repositoryProfiles",
+        ]) {
+            assert.equal(target[field].state, "unclassified");
+            assert.deepEqual(target[field].ids, []);
+        }
+        assert.equal(target.approval.state, "candidate");
+        assert.equal(target.includeInRuntime, false);
+    }
+});
+
 test("source digests remain bound to the current source bytes", () => {
     const catalogs = loadCatalogs();
     catalogs.sources.sources[0].contentDigest = "0".repeat(64);
@@ -113,6 +160,20 @@ test("approval cannot omit revision, digest, reviewer, evaluations, or security 
     target.approval.state = "approved";
     target.includeInRuntime = true;
     const errors = validateTargets(catalogs);
+    for (const requirement of [
+        "needs capability kind",
+        "needs invocation",
+        "needs approved lifecycle",
+        "needs classified architectures",
+        "needs classified personas",
+        "needs classified surfaces",
+        "needs classified repositoryProfiles",
+        "needs assessed trust and effects",
+        "needs classified dependencies",
+        "needs classified source contracts",
+    ]) {
+        assert(errors.some((error) => error.includes(requirement)));
+    }
     for (const field of [
         "reviewer",
         "approvedOn",
@@ -156,6 +217,224 @@ test("duplicate target and migration ids fail semantic validation", () => {
             error.includes("duplicate id"),
         ),
     );
+});
+
+test("migration outputs remain the exact inverse of target source mappings", () => {
+    const catalogs = loadCatalogs();
+    const migration = catalogs.migrations.migrations[0];
+    const removedTarget = migration.targetIds.pop();
+    let errors = validateMigrations(catalogs);
+    assert(errors.some((error) => error.includes("produce every target exactly once")));
+
+    migration.targetIds.push(removedTarget);
+    const target = catalogs.targets.targets.find(
+        (candidate) => candidate.id === removedTarget,
+    );
+    target.sourceSkillIds = [catalogs.sources.sources[0].id];
+    errors = validateMigrations(catalogs);
+    assert(
+        errors.some((error) =>
+            error.includes("target source skills must equal its migration inputs"),
+        ),
+    );
+});
+
+test("applicability, trust, and dependency classifications fail closed", () => {
+    const catalogs = loadCatalogs();
+    const first = catalogs.targets.targets[0];
+    const second = catalogs.targets.targets[1];
+    const third = catalogs.targets.targets[2];
+    first.architectures.state = "applicable";
+    first.architectures.ids = ["missing-architecture"];
+    first.trust.class = "executable";
+    first.trust.assessmentState = "assessed";
+    first.trust.effects = [
+        {
+            id: "fixture-write",
+            operation: "modify",
+            resourceBoundary: "Fixture repository",
+            scope: "Fixture file",
+            dataClassifications: ["credential"],
+            reversible: true,
+            rollbackOrCompensation: "Restore the fixture file.",
+            confirmation: {
+                required: false,
+                timing: "none",
+                reason: "Deliberately invalid fixture.",
+            },
+            authorization: {
+                required: false,
+                authority: "not-required",
+                evidenceIds: [],
+            },
+            evidenceIds: ["reevaluation-authority"],
+        },
+    ];
+    first.dependencyClassificationState = "classified";
+    first.dependencyEdges = [
+        {
+            dependencyId: second.id,
+            category: "target",
+            strength: "hard",
+            reason: "Fixture dependency",
+            missingBehavior: {
+                action: "degrade",
+                description: "Invalid hard dependency behavior.",
+            },
+        },
+        {
+            dependencyId: third.id,
+            category: "target",
+            strength: "soft",
+            reason: "Fixture substitute",
+            missingBehavior: {
+                action: "substitute",
+                description: "Invalid no-op substitution.",
+                substituteDependencyId: third.id,
+            },
+        },
+        {
+            dependencyId: "matt-pocock-skills",
+            category: "tool",
+            strength: "optional",
+            reason: "Invalid companion dependency.",
+            missingBehavior: {
+                action: "omit",
+                description: "Omit the invalid dependency.",
+            },
+        },
+    ];
+    second.dependencyClassificationState = "classified";
+    second.dependencyEdges = [
+        {
+            dependencyId: first.id,
+            category: "target",
+            strength: "hard",
+            reason: "Fixture cycle",
+            missingBehavior: {
+                action: "block",
+                description: "Block when missing.",
+            },
+        },
+    ];
+    const errors = validateTargets(catalogs);
+    assert(errors.some((error) => error.includes("unknown architectures id")));
+    assert(errors.some((error) => error.includes("trust class must match")));
+    assert(errors.some((error) => error.includes("requires explicit confirmation")));
+    assert(errors.some((error) => error.includes("requires explicit authorization")));
+    assert(errors.some((error) => error.includes("invalid degrade behavior")));
+    assert(
+        errors.some((error) =>
+            error.includes("cannot select the missing dependency"),
+        ),
+    );
+    assert(
+        errors.some((error) =>
+            error.includes("upstream companion cannot satisfy a dependency"),
+        ),
+    );
+    assert(
+        errors.some((error) =>
+            error.includes("classified target dependencies must preserve legacy membership"),
+        ),
+    );
+    assert(errors.some((error) => error.includes("directed acyclic graph")));
+});
+
+test("dependency cycle detection handles deep graphs without recursion", () => {
+    const size = 5000;
+    const graph = new Map();
+    for (let index = 0; index < size; index += 1) {
+        graph.set(
+            `target-${index}`,
+            index + 1 < size ? [`target-${index + 1}`] : [],
+        );
+    }
+    assert.equal(graphHasCycle(graph), false);
+    graph.set(`target-${size - 1}`, ["target-0"]);
+    assert.equal(graphHasCycle(graph), true);
+});
+
+test("source contracts cannot become inputs before exact verification", () => {
+    const catalogs = loadCatalogs();
+    const contract = catalogs.sourceContracts.contracts[0];
+    contract.distributionInputAllowed = true;
+    assert(
+        validateSourceContracts(catalogs).some((error) =>
+            error.includes("only verified source contracts"),
+        ),
+    );
+    contract.verificationState = "verified";
+    let errors = validateSourceContracts(catalogs);
+    for (const field of ["immutableRevision", "verifiedOn", "contentDigest"])
+        assert(errors.some((error) => error.includes(`missing ${field}`)));
+    contract.immutableRevision = "0".repeat(40);
+    contract.verifiedOn = "2026-08-20";
+    contract.contentDigest = "0".repeat(64);
+    errors = validateSourceContracts(catalogs);
+    assert(
+        errors.some((error) =>
+            error.includes("lacks revision-bound evidence"),
+        ),
+    );
+});
+
+test("draft bundles cannot imply publication or target approval", () => {
+    const catalogs = loadCatalogs();
+    const bundle = catalogs.bundles.bundles[0];
+    const selected = new Set(bundle.rootTargetIds);
+    const outsideTarget = catalogs.targets.targets.find(
+        (target) => !selected.has(target.id),
+    );
+    const arbitraryOptionalTarget = catalogs.targets.targets.find(
+        (target) =>
+            !selected.has(target.id) && target.id !== outsideTarget.id,
+    );
+    bundle.selectedSoftOrOptionalTargetIds = [arbitraryOptionalTarget.id];
+    const rootTarget = catalogs.targets.targets.find(
+        (target) => target.id === bundle.rootTargetIds[0],
+    );
+    rootTarget.dependencyClassificationState = "classified";
+    rootTarget.dependencyEdges = [
+        {
+            dependencyId: outsideTarget.id,
+            category: "target",
+            strength: "hard",
+            reason: "Fixture hard dependency",
+            missingBehavior: {
+                action: "block",
+                description: "Block when missing.",
+            },
+        },
+    ];
+    bundle.publishable = true;
+    const errors = validateBundles(catalogs);
+    assert(errors.some((error) => error.includes("must be approved")));
+    assert(errors.some((error) => error.includes("unapproved target")));
+    assert(errors.some((error) => error.includes("missing hard dependency")));
+    assert(
+        errors.some((error) =>
+            error.includes("is not reachable from bundle roots"),
+        ),
+    );
+});
+
+test("upstream companions contain metadata but never upstream bytes", () => {
+    const catalogs = loadCatalogs();
+    assert.deepEqual(validateUpstreamCompanions(catalogs), []);
+    assert(
+        catalogs.upstreamCompanions.companions.every(
+            (companion) => companion.bytesIncluded === false,
+        ),
+    );
+    const companions = clone(catalogs.upstreamCompanions);
+    companions.companions[0].bytesIncluded = true;
+    const errors = validateAgainstSchema(
+        companions,
+        schema.$defs.upstreamCompanionsCatalog,
+        schema,
+    );
+    assert(errors.some((error) => error.includes("expected constant false")));
 });
 
 test("unknown properties fail the closed catalog v2 schema", () => {
@@ -220,12 +499,17 @@ test("local evidence reports remain bound to repository bytes", () => {
     );
 });
 
-test("sources, migrations, artifacts, and inventory reject dangling evidence", () => {
+test("all v2 catalog families reject dangling evidence", () => {
     const catalogs = loadCatalogs();
     catalogs.sources.sources[0].evidenceIds.push("missing-evidence");
     catalogs.migrations.migrations[0].evidenceIds.push("missing-evidence");
     catalogs.artifacts.artifacts[0].evidenceIds.push("missing-evidence");
     catalogs.repositoryInventory.records[0].evidenceIds.push(
+        "missing-evidence",
+    );
+    catalogs.sourceContracts.contracts[0].evidenceIds.push("missing-evidence");
+    catalogs.bundles.bundles[0].evidenceIds.push("missing-evidence");
+    catalogs.upstreamCompanions.companions[0].evidenceIds.push(
         "missing-evidence",
     );
     assert(
@@ -246,6 +530,21 @@ test("sources, migrations, artifacts, and inventory reject dangling evidence", (
     assert(
         validateRepositoryInventory(catalogs, defaultRepositoryRoot).some(
             (error) => error.includes("unknown evidence missing-evidence"),
+        ),
+    );
+    assert(
+        validateSourceContracts(catalogs).some((error) =>
+            error.includes("unknown evidence missing-evidence"),
+        ),
+    );
+    assert(
+        validateBundles(catalogs).some((error) =>
+            error.includes("unknown evidence missing-evidence"),
+        ),
+    );
+    assert(
+        validateUpstreamCompanions(catalogs).some((error) =>
+            error.includes("unknown evidence missing-evidence"),
         ),
     );
 });

--- a/tooling/validate-catalogs.mjs
+++ b/tooling/validate-catalogs.mjs
@@ -14,6 +14,6 @@ if (errors.length > 0) {
     process.exitCode = 1;
 } else {
     process.stdout.write(
-        "Catalog validation passed: 3 legacy catalogs, 7 v2 catalogs, and 4 schemas are valid.\n",
+        "Catalog validation passed: 3 legacy catalogs, 11 v2 catalogs, and 4 schemas are valid.\n",
     );
 }


### PR DESCRIPTION
# Summary

Extend catalog v2 with explicit ecosystem, trust, dependency, source-authority, bundle, and upstream-companion contracts while keeping every capability unapproved.

## Added

- Add closed product, language, architecture, persona, surface, repository-profile, trust, effect, and dependency taxonomies. (#126)
- Add fail-closed product/client source contracts and explicit non-publishable review bundles. (Cratis/Workflows#68)
- Add repository-only upstream companion metadata with immutable revisions and `bytesIncluded: false`. (#126)
- Document the capability-model contract and evidence requirements. (#126)

## Changed

- Extend all 43 candidate targets with explicit unclassified invocation, applicability, trust/effects, typed-dependency, and source-contract state. (#126)
- Prevent classification gaps, dependency cycles, unverified sources, candidate bundles, or companion metadata from granting publication or runtime eligibility. (Cratis/Workflows#68)
