### PR TITLE
Add clean-room skill authoring catalog

### DIFF
--- a/.github/workflows/verify-ai-corpus.yml
+++ b/.github/workflows/verify-ai-corpus.yml
@@ -53,8 +53,9 @@ jobs:
         run: |
           set -euo pipefail
           node tooling/generate-catalog-v2.mjs
+          node tooling/generate-human-catalog.mjs
           node tooling/generate-repository-inventory.mjs
-          git diff --exit-code -- catalog/v2
+          git diff --exit-code -- catalog/v2 catalog/generated/human-catalog
 
       - name: Validate catalogs and specifications
         run: |

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
@@ -412,3 +412,100 @@ Exact next actions:
 3. commit and push the coherent capability-model unit, open a separate
    `no-release` pull request, monitor CI, merge, and record the result;
 4. start the separate skill-authoring and generated human-catalog contract PR.
+
+## 17. Skill-authoring and human-catalog checkpoint — 2026-08-21
+
+### Capability-model delivery
+
+Commit `695e5e97b7be6c3bdf9ab9afedd9e7974abf27fb` landed through
+[`Cratis/AI#131`](https://github.com/Cratis/AI/pull/131) with merge commit
+`029de952811f0af07364a65651a7013875210436`. CI passed and `no-release`
+correctly produced no package or product release. The local gate passed 56/56
+Node specifications, catalog validation, generation drift checks, strict JSON
+parsing, Markdown lint, links, LSP, actionlint, diff checks, and protected hash
+comparison. Final independent rereview returned `CLEAR` before commit. AI#126
+and Workflows#68 now record the partial completion. The merged branch/worktree
+was removed through normal cleanup.
+
+### Active authoring branch
+
+The next unit is active in `../AI-authoring-catalog` on
+`feat/skill-authoring-human-catalog`, fast-forwarded to merged `origin/main` at
+`029de952811f0af07364a65651a7013875210436`. It does not author or approve
+runtime skill bytes.
+
+Implemented source so far:
+
+- `catalog/v2/authoring-contracts.json` — active original-expression clean-room
+  Agent Skill contract with source/evidence, payload, similarity, and quality
+  requirements;
+- `catalog/v2/human-catalog.json` — bounded, deterministic, offline generation
+  contract that forbids runtime payload bytes and runtime-permission claims;
+- `Documentation/skill-authoring-contract.md` — human authoring workflow and
+  boundary explanation;
+- `tooling/generate-human-catalog.mjs` — bounded deterministic JSON/Markdown/
+  manifest generator with `--check`, manifest-last activation, and fault-tested
+  recovery without removing the live output directory;
+- `catalog/generated/human-catalog/` — generated metadata-only catalog for all
+  35 public targets, visibly candidate/unclassified/runtime-ineligible, with
+  engineering targets excluded from the public human surface;
+- schema, semantic validation, CI, inventory, and specification updates.
+
+Targets now carry an unclassified authoring-contract state. Approval will
+require the active `cratis-skill-clean-room-v1` contract, in addition to all
+existing source, trust, dependency, evaluation, security, and approval gates.
+Generated views are navigation only and cannot become evidence, source
+authority, authoring input, distribution input, or runtime payload.
+
+Current signals:
+
+- catalog validation: 3 legacy plus 13 v2 catalogs and 4 schemas passed;
+- Node specifications: 66/66 passed after security and interruption tests;
+- generated human catalog: 35 public targets, zero runtime-eligible, three manifested
+  files, deterministic `--check`, stale-extra-file rejection, public-audience
+  isolation, Markdown escaping, manifest-last activation, interruption, and
+  recovery specifications passed;
+- repository inventory: 39 groups over 402 tracked paths with authored and
+  generated catalog surfaces separated;
+- all target authoring-contract fields remain unclassified and approval now
+  requires the active clean-room contract;
+- no runtime skill source, package, plugin, or publication artifact exists.
+
+Exact next actions:
+
+1. run the complete generation-twice, `--check`, catalog/spec/LSP/lint/link/
+   diff/actionlint and protected-hash gates;
+2. run independent correctness, security, performance, and clean-room evidence
+   review;
+3. commit, push, open a `no-release` pull request, monitor CI, merge, and update
+   this handover;
+4. begin the separate clean-room navigator pilot and blind trigger/behavior
+   evaluation unit.
+
+## 18. Navigator pilot design checkpoint — 2026-08-21
+
+A five-model reasoning panel produced the first clean-room pilot design. The
+accepted bounded direction is one passive repository-only router that selects
+the narrowest revision-bound target and never invokes it. It preserves
+project-owned context, separates requested effect from target trust, asks at
+most one route-changing clarification, emits one route by default and at most
+five for explicitly separate tasks, and uses these fail-closed results:
+
+- `ROUTE_SIMULATED` for a verified passive destination;
+- `CLARIFY` for material route ambiguity;
+- `BLOCKED_UNVERIFIED` for absent, stale, conflicting, or malformed evidence;
+- `BLOCKED_EFFECT` for a verified executable destination because the pilot
+  cannot execute;
+- `REFUSE` for bypass, exfiltration, unsafe destruction, or self-promotion;
+- `ABSTAIN` when Cratis intent is not established.
+
+The pilot will live under repository-only `pilots/cratis-navigator/` with evals
+under `evals/cratis-navigator/`, never under a runtime skill path. The planned
+suite contains 12 positive routes, 16 difficult negatives/collisions,
+application/framework/client/corpus fixtures, model-selected and explicit-user
+conditions, baseline comparisons, held-out paraphrases, confusable terms,
+project-context precedence, and zero-tolerance write/network/invocation/
+secret-echo/unsupported-claim assertions. Promotion requires exact safety and
+context results, at least 95% held-out routing behavior, deterministic repeated
+runs, independent originality/security/portability review, and a separate
+runtime-candidacy decision. Passing the pilot grants no runtime approval.

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
@@ -470,10 +470,11 @@ The program is complete only when:
   materialization block.
 - [x] Land the autonomous authority, research, and foundation delivery unit in
   [`Cratis/AI#130`](https://github.com/Cratis/AI/pull/130).
-- [ ] Implement the normalized Phase 1 catalog/schema extensions — active on
-  `feat/catalog-v2-capability-model`.
-- [ ] Implement the skill-authoring and human-catalog contracts in the next
-  independent delivery unit.
+- [x] Implement the normalized Phase 1 catalog/schema extensions — merged in
+  [`Cratis/AI#131`](https://github.com/Cratis/AI/pull/131).
+- [ ] Implement the skill-authoring and human-catalog contracts — active on
+  `feat/skill-authoring-human-catalog` with source and initial generated views
+  implemented.
 
 Evidence and exact next actions are in
-[`AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md`](./AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md#16-capability-model-checkpoint--2026-08-21).
+[`AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md`](./AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md#17-skill-authoring-and-human-catalog-checkpoint--2026-08-21).

--- a/Documentation/skill-authoring-contract.md
+++ b/Documentation/skill-authoring-contract.md
@@ -1,0 +1,69 @@
+# Cratis skill-authoring contract
+
+**Status:** Active authoring gate; not a runtime capability
+
+## Purpose
+
+Cratis skills are authored from authoritative product sources, reviewed target
+metadata, and explicit evidence. Existing skill bodies, generated catalog views,
+third-party prompt text, runtime packages, and model memory are not authority.
+
+The machine-readable contract is
+[`catalog/v2/authoring-contracts.json`](../catalog/v2/authoring-contracts.json).
+The catalog validator fails when its clean-room, evidence, payload, or ownership
+requirements weaken.
+
+## Clean-room workflow
+
+1. Freeze every researched source URL, immutable revision, license, and reviewed
+   path.
+2. Record requirement-level lessons without preserving source wording,
+   headings, sequence, examples, templates, personas, or scripts.
+3. Verify product claims against the owning Cratis product or client repository.
+4. Draft from Cratis terminology, values, artifacts, and scenarios.
+5. Keep one capability and one trigger intent. State realistic near misses and
+   collision targets.
+6. Distinguish framework contracts, Cratis conventions, and downstream product
+   policy.
+7. Give each step observable completion evidence and honest blocked, skipped, or
+   inconclusive outcomes.
+8. Run behavior, positive-trigger, negative-trigger, collision, security,
+   portability, and product-source review.
+9. Run phrase and structural-similarity review. Redesign substantial similarity
+   rather than treating an open-source license as product approval.
+10. Approve an exact source revision and content digest only after every gate
+    passes.
+
+## Allowed output
+
+A future approved public skill may contain:
+
+- `SKILL.md` with `name` and `description` frontmatter;
+- linked, non-executable `references/**`;
+- approved, non-executable `assets/**`;
+- required license or notice files.
+
+Public runtime payloads do not contain evals, scripts, rules, agents, prompts,
+hooks, tooling, project facts, private facts, or unlinked resources. Creating a
+runtime skill remains a separate reviewed delivery; this authoring contract does
+not generate one.
+
+## Human catalog
+
+The human catalog is generated from metadata for navigation. It includes
+candidates and visibly reports unclassified, unapproved, and runtime-ineligible
+states. Generated views cannot become evidence, source authority, an authoring
+input, or a runtime payload.
+
+Run:
+
+```bash
+node tooling/generate-human-catalog.mjs
+node tooling/generate-human-catalog.mjs --check
+```
+
+The generator is deterministic, bounded, and offline. It writes complete
+partial files, publishes data files without removing the live directory, and
+atomically replaces `manifest.json` last as the activation pointer. Readers
+validate manifest hashes before trusting data. Its manifest hashes every
+generated data or Markdown file and does not hash itself.

--- a/catalog/generated/human-catalog/CATALOG.md
+++ b/catalog/generated/human-catalog/CATALOG.md
@@ -1,0 +1,2127 @@
+# Cratis capability catalog
+
+> Catalog inclusion, evaluation evidence, bundle generation, or publication does not grant runtime permission or approval.
+
+This catalog is generated from reviewed catalog metadata. It is a human
+navigation surface, not source authority and not an installation artifact.
+
+## cratis-application-react-specifications
+
+- **ID:** `cratis-application-react-specifications`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-application-react-specifications
+
+Application React specifications
+
+### When to use — cratis-application-react-specifications
+
+Use for React or TypeScript behavior in a Cratis application slice.
+
+### When not to use — cratis-application-react-specifications
+
+- Do not use for backend scenarios.
+- Do not use for framework package TypeScript specs.
+
+### Invocation — cratis-application-react-specifications
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-application-react-specifications
+
+- Products: application, arc-react, specifications
+- Languages: react, typescript
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-application-react-specifications
+
+- Unclassified
+
+### Trust and effects — cratis-application-react-specifications
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-application-react-specifications
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-application-react-specifications
+
+- cratis-application-slice-specifications
+- cratis-arc-react-page
+- cratis-specifications-typescript
+
+### Bundle membership — cratis-application-react-specifications
+
+- cratis-application-full-stack-review
+
+## cratis-application-slice-diagnostics
+
+- **ID:** `cratis-application-slice-diagnostics`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-application-slice-diagnostics
+
+Application slice diagnostics
+
+### When to use — cratis-application-slice-diagnostics
+
+Use when a Cratis slice misbehaves and source-level cause is unclear.
+
+### When not to use — cratis-application-slice-diagnostics
+
+- Do not use for direct live-store operation.
+- Do not use only for observable-query HTTP inspection.
+
+### Invocation — cratis-application-slice-diagnostics
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-application-slice-diagnostics
+
+- Products: application, arc, chronicle
+- Languages: csharp, typescript
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-application-slice-diagnostics
+
+- Unclassified
+
+### Trust and effects — cratis-application-slice-diagnostics
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-application-slice-diagnostics
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-application-slice-diagnostics
+
+- cratis-arc-command
+- cratis-arc-observable-query-http
+- cratis-chronicle-cli-operations
+- cratis-chronicle-projection
+
+### Bundle membership — cratis-application-slice-diagnostics
+
+- cratis-application-full-stack-review
+
+## cratis-application-slice-specifications
+
+- **ID:** `cratis-application-slice-specifications`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-application-slice-specifications
+
+Application slice specifications
+
+### When to use — cratis-application-slice-specifications
+
+Use to route event-sourced application backend behavior to the correct in-process scenario family.
+
+### When not to use — cratis-application-slice-specifications
+
+- Do not use for framework library specifications.
+- Do not use for frontend behavior.
+
+### Invocation — cratis-application-slice-specifications
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-application-slice-specifications
+
+- Products: application, specifications
+- Languages: csharp
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-application-slice-specifications
+
+- Unclassified
+
+### Trust and effects — cratis-application-slice-specifications
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-application-slice-specifications
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-application-slice-specifications
+
+- cratis-chronicle-event-specifications
+- cratis-chronicle-read-model-specifications
+- cratis-specifications-csharp
+
+### Bundle membership — cratis-application-slice-specifications
+
+- cratis-application-full-stack-review
+
+## cratis-application-vertical-slice
+
+- **ID:** `cratis-application-vertical-slice`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-application-vertical-slice
+
+Cratis application vertical slices
+
+### When to use — cratis-application-vertical-slice
+
+Use for vertical-slice architecture selection or end-to-end implementation after the merge experiment passes.
+
+### When not to use — cratis-application-vertical-slice
+
+- Do not assume architecture explanation and implementation triggers are equivalent.
+- Do not use only to scaffold an empty feature shell.
+
+### Invocation — cratis-application-vertical-slice
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-application-vertical-slice
+
+- Products: application
+- Languages: csharp, react, typescript
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-application-vertical-slice
+
+- Unclassified
+
+### Trust and effects — cratis-application-vertical-slice
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-application-vertical-slice
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-application-vertical-slice
+
+- cratis-application-slice-specifications
+- cratis-arc-react-feature-scaffolding
+- cratis-arc-react-page
+- cratis-chronicle-event-modeling
+
+### Bundle membership — cratis-application-vertical-slice
+
+- cratis-application-full-stack-review
+
+## cratis-arc-authentication-authorization-and-identity
+
+- **ID:** `cratis-arc-authentication-authorization-and-identity`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-arc-authentication-authorization-and-identity
+
+Arc authentication, authorization, and identity
+
+### When to use — cratis-arc-authentication-authorization-and-identity
+
+Use for Arc identity providers, endpoint protection, roles, or frontend identity integration.
+
+### When not to use — cratis-arc-authentication-authorization-and-identity
+
+- Do not use for isolated command validation.
+- Do not use for tenant namespaces alone.
+
+### Invocation — cratis-arc-authentication-authorization-and-identity
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-arc-authentication-authorization-and-identity
+
+- Products: arc, arc-react
+- Languages: csharp, react
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-arc-authentication-authorization-and-identity
+
+- Unclassified
+
+### Trust and effects — cratis-arc-authentication-authorization-and-identity
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-arc-authentication-authorization-and-identity
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-arc-authentication-authorization-and-identity
+
+- cratis-arc-command
+- cratis-arc-command-validation
+- cratis-arc-react-page
+- cratis-chronicle-multi-tenancy
+
+### Bundle membership — cratis-arc-authentication-authorization-and-identity
+
+- cratis-arc-backend-review
+
+## cratis-arc-command
+
+- **ID:** `cratis-arc-command`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-arc-command
+
+Arc command definition
+
+### When to use — cratis-arc-command
+
+Use when defining an Arc command and its generated full-stack proxy workflow.
+
+### When not to use — cratis-arc-command
+
+- Do not use for a validation-only change.
+- Do not use only to execute an existing command.
+
+### Invocation — cratis-arc-command
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-arc-command
+
+- Products: application, arc, arc-react
+- Languages: csharp, react
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-arc-command
+
+- Unclassified
+
+### Trust and effects — cratis-arc-command
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-arc-command
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-arc-command
+
+- cratis-arc-command-execution
+- cratis-arc-command-validation
+- cratis-chronicle-event-constraints
+- cratis-fundamentals-concept
+
+### Bundle membership — cratis-arc-command
+
+- cratis-arc-backend-review
+
+## cratis-arc-command-execution
+
+- **ID:** `cratis-arc-command-execution`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-arc-command-execution
+
+Arc command pipeline execution
+
+### When to use — cratis-arc-command-execution
+
+Use when backend code must execute an existing Arc command through ICommandPipeline.
+
+### When not to use — cratis-arc-command-execution
+
+- Do not use for reactor design alone.
+- Do not use to define a command.
+
+### Invocation — cratis-arc-command-execution
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-arc-command-execution
+
+- Products: arc
+- Languages: csharp
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-arc-command-execution
+
+- Unclassified
+
+### Trust and effects — cratis-arc-command-execution
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-arc-command-execution
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-arc-command-execution
+
+- cratis-arc-command
+- cratis-chronicle-reactor
+
+### Bundle membership — cratis-arc-command-execution
+
+- cratis-arc-backend-review
+
+## cratis-arc-command-validation
+
+- **ID:** `cratis-arc-command-validation`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-arc-command-validation
+
+Arc command validation
+
+### When to use — cratis-arc-command-validation
+
+Use when adding validation or state-dependent rejection to an existing Arc command.
+
+### When not to use — cratis-arc-command-validation
+
+- Do not use for append-time Chronicle constraints.
+- Do not use to define a new command.
+
+### Invocation — cratis-arc-command-validation
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-arc-command-validation
+
+- Products: application, arc
+- Languages: csharp
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-arc-command-validation
+
+- Unclassified
+
+### Trust and effects — cratis-arc-command-validation
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-arc-command-validation
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-arc-command-validation
+
+- cratis-arc-command
+- cratis-chronicle-event-constraints
+- cratis-fundamentals-concept
+
+### Bundle membership — cratis-arc-command-validation
+
+- cratis-arc-backend-review
+
+## cratis-arc-ef-core-migration
+
+- **ID:** `cratis-arc-ef-core-migration`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-arc-ef-core-migration
+
+Arc EF Core migrations
+
+### When to use — cratis-arc-ef-core-migration
+
+Use when adding or changing an EF Core schema in a Cratis application.
+
+### When not to use — cratis-arc-ef-core-migration
+
+- Do not use for Chronicle read models.
+- Do not use for query paging.
+
+### Invocation — cratis-arc-ef-core-migration
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-arc-ef-core-migration
+
+- Products: application, entity-framework-core
+- Languages: csharp
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-arc-ef-core-migration
+
+- Unclassified
+
+### Trust and effects — cratis-arc-ef-core-migration
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-arc-ef-core-migration
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-arc-ef-core-migration
+
+- cratis-arc-query-paging
+- cratis-chronicle-read-model
+- cratis-specifications-csharp
+
+### Bundle membership — cratis-arc-ef-core-migration
+
+- cratis-arc-backend-review
+
+## cratis-arc-observable-query-http
+
+- **ID:** `cratis-arc-observable-query-http`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-arc-observable-query-http
+
+Arc observable-query HTTP diagnostics
+
+### When to use — cratis-arc-observable-query-http
+
+Use when inspecting Arc observable query SSE or streaming behavior with curl or HTTP tools.
+
+### When not to use — cratis-arc-observable-query-http
+
+- Do not use for Chronicle store recovery.
+- Do not use to implement the frontend query.
+
+### Invocation — cratis-arc-observable-query-http
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-arc-observable-query-http
+
+- Products: arc
+- Languages: shell
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-arc-observable-query-http
+
+- Unclassified
+
+### Trust and effects — cratis-arc-observable-query-http
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-arc-observable-query-http
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-arc-observable-query-http
+
+- cratis-application-slice-diagnostics
+- cratis-arc-query-paging
+- cratis-chronicle-cli-operations
+- cratis-chronicle-read-model
+
+### Bundle membership — cratis-arc-observable-query-http
+
+- None
+
+## cratis-arc-query-paging
+
+- **ID:** `cratis-arc-query-paging`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-arc-query-paging
+
+Arc query paging
+
+### When to use — cratis-arc-query-paging
+
+Use when adding server-side paging and sorting to an Arc read-model query.
+
+### When not to use — cratis-arc-query-paging
+
+- Do not use as a general performance review.
+- Do not use for generic query creation.
+
+### Invocation — cratis-arc-query-paging
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-arc-query-paging
+
+- Products: arc, arc-react
+- Languages: csharp, react, typescript
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-arc-query-paging
+
+- Unclassified
+
+### Trust and effects — cratis-arc-query-paging
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-arc-query-paging
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-arc-query-paging
+
+- cratis-arc-react-page
+- cratis-chronicle-read-model
+- cratis-performance-review
+
+### Bundle membership — cratis-arc-query-paging
+
+- cratis-arc-backend-review
+
+## cratis-arc-react-feature-scaffolding
+
+- **ID:** `cratis-arc-react-feature-scaffolding`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-arc-react-feature-scaffolding
+
+Arc React feature scaffolding
+
+### When to use — cratis-arc-react-feature-scaffolding
+
+Use when creating an empty route, navigation entry, and feature composition shell.
+
+### When not to use — cratis-arc-react-feature-scaffolding
+
+- Do not use for a populated DataPage.
+- Do not use to implement a behavior slice.
+
+### Invocation — cratis-arc-react-feature-scaffolding
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-arc-react-feature-scaffolding
+
+- Products: application, arc-react
+- Languages: csharp, react, typescript
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-arc-react-feature-scaffolding
+
+- Unclassified
+
+### Trust and effects — cratis-arc-react-feature-scaffolding
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-arc-react-feature-scaffolding
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-arc-react-feature-scaffolding
+
+- cratis-application-vertical-slice
+- cratis-arc-react-page
+
+### Bundle membership — cratis-arc-react-feature-scaffolding
+
+- cratis-application-full-stack-review
+
+## cratis-arc-react-page
+
+- **ID:** `cratis-arc-react-page`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-arc-react-page
+
+Arc React pages
+
+### When to use — cratis-arc-react-page
+
+Use when building a DataPage or MVVM React page backed by generated Arc queries.
+
+### When not to use — cratis-arc-react-page
+
+- Do not use for a multi-step wizard alone.
+- Do not use for an empty route shell.
+
+### Invocation — cratis-arc-react-page
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-arc-react-page
+
+- Products: application, arc-react, components
+- Languages: react, typescript
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-arc-react-page
+
+- Unclassified
+
+### Trust and effects — cratis-arc-react-page
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-arc-react-page
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-arc-react-page
+
+- cratis-arc-command
+- cratis-arc-query-paging
+- cratis-arc-react-feature-scaffolding
+- cratis-components-stepper-command-dialog
+
+### Bundle membership — cratis-arc-react-page
+
+- cratis-application-full-stack-review
+
+## cratis-chronicle-cli-operations
+
+- **ID:** `cratis-chronicle-cli-operations`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-chronicle-cli-operations
+
+Chronicle CLI operations
+
+### When to use — cratis-chronicle-cli-operations
+
+Use to inspect a running Chronicle store and, only with explicit confirmation, perform recovery operations.
+
+### When not to use — cratis-chronicle-cli-operations
+
+- Do not mutate a store without an explicit target and confirmation.
+- Do not use for source-only diagnostics.
+
+### Invocation — cratis-chronicle-cli-operations
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-chronicle-cli-operations
+
+- Products: chronicle, cli
+- Languages: shell
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-chronicle-cli-operations
+
+- Unclassified
+
+### Trust and effects — cratis-chronicle-cli-operations
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-chronicle-cli-operations
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-chronicle-cli-operations
+
+- cratis-application-slice-diagnostics
+- cratis-arc-observable-query-http
+
+### Bundle membership — cratis-chronicle-cli-operations
+
+- None
+
+## cratis-chronicle-event-constraints
+
+- **ID:** `cratis-chronicle-event-constraints`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-chronicle-event-constraints
+
+Chronicle event constraints
+
+### When to use — cratis-chronicle-event-constraints
+
+Use when enforcing append-time uniqueness, concurrency, or event-store constraints.
+
+### When not to use — cratis-chronicle-event-constraints
+
+- Do not use for ordinary command input validation.
+- Do not use to create a projection.
+
+### Invocation — cratis-chronicle-event-constraints
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-chronicle-event-constraints
+
+- Products: application, arc
+- Languages: csharp
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-chronicle-event-constraints
+
+- Unclassified
+
+### Trust and effects — cratis-chronicle-event-constraints
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-chronicle-event-constraints
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-chronicle-event-constraints
+
+- cratis-arc-command
+- cratis-arc-command-validation
+- cratis-chronicle-event-specifications
+- cratis-fundamentals-concept
+
+### Bundle membership — cratis-chronicle-event-constraints
+
+- cratis-chronicle-dotnet-review
+
+## cratis-chronicle-event-metadata
+
+- **ID:** `cratis-chronicle-event-metadata`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-chronicle-event-metadata
+
+Chronicle event metadata
+
+### When to use — cratis-chronicle-event-metadata
+
+Use when attaching audit, actor, tenant, or correlation metadata outside domain event payloads.
+
+### When not to use — cratis-chronicle-event-metadata
+
+- Do not use for domain facts.
+- Do not use for tenant isolation alone.
+
+### Invocation — cratis-chronicle-event-metadata
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-chronicle-event-metadata
+
+- Products: chronicle
+- Languages: csharp
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-chronicle-event-metadata
+
+- Unclassified
+
+### Trust and effects — cratis-chronicle-event-metadata
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-chronicle-event-metadata
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-chronicle-event-metadata
+
+- cratis-chronicle-multi-tenancy
+
+### Bundle membership — cratis-chronicle-event-metadata
+
+- cratis-chronicle-dotnet-review
+
+## cratis-chronicle-event-modeling
+
+- **ID:** `cratis-chronicle-event-modeling`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-chronicle-event-modeling
+
+Chronicle event modeling
+
+### When to use — cratis-chronicle-event-modeling
+
+Use before implementation when commands, events, streams, read models, or reactions are unsettled.
+
+### When not to use — cratis-chronicle-event-modeling
+
+- Do not use only to edit a Mermaid diagram.
+- Do not use when the model is already accepted.
+
+### Invocation — cratis-chronicle-event-modeling
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-chronicle-event-modeling
+
+- Products: application, chronicle
+- Languages: language-agnostic
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-chronicle-event-modeling
+
+- Unclassified
+
+### Trust and effects — cratis-chronicle-event-modeling
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-chronicle-event-modeling
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-chronicle-event-modeling
+
+- cratis-application-vertical-slice
+- cratis-event-model-diagram
+
+### Bundle membership — cratis-chronicle-event-modeling
+
+- cratis-core-review
+
+## cratis-chronicle-event-specifications
+
+- **ID:** `cratis-chronicle-event-specifications`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-chronicle-event-specifications
+
+Chronicle event specifications
+
+### When to use — cratis-chronicle-event-specifications
+
+Use for EventScenario append, constraint, concurrency, or sequence behavior.
+
+### When not to use — cratis-chronicle-event-specifications
+
+- Do not use for command handling.
+- Do not use for read-model projection behavior.
+
+### Invocation — cratis-chronicle-event-specifications
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-chronicle-event-specifications
+
+- Products: application, chronicle, specifications
+- Languages: csharp
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-chronicle-event-specifications
+
+- Unclassified
+
+### Trust and effects — cratis-chronicle-event-specifications
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-chronicle-event-specifications
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-chronicle-event-specifications
+
+- cratis-application-slice-specifications
+- cratis-chronicle-read-model-specifications
+- cratis-specifications-csharp
+
+### Bundle membership — cratis-chronicle-event-specifications
+
+- None
+
+## cratis-chronicle-event-type-migration
+
+- **ID:** `cratis-chronicle-event-type-migration`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-chronicle-event-type-migration
+
+Chronicle event type migration
+
+### When to use — cratis-chronicle-event-type-migration
+
+Use when a stored event schema needs a new generation and migration.
+
+### When not to use — cratis-chronicle-event-type-migration
+
+- Do not use for a new event.
+- Do not use for an EF Core migration.
+
+### Invocation — cratis-chronicle-event-type-migration
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-chronicle-event-type-migration
+
+- Products: chronicle
+- Languages: csharp
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-chronicle-event-type-migration
+
+- Unclassified
+
+### Trust and effects — cratis-chronicle-event-type-migration
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-chronicle-event-type-migration
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-chronicle-event-type-migration
+
+- cratis-arc-ef-core-migration
+- cratis-chronicle-read-model
+
+### Bundle membership — cratis-chronicle-event-type-migration
+
+- cratis-chronicle-dotnet-review
+
+## cratis-chronicle-multi-tenancy
+
+- **ID:** `cratis-chronicle-multi-tenancy`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-chronicle-multi-tenancy
+
+Chronicle multi-tenancy
+
+### When to use — cratis-chronicle-multi-tenancy
+
+Use when isolating tenants through Chronicle namespaces and Arc tenant resolution.
+
+### When not to use — cratis-chronicle-multi-tenancy
+
+- Do not use for event metadata alone.
+- Do not use for identity alone.
+
+### Invocation — cratis-chronicle-multi-tenancy
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-chronicle-multi-tenancy
+
+- Products: arc, chronicle
+- Languages: csharp
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-chronicle-multi-tenancy
+
+- Unclassified
+
+### Trust and effects — cratis-chronicle-multi-tenancy
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-chronicle-multi-tenancy
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-chronicle-multi-tenancy
+
+- cratis-arc-authentication-authorization-and-identity
+- cratis-chronicle-event-metadata
+
+### Bundle membership — cratis-chronicle-multi-tenancy
+
+- cratis-chronicle-dotnet-review
+
+## cratis-chronicle-projection
+
+- **ID:** `cratis-chronicle-projection`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-chronicle-projection
+
+Chronicle projections
+
+### When to use — cratis-chronicle-projection
+
+Use when adding projection behavior to an existing Chronicle read model.
+
+### When not to use — cratis-chronicle-projection
+
+- Do not use to create the read model itself.
+- Do not use when a reducer is not genuinely required.
+
+### Invocation — cratis-chronicle-projection
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-chronicle-projection
+
+- Products: application, chronicle
+- Languages: csharp
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-chronicle-projection
+
+- Unclassified
+
+### Trust and effects — cratis-chronicle-projection
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-chronicle-projection
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-chronicle-projection
+
+- cratis-chronicle-read-model
+- cratis-chronicle-read-model-specifications
+- cratis-chronicle-reducer
+
+### Bundle membership — cratis-chronicle-projection
+
+- cratis-chronicle-dotnet-review
+
+## cratis-chronicle-reactor
+
+- **ID:** `cratis-chronicle-reactor`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-chronicle-reactor
+
+Chronicle reactors
+
+### When to use — cratis-chronicle-reactor
+
+Use when implementing an automation or translation that reacts to events.
+
+### When not to use — cratis-chronicle-reactor
+
+- Do not use for an ordinary backend command call.
+- Do not use for projections.
+
+### Invocation — cratis-chronicle-reactor
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-chronicle-reactor
+
+- Products: application, chronicle
+- Languages: csharp
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-chronicle-reactor
+
+- Unclassified
+
+### Trust and effects — cratis-chronicle-reactor
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-chronicle-reactor
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-chronicle-reactor
+
+- cratis-application-slice-specifications
+- cratis-arc-command-execution
+- cratis-chronicle-projection
+
+### Bundle membership — cratis-chronicle-reactor
+
+- cratis-chronicle-dotnet-review
+
+## cratis-chronicle-read-model
+
+- **ID:** `cratis-chronicle-read-model`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-chronicle-read-model
+
+Chronicle read models
+
+### When to use — cratis-chronicle-read-model
+
+Use when creating a Chronicle read model and model-bound query surface.
+
+### When not to use — cratis-chronicle-read-model
+
+- Do not default to a reducer.
+- Do not use for projection-only changes.
+
+### Invocation — cratis-chronicle-read-model
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-chronicle-read-model
+
+- Products: application, arc, chronicle
+- Languages: csharp, typescript
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-chronicle-read-model
+
+- Unclassified
+
+### Trust and effects — cratis-chronicle-read-model
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-chronicle-read-model
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-chronicle-read-model
+
+- cratis-arc-query-paging
+- cratis-chronicle-projection
+- cratis-chronicle-reducer
+
+### Bundle membership — cratis-chronicle-read-model
+
+- cratis-chronicle-dotnet-review
+
+## cratis-chronicle-read-model-specifications
+
+- **ID:** `cratis-chronicle-read-model-specifications`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-chronicle-read-model-specifications
+
+Chronicle read-model specifications
+
+### When to use — cratis-chronicle-read-model-specifications
+
+Use for ReadModelScenario projection or reducer behavior.
+
+### When not to use — cratis-chronicle-read-model-specifications
+
+- Do not use for raw event append behavior.
+- Do not use for read-model creation.
+
+### Invocation — cratis-chronicle-read-model-specifications
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-chronicle-read-model-specifications
+
+- Products: application, chronicle, specifications
+- Languages: csharp
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-chronicle-read-model-specifications
+
+- Unclassified
+
+### Trust and effects — cratis-chronicle-read-model-specifications
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-chronicle-read-model-specifications
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-chronicle-read-model-specifications
+
+- cratis-application-slice-specifications
+- cratis-chronicle-event-specifications
+- cratis-chronicle-projection
+- cratis-chronicle-read-model
+- cratis-chronicle-reducer
+
+### Bundle membership — cratis-chronicle-read-model-specifications
+
+- None
+
+## cratis-chronicle-reducer
+
+- **ID:** `cratis-chronicle-reducer`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-chronicle-reducer
+
+Chronicle reducers
+
+### When to use — cratis-chronicle-reducer
+
+Use when a current-state-plus-event transition cannot be expressed as a projection.
+
+### When not to use — cratis-chronicle-reducer
+
+- Do not use before projection alternatives are exhausted.
+- Do not use for simple mapping.
+
+### Invocation — cratis-chronicle-reducer
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-chronicle-reducer
+
+- Products: application, chronicle
+- Languages: csharp
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-chronicle-reducer
+
+- Unclassified
+
+### Trust and effects — cratis-chronicle-reducer
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-chronicle-reducer
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-chronicle-reducer
+
+- cratis-chronicle-projection
+- cratis-chronicle-read-model
+- cratis-chronicle-read-model-specifications
+
+### Bundle membership — cratis-chronicle-reducer
+
+- cratis-chronicle-dotnet-review
+
+## cratis-code-review
+
+- **ID:** `cratis-code-review`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-code-review
+
+Cratis code review
+
+### When to use — cratis-code-review
+
+Use for a general correctness and maintainability review of Cratis code.
+
+### When not to use — cratis-code-review
+
+- Do not duplicate specialist performance findings.
+- Do not substitute it for a focused security audit.
+
+### Invocation — cratis-code-review
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-code-review
+
+- Products: cross-product
+- Languages: csharp, typescript
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-code-review
+
+- Unclassified
+
+### Trust and effects — cratis-code-review
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-code-review
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-code-review
+
+- cratis-performance-review
+- cratis-security-review
+
+### Bundle membership — cratis-code-review
+
+- cratis-review-capabilities
+
+## cratis-components-stepper-command-dialog
+
+- **ID:** `cratis-components-stepper-command-dialog`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-components-stepper-command-dialog
+
+Cratis Components stepper command dialogs
+
+### When to use — cratis-components-stepper-command-dialog
+
+Use when a command requires a multi-step wizard dialog.
+
+### When not to use — cratis-components-stepper-command-dialog
+
+- Do not use for a page shell.
+- Do not use for an ordinary command dialog.
+
+### Invocation — cratis-components-stepper-command-dialog
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-components-stepper-command-dialog
+
+- Products: arc-react, components
+- Languages: react, typescript
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-components-stepper-command-dialog
+
+- Unclassified
+
+### Trust and effects — cratis-components-stepper-command-dialog
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-components-stepper-command-dialog
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-components-stepper-command-dialog
+
+- cratis-arc-command
+- cratis-arc-react-page
+
+### Bundle membership — cratis-components-stepper-command-dialog
+
+- cratis-application-full-stack-review
+
+## cratis-components-toolbar
+
+- **ID:** `cratis-components-toolbar`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-components-toolbar
+
+Cratis Components toolbar
+
+### When to use — cratis-components-toolbar
+
+Use when building a canvas-style icon toolbar with active tools or fan-out controls.
+
+### When not to use — cratis-components-toolbar
+
+- Do not use for ordinary page actions or menus.
+
+### Invocation — cratis-components-toolbar
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-components-toolbar
+
+- Products: components
+- Languages: react, typescript
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-components-toolbar
+
+- Unclassified
+
+### Trust and effects — cratis-components-toolbar
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-components-toolbar
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-components-toolbar
+
+- cratis-arc-react-page
+
+### Bundle membership — cratis-components-toolbar
+
+- cratis-application-full-stack-review
+
+## cratis-event-model-diagram
+
+- **ID:** `cratis-event-model-diagram`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-event-model-diagram
+
+Event-model diagrams
+
+### When to use — cratis-event-model-diagram
+
+Use when creating or maintaining a Mermaid EventModel.md diagram for settled behavior.
+
+### When not to use — cratis-event-model-diagram
+
+- Do not use to implement a slice.
+- Do not use to settle event vocabulary.
+
+### Invocation — cratis-event-model-diagram
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-event-model-diagram
+
+- Products: application, chronicle
+- Languages: markdown
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-event-model-diagram
+
+- Unclassified
+
+### Trust and effects — cratis-event-model-diagram
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-event-model-diagram
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-event-model-diagram
+
+- cratis-application-vertical-slice
+- cratis-chronicle-event-modeling
+
+### Bundle membership — cratis-event-model-diagram
+
+- None
+
+## cratis-fundamentals-concept
+
+- **ID:** `cratis-fundamentals-concept`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-fundamentals-concept
+
+Strongly typed Cratis concepts
+
+### When to use — cratis-fundamentals-concept
+
+Use when creating a ConceptAs&lt;T&gt; value or EventSourceId&lt;T&gt; identity.
+
+### When not to use — cratis-fundamentals-concept
+
+- Do not use for DTO cleanup.
+- Do not use for event schema migration.
+
+### Invocation — cratis-fundamentals-concept
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-fundamentals-concept
+
+- Products: fundamentals
+- Languages: csharp
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-fundamentals-concept
+
+- Unclassified
+
+### Trust and effects — cratis-fundamentals-concept
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-fundamentals-concept
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-fundamentals-concept
+
+- cratis-chronicle-event-type-migration
+
+### Bundle membership — cratis-fundamentals-concept
+
+- cratis-core-review
+
+## cratis-fundamentals-type-discovery
+
+- **ID:** `cratis-fundamentals-type-discovery`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-fundamentals-type-discovery
+
+Cratis implementation discovery
+
+### When to use — cratis-fundamentals-type-discovery
+
+Use when a service must enumerate all implementations through IInstancesOf&lt;T&gt;.
+
+### When not to use — cratis-fundamentals-type-discovery
+
+- Do not use for normal single-service dependency injection.
+
+### Invocation — cratis-fundamentals-type-discovery
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-fundamentals-type-discovery
+
+- Products: fundamentals
+- Languages: csharp
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-fundamentals-type-discovery
+
+- Unclassified
+
+### Trust and effects — cratis-fundamentals-type-discovery
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-fundamentals-type-discovery
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-fundamentals-type-discovery
+
+- None
+
+### Bundle membership — cratis-fundamentals-type-discovery
+
+- cratis-core-review
+
+## cratis-performance-review
+
+- **ID:** `cratis-performance-review`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-performance-review
+
+Cratis performance review
+
+### When to use — cratis-performance-review
+
+Use for focused Chronicle, database, .NET, or React scalability analysis.
+
+### When not to use — cratis-performance-review
+
+- Do not override authoritative paging guidance.
+- Do not use for ordinary implementation.
+
+### Invocation — cratis-performance-review
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-performance-review
+
+- Products: arc-react, chronicle, cross-product
+- Languages: csharp, typescript
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-performance-review
+
+- Unclassified
+
+### Trust and effects — cratis-performance-review
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-performance-review
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-performance-review
+
+- cratis-arc-query-paging
+- cratis-code-review
+
+### Bundle membership — cratis-performance-review
+
+- cratis-review-capabilities
+
+## cratis-security-review
+
+- **ID:** `cratis-security-review`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-security-review
+
+Cratis security review
+
+### When to use — cratis-security-review
+
+Use for focused authentication, authorization, data exposure, event-sourcing, and frontend security review.
+
+### When not to use — cratis-security-review
+
+- Do not treat policy preferences as framework contracts.
+- Do not use to implement authentication.
+
+### Invocation — cratis-security-review
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-security-review
+
+- Products: arc, chronicle, cross-product
+- Languages: csharp, typescript
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-security-review
+
+- Unclassified
+
+### Trust and effects — cratis-security-review
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-security-review
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-security-review
+
+- cratis-arc-authentication-authorization-and-identity
+- cratis-code-review
+
+### Bundle membership — cratis-security-review
+
+- cratis-review-capabilities
+
+## cratis-specifications-csharp
+
+- **ID:** `cratis-specifications-csharp`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-specifications-csharp
+
+Cratis C# specification foundations
+
+### When to use — cratis-specifications-csharp
+
+Use for framework or library C# Specification by Example tests.
+
+### When not to use — cratis-specifications-csharp
+
+- Do not use for React tests.
+- Do not use for application scenario routing.
+
+### Invocation — cratis-specifications-csharp
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-specifications-csharp
+
+- Products: cross-product, specifications
+- Languages: csharp
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-specifications-csharp
+
+- Unclassified
+
+### Trust and effects — cratis-specifications-csharp
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-specifications-csharp
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-specifications-csharp
+
+- cratis-application-slice-specifications
+- cratis-specifications-typescript
+
+### Bundle membership — cratis-specifications-csharp
+
+- None
+
+## cratis-specifications-typescript
+
+- **ID:** `cratis-specifications-typescript`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+### Purpose — cratis-specifications-typescript
+
+Cratis TypeScript specification foundations
+
+### When to use — cratis-specifications-typescript
+
+Use for framework or package TypeScript Specification by Example tests.
+
+### When not to use — cratis-specifications-typescript
+
+- Do not use for C# scenarios.
+- Do not use for React application slice behavior.
+
+### Invocation — cratis-specifications-typescript
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+### Applicability — cratis-specifications-typescript
+
+- Products: cross-product, specifications
+- Languages: typescript
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+### Dependencies — cratis-specifications-typescript
+
+- Unclassified
+
+### Trust and effects — cratis-specifications-typescript
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+### Evidence and support — cratis-specifications-typescript
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+### Related capabilities — cratis-specifications-typescript
+
+- cratis-application-react-specifications
+- cratis-specifications-csharp
+
+### Bundle membership — cratis-specifications-typescript
+
+- None

--- a/catalog/generated/human-catalog/catalog.json
+++ b/catalog/generated/human-catalog/catalog.json
@@ -1,0 +1,2165 @@
+{
+  "schemaVersion": 2,
+  "contractVersion": 1,
+  "disclaimer": "Catalog inclusion, evaluation evidence, bundle generation, or publication does not grant runtime permission or approval.",
+  "inputDigest": "e42bfa066a6c58d75a51d607dcb9660ea2145af6d643958eb94c200ef3d66ee6",
+  "capabilities": [
+    {
+      "id": "cratis-application-react-specifications",
+      "semanticName": "cratis-application-react-specifications",
+      "audience": "public",
+      "purpose": "Application React specifications",
+      "whenToUse": "Use for React or TypeScript behavior in a Cratis application slice.",
+      "whenNotToUse": [
+        "Do not use for backend scenarios.",
+        "Do not use for framework package TypeScript specs."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "application",
+        "arc-react",
+        "specifications"
+      ],
+      "languages": [
+        "react",
+        "typescript"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-application-slice-specifications",
+        "cratis-arc-react-page",
+        "cratis-specifications-typescript"
+      ],
+      "bundleIds": [
+        "cratis-application-full-stack-review"
+      ]
+    },
+    {
+      "id": "cratis-application-slice-diagnostics",
+      "semanticName": "cratis-application-slice-diagnostics",
+      "audience": "public",
+      "purpose": "Application slice diagnostics",
+      "whenToUse": "Use when a Cratis slice misbehaves and source-level cause is unclear.",
+      "whenNotToUse": [
+        "Do not use for direct live-store operation.",
+        "Do not use only for observable-query HTTP inspection."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "application",
+        "arc",
+        "chronicle"
+      ],
+      "languages": [
+        "csharp",
+        "typescript"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-arc-command",
+        "cratis-arc-observable-query-http",
+        "cratis-chronicle-cli-operations",
+        "cratis-chronicle-projection"
+      ],
+      "bundleIds": [
+        "cratis-application-full-stack-review"
+      ]
+    },
+    {
+      "id": "cratis-application-slice-specifications",
+      "semanticName": "cratis-application-slice-specifications",
+      "audience": "public",
+      "purpose": "Application slice specifications",
+      "whenToUse": "Use to route event-sourced application backend behavior to the correct in-process scenario family.",
+      "whenNotToUse": [
+        "Do not use for framework library specifications.",
+        "Do not use for frontend behavior."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "application",
+        "specifications"
+      ],
+      "languages": [
+        "csharp"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-chronicle-event-specifications",
+        "cratis-chronicle-read-model-specifications",
+        "cratis-specifications-csharp"
+      ],
+      "bundleIds": [
+        "cratis-application-full-stack-review"
+      ]
+    },
+    {
+      "id": "cratis-application-vertical-slice",
+      "semanticName": "cratis-application-vertical-slice",
+      "audience": "public",
+      "purpose": "Cratis application vertical slices",
+      "whenToUse": "Use for vertical-slice architecture selection or end-to-end implementation after the merge experiment passes.",
+      "whenNotToUse": [
+        "Do not assume architecture explanation and implementation triggers are equivalent.",
+        "Do not use only to scaffold an empty feature shell."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "application"
+      ],
+      "languages": [
+        "csharp",
+        "react",
+        "typescript"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-application-slice-specifications",
+        "cratis-arc-react-feature-scaffolding",
+        "cratis-arc-react-page",
+        "cratis-chronicle-event-modeling"
+      ],
+      "bundleIds": [
+        "cratis-application-full-stack-review"
+      ]
+    },
+    {
+      "id": "cratis-arc-authentication-authorization-and-identity",
+      "semanticName": "cratis-arc-authentication-authorization-and-identity",
+      "audience": "public",
+      "purpose": "Arc authentication, authorization, and identity",
+      "whenToUse": "Use for Arc identity providers, endpoint protection, roles, or frontend identity integration.",
+      "whenNotToUse": [
+        "Do not use for isolated command validation.",
+        "Do not use for tenant namespaces alone."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "arc",
+        "arc-react"
+      ],
+      "languages": [
+        "csharp",
+        "react"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-arc-command",
+        "cratis-arc-command-validation",
+        "cratis-arc-react-page",
+        "cratis-chronicle-multi-tenancy"
+      ],
+      "bundleIds": [
+        "cratis-arc-backend-review"
+      ]
+    },
+    {
+      "id": "cratis-arc-command",
+      "semanticName": "cratis-arc-command",
+      "audience": "public",
+      "purpose": "Arc command definition",
+      "whenToUse": "Use when defining an Arc command and its generated full-stack proxy workflow.",
+      "whenNotToUse": [
+        "Do not use for a validation-only change.",
+        "Do not use only to execute an existing command."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "application",
+        "arc",
+        "arc-react"
+      ],
+      "languages": [
+        "csharp",
+        "react"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-arc-command-execution",
+        "cratis-arc-command-validation",
+        "cratis-chronicle-event-constraints",
+        "cratis-fundamentals-concept"
+      ],
+      "bundleIds": [
+        "cratis-arc-backend-review"
+      ]
+    },
+    {
+      "id": "cratis-arc-command-execution",
+      "semanticName": "cratis-arc-command-execution",
+      "audience": "public",
+      "purpose": "Arc command pipeline execution",
+      "whenToUse": "Use when backend code must execute an existing Arc command through ICommandPipeline.",
+      "whenNotToUse": [
+        "Do not use for reactor design alone.",
+        "Do not use to define a command."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "arc"
+      ],
+      "languages": [
+        "csharp"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-arc-command",
+        "cratis-chronicle-reactor"
+      ],
+      "bundleIds": [
+        "cratis-arc-backend-review"
+      ]
+    },
+    {
+      "id": "cratis-arc-command-validation",
+      "semanticName": "cratis-arc-command-validation",
+      "audience": "public",
+      "purpose": "Arc command validation",
+      "whenToUse": "Use when adding validation or state-dependent rejection to an existing Arc command.",
+      "whenNotToUse": [
+        "Do not use for append-time Chronicle constraints.",
+        "Do not use to define a new command."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "application",
+        "arc"
+      ],
+      "languages": [
+        "csharp"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-arc-command",
+        "cratis-chronicle-event-constraints",
+        "cratis-fundamentals-concept"
+      ],
+      "bundleIds": [
+        "cratis-arc-backend-review"
+      ]
+    },
+    {
+      "id": "cratis-arc-ef-core-migration",
+      "semanticName": "cratis-arc-ef-core-migration",
+      "audience": "public",
+      "purpose": "Arc EF Core migrations",
+      "whenToUse": "Use when adding or changing an EF Core schema in a Cratis application.",
+      "whenNotToUse": [
+        "Do not use for Chronicle read models.",
+        "Do not use for query paging."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "application",
+        "entity-framework-core"
+      ],
+      "languages": [
+        "csharp"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-arc-query-paging",
+        "cratis-chronicle-read-model",
+        "cratis-specifications-csharp"
+      ],
+      "bundleIds": [
+        "cratis-arc-backend-review"
+      ]
+    },
+    {
+      "id": "cratis-arc-observable-query-http",
+      "semanticName": "cratis-arc-observable-query-http",
+      "audience": "public",
+      "purpose": "Arc observable-query HTTP diagnostics",
+      "whenToUse": "Use when inspecting Arc observable query SSE or streaming behavior with curl or HTTP tools.",
+      "whenNotToUse": [
+        "Do not use for Chronicle store recovery.",
+        "Do not use to implement the frontend query."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "arc"
+      ],
+      "languages": [
+        "shell"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-application-slice-diagnostics",
+        "cratis-arc-query-paging",
+        "cratis-chronicle-cli-operations",
+        "cratis-chronicle-read-model"
+      ],
+      "bundleIds": []
+    },
+    {
+      "id": "cratis-arc-query-paging",
+      "semanticName": "cratis-arc-query-paging",
+      "audience": "public",
+      "purpose": "Arc query paging",
+      "whenToUse": "Use when adding server-side paging and sorting to an Arc read-model query.",
+      "whenNotToUse": [
+        "Do not use as a general performance review.",
+        "Do not use for generic query creation."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "arc",
+        "arc-react"
+      ],
+      "languages": [
+        "csharp",
+        "react",
+        "typescript"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-arc-react-page",
+        "cratis-chronicle-read-model",
+        "cratis-performance-review"
+      ],
+      "bundleIds": [
+        "cratis-arc-backend-review"
+      ]
+    },
+    {
+      "id": "cratis-arc-react-feature-scaffolding",
+      "semanticName": "cratis-arc-react-feature-scaffolding",
+      "audience": "public",
+      "purpose": "Arc React feature scaffolding",
+      "whenToUse": "Use when creating an empty route, navigation entry, and feature composition shell.",
+      "whenNotToUse": [
+        "Do not use for a populated DataPage.",
+        "Do not use to implement a behavior slice."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "application",
+        "arc-react"
+      ],
+      "languages": [
+        "csharp",
+        "react",
+        "typescript"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-application-vertical-slice",
+        "cratis-arc-react-page"
+      ],
+      "bundleIds": [
+        "cratis-application-full-stack-review"
+      ]
+    },
+    {
+      "id": "cratis-arc-react-page",
+      "semanticName": "cratis-arc-react-page",
+      "audience": "public",
+      "purpose": "Arc React pages",
+      "whenToUse": "Use when building a DataPage or MVVM React page backed by generated Arc queries.",
+      "whenNotToUse": [
+        "Do not use for a multi-step wizard alone.",
+        "Do not use for an empty route shell."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "application",
+        "arc-react",
+        "components"
+      ],
+      "languages": [
+        "react",
+        "typescript"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-arc-command",
+        "cratis-arc-query-paging",
+        "cratis-arc-react-feature-scaffolding",
+        "cratis-components-stepper-command-dialog"
+      ],
+      "bundleIds": [
+        "cratis-application-full-stack-review"
+      ]
+    },
+    {
+      "id": "cratis-chronicle-cli-operations",
+      "semanticName": "cratis-chronicle-cli-operations",
+      "audience": "public",
+      "purpose": "Chronicle CLI operations",
+      "whenToUse": "Use to inspect a running Chronicle store and, only with explicit confirmation, perform recovery operations.",
+      "whenNotToUse": [
+        "Do not mutate a store without an explicit target and confirmation.",
+        "Do not use for source-only diagnostics."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "chronicle",
+        "cli"
+      ],
+      "languages": [
+        "shell"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-application-slice-diagnostics",
+        "cratis-arc-observable-query-http"
+      ],
+      "bundleIds": []
+    },
+    {
+      "id": "cratis-chronicle-event-constraints",
+      "semanticName": "cratis-chronicle-event-constraints",
+      "audience": "public",
+      "purpose": "Chronicle event constraints",
+      "whenToUse": "Use when enforcing append-time uniqueness, concurrency, or event-store constraints.",
+      "whenNotToUse": [
+        "Do not use for ordinary command input validation.",
+        "Do not use to create a projection."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "application",
+        "arc"
+      ],
+      "languages": [
+        "csharp"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-arc-command",
+        "cratis-arc-command-validation",
+        "cratis-chronicle-event-specifications",
+        "cratis-fundamentals-concept"
+      ],
+      "bundleIds": [
+        "cratis-chronicle-dotnet-review"
+      ]
+    },
+    {
+      "id": "cratis-chronicle-event-metadata",
+      "semanticName": "cratis-chronicle-event-metadata",
+      "audience": "public",
+      "purpose": "Chronicle event metadata",
+      "whenToUse": "Use when attaching audit, actor, tenant, or correlation metadata outside domain event payloads.",
+      "whenNotToUse": [
+        "Do not use for domain facts.",
+        "Do not use for tenant isolation alone."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "chronicle"
+      ],
+      "languages": [
+        "csharp"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-chronicle-multi-tenancy"
+      ],
+      "bundleIds": [
+        "cratis-chronicle-dotnet-review"
+      ]
+    },
+    {
+      "id": "cratis-chronicle-event-modeling",
+      "semanticName": "cratis-chronicle-event-modeling",
+      "audience": "public",
+      "purpose": "Chronicle event modeling",
+      "whenToUse": "Use before implementation when commands, events, streams, read models, or reactions are unsettled.",
+      "whenNotToUse": [
+        "Do not use only to edit a Mermaid diagram.",
+        "Do not use when the model is already accepted."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "application",
+        "chronicle"
+      ],
+      "languages": [
+        "language-agnostic"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-application-vertical-slice",
+        "cratis-event-model-diagram"
+      ],
+      "bundleIds": [
+        "cratis-core-review"
+      ]
+    },
+    {
+      "id": "cratis-chronicle-event-specifications",
+      "semanticName": "cratis-chronicle-event-specifications",
+      "audience": "public",
+      "purpose": "Chronicle event specifications",
+      "whenToUse": "Use for EventScenario append, constraint, concurrency, or sequence behavior.",
+      "whenNotToUse": [
+        "Do not use for command handling.",
+        "Do not use for read-model projection behavior."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "application",
+        "chronicle",
+        "specifications"
+      ],
+      "languages": [
+        "csharp"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-application-slice-specifications",
+        "cratis-chronicle-read-model-specifications",
+        "cratis-specifications-csharp"
+      ],
+      "bundleIds": []
+    },
+    {
+      "id": "cratis-chronicle-event-type-migration",
+      "semanticName": "cratis-chronicle-event-type-migration",
+      "audience": "public",
+      "purpose": "Chronicle event type migration",
+      "whenToUse": "Use when a stored event schema needs a new generation and migration.",
+      "whenNotToUse": [
+        "Do not use for a new event.",
+        "Do not use for an EF Core migration."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "chronicle"
+      ],
+      "languages": [
+        "csharp"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-arc-ef-core-migration",
+        "cratis-chronicle-read-model"
+      ],
+      "bundleIds": [
+        "cratis-chronicle-dotnet-review"
+      ]
+    },
+    {
+      "id": "cratis-chronicle-multi-tenancy",
+      "semanticName": "cratis-chronicle-multi-tenancy",
+      "audience": "public",
+      "purpose": "Chronicle multi-tenancy",
+      "whenToUse": "Use when isolating tenants through Chronicle namespaces and Arc tenant resolution.",
+      "whenNotToUse": [
+        "Do not use for event metadata alone.",
+        "Do not use for identity alone."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "arc",
+        "chronicle"
+      ],
+      "languages": [
+        "csharp"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-arc-authentication-authorization-and-identity",
+        "cratis-chronicle-event-metadata"
+      ],
+      "bundleIds": [
+        "cratis-chronicle-dotnet-review"
+      ]
+    },
+    {
+      "id": "cratis-chronicle-projection",
+      "semanticName": "cratis-chronicle-projection",
+      "audience": "public",
+      "purpose": "Chronicle projections",
+      "whenToUse": "Use when adding projection behavior to an existing Chronicle read model.",
+      "whenNotToUse": [
+        "Do not use to create the read model itself.",
+        "Do not use when a reducer is not genuinely required."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "application",
+        "chronicle"
+      ],
+      "languages": [
+        "csharp"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-chronicle-read-model",
+        "cratis-chronicle-read-model-specifications",
+        "cratis-chronicle-reducer"
+      ],
+      "bundleIds": [
+        "cratis-chronicle-dotnet-review"
+      ]
+    },
+    {
+      "id": "cratis-chronicle-reactor",
+      "semanticName": "cratis-chronicle-reactor",
+      "audience": "public",
+      "purpose": "Chronicle reactors",
+      "whenToUse": "Use when implementing an automation or translation that reacts to events.",
+      "whenNotToUse": [
+        "Do not use for an ordinary backend command call.",
+        "Do not use for projections."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "application",
+        "chronicle"
+      ],
+      "languages": [
+        "csharp"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-application-slice-specifications",
+        "cratis-arc-command-execution",
+        "cratis-chronicle-projection"
+      ],
+      "bundleIds": [
+        "cratis-chronicle-dotnet-review"
+      ]
+    },
+    {
+      "id": "cratis-chronicle-read-model",
+      "semanticName": "cratis-chronicle-read-model",
+      "audience": "public",
+      "purpose": "Chronicle read models",
+      "whenToUse": "Use when creating a Chronicle read model and model-bound query surface.",
+      "whenNotToUse": [
+        "Do not default to a reducer.",
+        "Do not use for projection-only changes."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "application",
+        "arc",
+        "chronicle"
+      ],
+      "languages": [
+        "csharp",
+        "typescript"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-arc-query-paging",
+        "cratis-chronicle-projection",
+        "cratis-chronicle-reducer"
+      ],
+      "bundleIds": [
+        "cratis-chronicle-dotnet-review"
+      ]
+    },
+    {
+      "id": "cratis-chronicle-read-model-specifications",
+      "semanticName": "cratis-chronicle-read-model-specifications",
+      "audience": "public",
+      "purpose": "Chronicle read-model specifications",
+      "whenToUse": "Use for ReadModelScenario projection or reducer behavior.",
+      "whenNotToUse": [
+        "Do not use for raw event append behavior.",
+        "Do not use for read-model creation."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "application",
+        "chronicle",
+        "specifications"
+      ],
+      "languages": [
+        "csharp"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-application-slice-specifications",
+        "cratis-chronicle-event-specifications",
+        "cratis-chronicle-projection",
+        "cratis-chronicle-read-model",
+        "cratis-chronicle-reducer"
+      ],
+      "bundleIds": []
+    },
+    {
+      "id": "cratis-chronicle-reducer",
+      "semanticName": "cratis-chronicle-reducer",
+      "audience": "public",
+      "purpose": "Chronicle reducers",
+      "whenToUse": "Use when a current-state-plus-event transition cannot be expressed as a projection.",
+      "whenNotToUse": [
+        "Do not use before projection alternatives are exhausted.",
+        "Do not use for simple mapping."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "application",
+        "chronicle"
+      ],
+      "languages": [
+        "csharp"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-chronicle-projection",
+        "cratis-chronicle-read-model",
+        "cratis-chronicle-read-model-specifications"
+      ],
+      "bundleIds": [
+        "cratis-chronicle-dotnet-review"
+      ]
+    },
+    {
+      "id": "cratis-code-review",
+      "semanticName": "cratis-code-review",
+      "audience": "public",
+      "purpose": "Cratis code review",
+      "whenToUse": "Use for a general correctness and maintainability review of Cratis code.",
+      "whenNotToUse": [
+        "Do not duplicate specialist performance findings.",
+        "Do not substitute it for a focused security audit."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "cross-product"
+      ],
+      "languages": [
+        "csharp",
+        "typescript"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-performance-review",
+        "cratis-security-review"
+      ],
+      "bundleIds": [
+        "cratis-review-capabilities"
+      ]
+    },
+    {
+      "id": "cratis-components-stepper-command-dialog",
+      "semanticName": "cratis-components-stepper-command-dialog",
+      "audience": "public",
+      "purpose": "Cratis Components stepper command dialogs",
+      "whenToUse": "Use when a command requires a multi-step wizard dialog.",
+      "whenNotToUse": [
+        "Do not use for a page shell.",
+        "Do not use for an ordinary command dialog."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "arc-react",
+        "components"
+      ],
+      "languages": [
+        "react",
+        "typescript"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-arc-command",
+        "cratis-arc-react-page"
+      ],
+      "bundleIds": [
+        "cratis-application-full-stack-review"
+      ]
+    },
+    {
+      "id": "cratis-components-toolbar",
+      "semanticName": "cratis-components-toolbar",
+      "audience": "public",
+      "purpose": "Cratis Components toolbar",
+      "whenToUse": "Use when building a canvas-style icon toolbar with active tools or fan-out controls.",
+      "whenNotToUse": [
+        "Do not use for ordinary page actions or menus."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "components"
+      ],
+      "languages": [
+        "react",
+        "typescript"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-arc-react-page"
+      ],
+      "bundleIds": [
+        "cratis-application-full-stack-review"
+      ]
+    },
+    {
+      "id": "cratis-event-model-diagram",
+      "semanticName": "cratis-event-model-diagram",
+      "audience": "public",
+      "purpose": "Event-model diagrams",
+      "whenToUse": "Use when creating or maintaining a Mermaid EventModel.md diagram for settled behavior.",
+      "whenNotToUse": [
+        "Do not use to implement a slice.",
+        "Do not use to settle event vocabulary."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "application",
+        "chronicle"
+      ],
+      "languages": [
+        "markdown"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-application-vertical-slice",
+        "cratis-chronicle-event-modeling"
+      ],
+      "bundleIds": []
+    },
+    {
+      "id": "cratis-fundamentals-concept",
+      "semanticName": "cratis-fundamentals-concept",
+      "audience": "public",
+      "purpose": "Strongly typed Cratis concepts",
+      "whenToUse": "Use when creating a ConceptAs<T> value or EventSourceId<T> identity.",
+      "whenNotToUse": [
+        "Do not use for DTO cleanup.",
+        "Do not use for event schema migration."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "fundamentals"
+      ],
+      "languages": [
+        "csharp"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-chronicle-event-type-migration"
+      ],
+      "bundleIds": [
+        "cratis-core-review"
+      ]
+    },
+    {
+      "id": "cratis-fundamentals-type-discovery",
+      "semanticName": "cratis-fundamentals-type-discovery",
+      "audience": "public",
+      "purpose": "Cratis implementation discovery",
+      "whenToUse": "Use when a service must enumerate all implementations through IInstancesOf<T>.",
+      "whenNotToUse": [
+        "Do not use for normal single-service dependency injection."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "fundamentals"
+      ],
+      "languages": [
+        "csharp"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [],
+      "bundleIds": [
+        "cratis-core-review"
+      ]
+    },
+    {
+      "id": "cratis-performance-review",
+      "semanticName": "cratis-performance-review",
+      "audience": "public",
+      "purpose": "Cratis performance review",
+      "whenToUse": "Use for focused Chronicle, database, .NET, or React scalability analysis.",
+      "whenNotToUse": [
+        "Do not override authoritative paging guidance.",
+        "Do not use for ordinary implementation."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "arc-react",
+        "chronicle",
+        "cross-product"
+      ],
+      "languages": [
+        "csharp",
+        "typescript"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-arc-query-paging",
+        "cratis-code-review"
+      ],
+      "bundleIds": [
+        "cratis-review-capabilities"
+      ]
+    },
+    {
+      "id": "cratis-security-review",
+      "semanticName": "cratis-security-review",
+      "audience": "public",
+      "purpose": "Cratis security review",
+      "whenToUse": "Use for focused authentication, authorization, data exposure, event-sourcing, and frontend security review.",
+      "whenNotToUse": [
+        "Do not treat policy preferences as framework contracts.",
+        "Do not use to implement authentication."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "arc",
+        "chronicle",
+        "cross-product"
+      ],
+      "languages": [
+        "csharp",
+        "typescript"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-arc-authentication-authorization-and-identity",
+        "cratis-code-review"
+      ],
+      "bundleIds": [
+        "cratis-review-capabilities"
+      ]
+    },
+    {
+      "id": "cratis-specifications-csharp",
+      "semanticName": "cratis-specifications-csharp",
+      "audience": "public",
+      "purpose": "Cratis C# specification foundations",
+      "whenToUse": "Use for framework or library C# Specification by Example tests.",
+      "whenNotToUse": [
+        "Do not use for React tests.",
+        "Do not use for application scenario routing."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "cross-product",
+        "specifications"
+      ],
+      "languages": [
+        "csharp"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-application-slice-specifications",
+        "cratis-specifications-typescript"
+      ],
+      "bundleIds": []
+    },
+    {
+      "id": "cratis-specifications-typescript",
+      "semanticName": "cratis-specifications-typescript",
+      "audience": "public",
+      "purpose": "Cratis TypeScript specification foundations",
+      "whenToUse": "Use for framework or package TypeScript Specification by Example tests.",
+      "whenNotToUse": [
+        "Do not use for C# scenarios.",
+        "Do not use for React application slice behavior."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "cross-product",
+        "specifications"
+      ],
+      "languages": [
+        "typescript"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [
+        "cratis-application-react-specifications",
+        "cratis-specifications-csharp"
+      ],
+      "bundleIds": []
+    }
+  ]
+}

--- a/catalog/generated/human-catalog/manifest.json
+++ b/catalog/generated/human-catalog/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 2,
+  "contractVersion": 1,
+  "inputDigest": "e42bfa066a6c58d75a51d607dcb9660ea2145af6d643958eb94c200ef3d66ee6",
+  "files": [
+    {
+      "path": "CATALOG.md",
+      "size": 59967,
+      "sha256": "09cbd51c5f3a870eebd80eaf7c0a6d27faf3ac96fd61dd2ddede6619f3363ae3"
+    },
+    {
+      "path": "catalog.json",
+      "size": 64765,
+      "sha256": "c47df1d2daf7fe424c9084dea5d1b4e178d182b1b2169b143c14efe5197e11c6"
+    }
+  ]
+}

--- a/catalog/schemas/v2/catalog-v2.schema.json
+++ b/catalog/schemas/v2/catalog-v2.schema.json
@@ -227,6 +227,8 @@
         "sourceContractState",
         "sourceContractIds",
         "sourceAuthoritySubjects",
+        "authoringContractState",
+        "authoringContractIds",
         "capability",
         "positiveTriggerIntent",
         "nearMissExclusions",
@@ -281,6 +283,8 @@
         "sourceContractState": { "enum": ["unclassified", "classified"] },
         "sourceContractIds": { "$ref": "#/$defs/idArray" },
         "sourceAuthoritySubjects": { "$ref": "#/$defs/idArray" },
+        "authoringContractState": { "enum": ["unclassified", "classified"] },
+        "authoringContractIds": { "$ref": "#/$defs/idArray" },
         "capability": { "$ref": "#/$defs/nonEmptyString" },
         "positiveTriggerIntent": { "$ref": "#/$defs/nonEmptyString" },
         "nearMissExclusions": {
@@ -584,6 +588,319 @@
           "minItems": 1,
           "uniqueItems": true,
           "items": { "$ref": "#/$defs/upstreamCompanion" }
+        }
+      }
+    },
+    "authoringContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind",
+        "state",
+        "audience",
+        "inputPolicy",
+        "outputPolicy",
+        "contentRules",
+        "cleanRoomReview",
+        "requiredEvidenceKinds",
+        "evidenceIds"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "kind": { "const": "agent-skill" },
+        "state": { "enum": ["draft", "active", "deprecated", "retired"] },
+        "audience": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "enum": ["public", "cratis-engineering"] }
+        },
+        "inputPolicy": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "authoritativeProductSources",
+            "targetEvidence",
+            "catalogMetadata",
+            "upstreamCompanions",
+            "thirdPartyBodies",
+            "generatedCatalogViews",
+            "runtimePayloads",
+            "modelMemory"
+          ],
+          "properties": {
+            "authoritativeProductSources": { "const": "required" },
+            "targetEvidence": { "const": "required" },
+            "catalogMetadata": { "const": "index-only" },
+            "upstreamCompanions": { "const": "metadata-only" },
+            "thirdPartyBodies": { "const": "forbidden" },
+            "generatedCatalogViews": { "const": "non-authoritative" },
+            "runtimePayloads": { "const": "forbidden-as-input" },
+            "modelMemory": { "const": "non-authoritative" }
+          }
+        },
+        "outputPolicy": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "mediaType",
+            "relativePath",
+            "requiredFrontmatterKeys",
+            "normativeClaimsRequireEvidence",
+            "distinguishContractsConventionsAndPolicies",
+            "unresolvedClaims",
+            "copyPolicy",
+            "runtimePayloadGeneration"
+          ],
+          "properties": {
+            "mediaType": { "const": "text/markdown" },
+            "relativePath": { "const": "SKILL.md" },
+            "requiredFrontmatterKeys": {
+              "type": "array",
+              "minItems": 2,
+              "uniqueItems": true,
+              "items": { "enum": ["name", "description", "license", "compatibility", "metadata", "allowed-tools"] }
+            },
+            "normativeClaimsRequireEvidence": { "const": true },
+            "distinguishContractsConventionsAndPolicies": { "const": true },
+            "unresolvedClaims": { "const": "omit-or-mark-unknown" },
+            "copyPolicy": { "const": "original-cratis-expression" },
+            "runtimePayloadGeneration": { "const": "separate-approved-delivery-only" }
+          }
+        },
+        "contentRules": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "oneCapability",
+            "oneTriggerIntent",
+            "nearMissesRequired",
+            "collisionSetRequired",
+            "observableCompletionRequired",
+            "progressiveDisclosure",
+            "americanEnglish",
+            "projectFactsForbidden",
+            "privateFactsForbidden",
+            "scriptsForbiddenForPublicSkills",
+            "evalsForbiddenInRuntimePayload"
+          ],
+          "properties": {
+            "oneCapability": { "const": true },
+            "oneTriggerIntent": { "const": true },
+            "nearMissesRequired": { "const": true },
+            "collisionSetRequired": { "const": true },
+            "observableCompletionRequired": { "const": true },
+            "progressiveDisclosure": { "const": true },
+            "americanEnglish": { "const": true },
+            "projectFactsForbidden": { "const": true },
+            "privateFactsForbidden": { "const": true },
+            "scriptsForbiddenForPublicSkills": { "const": true },
+            "evalsForbiddenInRuntimePayload": { "const": true }
+          }
+        },
+        "cleanRoomReview": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "sourceRevisionRecorded",
+            "requirementLevelNotesOnly",
+            "phraseSimilarityReviewRequired",
+            "structuralSimilarityReviewRequired",
+            "copiedWordingForbidden",
+            "copiedHeadingsForbidden",
+            "copiedExamplesForbidden",
+            "copiedTemplatesForbidden",
+            "copiedPersonasForbidden",
+            "copiedScriptsForbidden"
+          ],
+          "properties": {
+            "sourceRevisionRecorded": { "const": true },
+            "requirementLevelNotesOnly": { "const": true },
+            "phraseSimilarityReviewRequired": { "const": true },
+            "structuralSimilarityReviewRequired": { "const": true },
+            "copiedWordingForbidden": { "const": true },
+            "copiedHeadingsForbidden": { "const": true },
+            "copiedExamplesForbidden": { "const": true },
+            "copiedTemplatesForbidden": { "const": true },
+            "copiedPersonasForbidden": { "const": true },
+            "copiedScriptsForbidden": { "const": true }
+          }
+        },
+        "requiredEvidenceKinds": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "enum": ["behavior", "positive-trigger", "negative-trigger", "collision", "security", "portability", "source-review"] }
+        },
+        "evidenceIds": { "$ref": "#/$defs/evidenceIds" }
+      }
+    },
+    "authoringContractsCatalog": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schemaVersion", "defaultPolicy", "contracts"],
+      "properties": {
+        "schemaVersion": { "const": 2 },
+        "defaultPolicy": { "const": "deny" },
+        "contracts": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/authoringContract" }
+        }
+      }
+    },
+    "humanCatalogContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "contractVersion",
+        "outputRoot",
+        "generatedFiles",
+        "includeAudiences",
+        "includeUnapprovedTargets",
+        "includeRuntimePayloadBytes",
+        "referenceExpansion",
+        "requiredCapabilitySections",
+        "disclaimer",
+        "limits",
+        "determinism"
+      ],
+      "properties": {
+        "schemaVersion": { "const": 2 },
+        "contractVersion": { "const": 1 },
+        "outputRoot": { "const": "catalog/generated/human-catalog" },
+        "generatedFiles": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["data", "markdown", "manifest"],
+          "properties": {
+            "data": { "const": "catalog.json" },
+            "markdown": { "const": "CATALOG.md" },
+            "manifest": { "const": "manifest.json" }
+          }
+        },
+        "includeAudiences": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "enum": ["public", "cratis-engineering"] }
+        },
+        "includeUnapprovedTargets": { "const": true },
+        "includeRuntimePayloadBytes": { "const": false },
+        "referenceExpansion": { "const": "complete-bounded" },
+        "requiredCapabilitySections": { "$ref": "#/$defs/idArray" },
+        "disclaimer": { "$ref": "#/$defs/nonEmptyString" },
+        "limits": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["maximumInputBytes", "maximumJsonDepth", "maximumItemsPerRegistry", "maximumStringBytes", "maximumGeneratedFiles", "maximumGeneratedBytes"],
+          "properties": {
+            "maximumInputBytes": { "type": "integer", "minimum": 1 },
+            "maximumJsonDepth": { "type": "integer", "minimum": 1 },
+            "maximumItemsPerRegistry": { "type": "integer", "minimum": 1 },
+            "maximumStringBytes": { "type": "integer", "minimum": 1 },
+            "maximumGeneratedFiles": { "type": "integer", "minimum": 3 },
+            "maximumGeneratedBytes": { "type": "integer", "minimum": 1 }
+          }
+        },
+        "determinism": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["timestamps", "environmentValues", "networkAccess", "ordering", "encoding", "lineEndings", "jsonIndentation", "terminalNewline"],
+          "properties": {
+            "timestamps": { "const": false },
+            "environmentValues": { "const": false },
+            "networkAccess": { "const": false },
+            "ordering": { "const": "ordinal" },
+            "encoding": { "const": "utf-8" },
+            "lineEndings": { "const": "lf" },
+            "jsonIndentation": { "const": 2 },
+            "terminalNewline": { "const": true }
+          }
+        }
+      }
+    },
+    "generatedHumanCapability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id", "semanticName", "audience", "purpose", "whenToUse", "whenNotToUse",
+        "capabilityKind", "invocation", "lifecycle", "approvalState", "runtimeEligible",
+        "products", "languages", "architectures", "personas", "surfaces", "repositoryProfiles",
+        "trust", "dependencies", "authoringContractIds", "evidenceIds", "relatedTargetIds", "bundleIds"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "semanticName": { "$ref": "#/$defs/id" },
+        "audience": { "enum": ["public", "cratis-engineering"] },
+        "purpose": { "$ref": "#/$defs/nonEmptyString" },
+        "whenToUse": { "$ref": "#/$defs/nonEmptyString" },
+        "whenNotToUse": { "$ref": "#/$defs/stringArray" },
+        "capabilityKind": { "$ref": "#/$defs/nonEmptyString" },
+        "invocation": { "$ref": "#/$defs/nonEmptyString" },
+        "lifecycle": { "$ref": "#/$defs/nonEmptyString" },
+        "approvalState": { "$ref": "#/$defs/nonEmptyString" },
+        "runtimeEligible": { "type": "boolean" },
+        "products": { "$ref": "#/$defs/idArray" },
+        "languages": { "$ref": "#/$defs/idArray" },
+        "architectures": { "$ref": "#/$defs/applicability" },
+        "personas": { "$ref": "#/$defs/applicability" },
+        "surfaces": { "$ref": "#/$defs/applicability" },
+        "repositoryProfiles": { "$ref": "#/$defs/applicability" },
+        "trust": { "$ref": "#/$defs/trustAssessment" },
+        "dependencies": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/dependencyEdge" }
+        },
+        "authoringContractIds": { "$ref": "#/$defs/idArray" },
+        "evidenceIds": { "$ref": "#/$defs/evidenceIds" },
+        "relatedTargetIds": { "$ref": "#/$defs/idArray" },
+        "bundleIds": { "$ref": "#/$defs/idArray" }
+      }
+    },
+    "generatedHumanCatalog": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schemaVersion", "contractVersion", "disclaimer", "inputDigest", "capabilities"],
+      "properties": {
+        "schemaVersion": { "const": 2 },
+        "contractVersion": { "const": 1 },
+        "disclaimer": { "$ref": "#/$defs/nonEmptyString" },
+        "inputDigest": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        "capabilities": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/generatedHumanCapability" }
+        }
+      }
+    },
+    "generatedHumanCatalogManifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schemaVersion", "contractVersion", "inputDigest", "files"],
+      "properties": {
+        "schemaVersion": { "const": 2 },
+        "contractVersion": { "const": 1 },
+        "inputDigest": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        "files": {
+          "type": "array",
+          "minItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["path", "size", "sha256"],
+            "properties": {
+              "path": { "$ref": "#/$defs/path" },
+              "size": { "type": "integer", "minimum": 0 },
+              "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+            }
+          }
         }
       }
     },

--- a/catalog/v2/authoring-contracts.json
+++ b/catalog/v2/authoring-contracts.json
@@ -1,0 +1,70 @@
+{
+  "schemaVersion": 2,
+  "defaultPolicy": "deny",
+  "contracts": [
+    {
+      "id": "cratis-skill-clean-room-v1",
+      "kind": "agent-skill",
+      "state": "active",
+      "audience": ["public", "cratis-engineering"],
+      "inputPolicy": {
+        "authoritativeProductSources": "required",
+        "targetEvidence": "required",
+        "catalogMetadata": "index-only",
+        "upstreamCompanions": "metadata-only",
+        "thirdPartyBodies": "forbidden",
+        "generatedCatalogViews": "non-authoritative",
+        "runtimePayloads": "forbidden-as-input",
+        "modelMemory": "non-authoritative"
+      },
+      "outputPolicy": {
+        "mediaType": "text/markdown",
+        "relativePath": "SKILL.md",
+        "requiredFrontmatterKeys": ["name", "description"],
+        "normativeClaimsRequireEvidence": true,
+        "distinguishContractsConventionsAndPolicies": true,
+        "unresolvedClaims": "omit-or-mark-unknown",
+        "copyPolicy": "original-cratis-expression",
+        "runtimePayloadGeneration": "separate-approved-delivery-only"
+      },
+      "contentRules": {
+        "oneCapability": true,
+        "oneTriggerIntent": true,
+        "nearMissesRequired": true,
+        "collisionSetRequired": true,
+        "observableCompletionRequired": true,
+        "progressiveDisclosure": true,
+        "americanEnglish": true,
+        "projectFactsForbidden": true,
+        "privateFactsForbidden": true,
+        "scriptsForbiddenForPublicSkills": true,
+        "evalsForbiddenInRuntimePayload": true
+      },
+      "cleanRoomReview": {
+        "sourceRevisionRecorded": true,
+        "requirementLevelNotesOnly": true,
+        "phraseSimilarityReviewRequired": true,
+        "structuralSimilarityReviewRequired": true,
+        "copiedWordingForbidden": true,
+        "copiedHeadingsForbidden": true,
+        "copiedExamplesForbidden": true,
+        "copiedTemplatesForbidden": true,
+        "copiedPersonasForbidden": true,
+        "copiedScriptsForbidden": true
+      },
+      "requiredEvidenceKinds": [
+        "behavior",
+        "positive-trigger",
+        "negative-trigger",
+        "collision",
+        "security",
+        "portability",
+        "source-review"
+      ],
+      "evidenceIds": [
+        "ecosystem-use-cases",
+        "third-party-skills-evaluation"
+      ]
+    }
+  ]
+}

--- a/catalog/v2/human-catalog.json
+++ b/catalog/v2/human-catalog.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 2,
+  "contractVersion": 1,
+  "outputRoot": "catalog/generated/human-catalog",
+  "generatedFiles": {
+    "data": "catalog.json",
+    "markdown": "CATALOG.md",
+    "manifest": "manifest.json"
+  },
+  "includeAudiences": ["public"],
+  "includeUnapprovedTargets": true,
+  "includeRuntimePayloadBytes": false,
+  "referenceExpansion": "complete-bounded",
+  "requiredCapabilitySections": [
+    "identity",
+    "purpose",
+    "when-to-use",
+    "when-not-to-use",
+    "invocation",
+    "applicability",
+    "dependencies",
+    "trust-and-effects",
+    "evidence-and-support",
+    "related-capabilities",
+    "bundle-membership"
+  ],
+  "disclaimer": "Catalog inclusion, evaluation evidence, bundle generation, or publication does not grant runtime permission or approval.",
+  "limits": {
+    "maximumInputBytes": 16777216,
+    "maximumJsonDepth": 64,
+    "maximumItemsPerRegistry": 10000,
+    "maximumStringBytes": 1048576,
+    "maximumGeneratedFiles": 16,
+    "maximumGeneratedBytes": 16777216
+  },
+  "determinism": {
+    "timestamps": false,
+    "environmentValues": false,
+    "networkAccess": false,
+    "ordering": "ordinal",
+    "encoding": "utf-8",
+    "lineEndings": "lf",
+    "jsonIndentation": 2,
+    "terminalNewline": true
+  }
+}

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "8ac6f0660e84a14a5e051db2f0b0b18a4a9bd803df86ced9a3654ac7fcf4eca9",
+  "indexDigest": "a9e337da46f169bd905260f18edcb73c90dfcb87affa28fd20b0893bce9ba7bf",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -147,11 +147,27 @@
       "status": "added"
     },
     {
+      "path": "Documentation/skill-authoring-contract.md",
+      "status": "added"
+    },
+    {
       "path": "Documentation/skill-classification-audit.md",
       "status": "added"
     },
     {
       "path": "catalog/ecosystem-versions.json",
+      "status": "added"
+    },
+    {
+      "path": "catalog/generated/human-catalog/CATALOG.md",
+      "status": "added"
+    },
+    {
+      "path": "catalog/generated/human-catalog/catalog.json",
+      "status": "added"
+    },
+    {
+      "path": "catalog/generated/human-catalog/manifest.json",
       "status": "added"
     },
     {
@@ -183,11 +199,19 @@
       "status": "added"
     },
     {
+      "path": "catalog/v2/authoring-contracts.json",
+      "status": "added"
+    },
+    {
       "path": "catalog/v2/bundles.json",
       "status": "added"
     },
     {
       "path": "catalog/v2/evidence.json",
+      "status": "added"
+    },
+    {
+      "path": "catalog/v2/human-catalog.json",
       "status": "added"
     },
     {
@@ -295,6 +319,10 @@
       "status": "added"
     },
     {
+      "path": "tooling/generate-human-catalog.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/generate-repository-inventory.mjs",
       "status": "added"
     },
@@ -316,6 +344,10 @@
     },
     {
       "path": "tooling/specs/catalog-validation.spec.mjs",
+      "status": "added"
+    },
+    {
+      "path": "tooling/specs/human-catalog.spec.mjs",
       "status": "added"
     },
     {
@@ -1142,6 +1174,32 @@
     },
     {
       "excludePathPatterns": [],
+      "id": "skill-authoring-documentation",
+      "sourcePathPatterns": [
+        "Documentation/skill-authoring-contract.md"
+      ],
+      "artifactType": "documentation",
+      "currentOwner": "repository-only authoring/release tooling",
+      "targetOwner": "repository-only authoring/release tooling",
+      "runtimeEligibility": "repository-only",
+      "generatedStatus": "source",
+      "adapterStatus": "none",
+      "dependencies": [
+        "catalog/v2/authoring-contracts.json",
+        "catalog/v2/human-catalog.json",
+        "tooling/generate-human-catalog.mjs"
+      ],
+      "risk": "medium",
+      "migrationState": "retain",
+      "evidenceIds": [
+        "ecosystem-use-cases",
+        "third-party-skills-evaluation"
+      ],
+      "expectedPathCount": 1,
+      "expectedPathsDigest": "72c58a7f75edd132552b00b3bbdbe9e4b406548c3286c742e4fc21ea27c9468a"
+    },
+    {
+      "excludePathPatterns": [],
       "id": "catalog-v1-scaffold",
       "sourcePathPatterns": [
         "catalog/ecosystem-versions.json",
@@ -1172,7 +1230,9 @@
       "excludePathPatterns": [],
       "id": "catalog-v2-authored-registries",
       "sourcePathPatterns": [
+        "catalog/v2/authoring-contracts.json",
         "catalog/v2/bundles.json",
+        "catalog/v2/human-catalog.json",
         "catalog/v2/source-contracts.json",
         "catalog/v2/taxonomy.json",
         "catalog/v2/upstream-companions.json"
@@ -1193,12 +1253,14 @@
         "ecosystem-use-cases",
         "third-party-skills-evaluation"
       ],
-      "expectedPathCount": 4,
-      "expectedPathsDigest": "ec3ac58212de700f909cb30e4e3761dc16a1eed0d6a0c210fd8b625ba2761a95"
+      "expectedPathCount": 6,
+      "expectedPathsDigest": "3350efe628cafcb336a57b5c118a4789687fb83bce6c360752fd69aed5938b75"
     },
     {
       "excludePathPatterns": [
+        "catalog/v2/authoring-contracts.json",
         "catalog/v2/bundles.json",
+        "catalog/v2/human-catalog.json",
         "catalog/v2/source-contracts.json",
         "catalog/v2/taxonomy.json",
         "catalog/v2/upstream-companions.json"
@@ -1225,6 +1287,32 @@
       "generator": "tooling/generate-catalog-v2.mjs and tooling/generate-repository-inventory.mjs",
       "expectedPathCount": 7,
       "expectedPathsDigest": "e357183a0be12bfbbdea6835b9946fc8b10004c5c902cb1dd4a9d96c105a32c8"
+    },
+    {
+      "excludePathPatterns": [],
+      "id": "generated-human-catalog",
+      "sourcePathPatterns": [
+        "catalog/generated/human-catalog/**"
+      ],
+      "artifactType": "documentation",
+      "currentOwner": "repository-only authoring/release tooling",
+      "targetOwner": "repository-only authoring/release tooling",
+      "runtimeEligibility": "repository-only",
+      "generatedStatus": "generated",
+      "adapterStatus": "none",
+      "dependencies": [
+        "catalog/v2/human-catalog.json",
+        "catalog/v2/targets.json",
+        "tooling/generate-human-catalog.mjs"
+      ],
+      "risk": "medium",
+      "migrationState": "retain",
+      "evidenceIds": [
+        "option-a-plus-authority"
+      ],
+      "generator": "tooling/generate-human-catalog.mjs",
+      "expectedPathCount": 3,
+      "expectedPathsDigest": "61a75cf6c23c8f3f8ed848eed741ef65aad391f1132c9baa0f8719455757c7db"
     },
     {
       "excludePathPatterns": [],
@@ -1269,8 +1357,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 8,
-      "expectedPathsDigest": "ba097e98690b3dbb288c3b2cacc6d4ab1418572db214c07253c91863537f1958"
+      "expectedPathCount": 9,
+      "expectedPathsDigest": "ef466bcc5f8eafcf6d355a607462bb158fa37e1f1c62e93097b3af547cd72d69"
     },
     {
       "excludePathPatterns": [],
@@ -1293,8 +1381,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 5,
-      "expectedPathsDigest": "dd3f31be67af69b280aa4b2b10008d8dac30af7199aaaab3e3b0351583111c73"
+      "expectedPathCount": 6,
+      "expectedPathsDigest": "5cded27045420ef685ebe1efd9038a3f6929fe0ab7b7553b8bdc03d372c1718e"
     },
     {
       "excludePathPatterns": [],

--- a/catalog/v2/targets.json
+++ b/catalog/v2/targets.json
@@ -53,6 +53,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Application React specifications",
       "positiveTriggerIntent": "Use for React or TypeScript behavior in a Cratis application slice.",
       "nearMissExclusions": [
@@ -182,6 +184,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Application slice diagnostics",
       "positiveTriggerIntent": "Use when a Cratis slice misbehaves and source-level cause is unclear.",
       "nearMissExclusions": [
@@ -315,6 +319,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Application slice specifications",
       "positiveTriggerIntent": "Use to route event-sourced application backend behavior to the correct in-process scenario family.",
       "nearMissExclusions": [
@@ -448,6 +454,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Cratis application vertical slices",
       "positiveTriggerIntent": "Use for vertical-slice architecture selection or end-to-end implementation after the merge experiment passes.",
       "nearMissExclusions": [
@@ -579,6 +587,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Arc authentication, authorization, and identity",
       "positiveTriggerIntent": "Use for Arc identity providers, endpoint protection, roles, or frontend identity integration.",
       "nearMissExclusions": [
@@ -710,6 +720,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Arc command definition",
       "positiveTriggerIntent": "Use when defining an Arc command and its generated full-stack proxy workflow.",
       "nearMissExclusions": [
@@ -838,6 +850,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Arc command pipeline execution",
       "positiveTriggerIntent": "Use when backend code must execute an existing Arc command through ICommandPipeline.",
       "nearMissExclusions": [
@@ -963,6 +977,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Arc command validation",
       "positiveTriggerIntent": "Use when adding validation or state-dependent rejection to an existing Arc command.",
       "nearMissExclusions": [
@@ -1090,6 +1106,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Arc EF Core migrations",
       "positiveTriggerIntent": "Use when adding or changing an EF Core schema in a Cratis application.",
       "nearMissExclusions": [
@@ -1214,6 +1232,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Arc observable-query HTTP diagnostics",
       "positiveTriggerIntent": "Use when inspecting Arc observable query SSE or streaming behavior with curl or HTTP tools.",
       "nearMissExclusions": [
@@ -1340,6 +1360,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Arc query paging",
       "positiveTriggerIntent": "Use when adding server-side paging and sorting to an Arc read-model query.",
       "nearMissExclusions": [
@@ -1470,6 +1492,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Arc React feature scaffolding",
       "positiveTriggerIntent": "Use when creating an empty route, navigation entry, and feature composition shell.",
       "nearMissExclusions": [
@@ -1597,6 +1621,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Arc React pages",
       "positiveTriggerIntent": "Use when building a DataPage or MVVM React page backed by generated Arc queries.",
       "nearMissExclusions": [
@@ -1725,6 +1751,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Chronicle CLI operations",
       "positiveTriggerIntent": "Use to inspect a running Chronicle store and, only with explicit confirmation, perform recovery operations.",
       "nearMissExclusions": [
@@ -1853,6 +1881,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Chronicle event constraints",
       "positiveTriggerIntent": "Use when enforcing append-time uniqueness, concurrency, or event-store constraints.",
       "nearMissExclusions": [
@@ -1979,6 +2009,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Chronicle event metadata",
       "positiveTriggerIntent": "Use when attaching audit, actor, tenant, or correlation metadata outside domain event payloads.",
       "nearMissExclusions": [
@@ -2103,6 +2135,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Chronicle event modeling",
       "positiveTriggerIntent": "Use before implementation when commands, events, streams, read models, or reactions are unsettled.",
       "nearMissExclusions": [
@@ -2229,6 +2263,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Chronicle event specifications",
       "positiveTriggerIntent": "Use for EventScenario append, constraint, concurrency, or sequence behavior.",
       "nearMissExclusions": [
@@ -2352,6 +2388,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Chronicle event type migration",
       "positiveTriggerIntent": "Use when a stored event schema needs a new generation and migration.",
       "nearMissExclusions": [
@@ -2476,6 +2514,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Chronicle multi-tenancy",
       "positiveTriggerIntent": "Use when isolating tenants through Chronicle namespaces and Arc tenant resolution.",
       "nearMissExclusions": [
@@ -2601,6 +2641,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Chronicle projections",
       "positiveTriggerIntent": "Use when adding projection behavior to an existing Chronicle read model.",
       "nearMissExclusions": [
@@ -2728,6 +2770,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Chronicle reactors",
       "positiveTriggerIntent": "Use when implementing an automation or translation that reacts to events.",
       "nearMissExclusions": [
@@ -2858,6 +2902,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Chronicle read models",
       "positiveTriggerIntent": "Use when creating a Chronicle read model and model-bound query surface.",
       "nearMissExclusions": [
@@ -2989,6 +3035,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Chronicle read-model specifications",
       "positiveTriggerIntent": "Use for ReadModelScenario projection or reducer behavior.",
       "nearMissExclusions": [
@@ -3115,6 +3163,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Chronicle reducers",
       "positiveTriggerIntent": "Use when a current-state-plus-event transition cannot be expressed as a projection.",
       "nearMissExclusions": [
@@ -3242,6 +3292,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Cratis code review",
       "positiveTriggerIntent": "Use for a general correctness and maintainability review of Cratis code.",
       "nearMissExclusions": [
@@ -3369,6 +3421,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Cratis Components stepper command dialogs",
       "positiveTriggerIntent": "Use when a command requires a multi-step wizard dialog.",
       "nearMissExclusions": [
@@ -3493,6 +3547,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Cratis Components toolbar",
       "positiveTriggerIntent": "Use when building a canvas-style icon toolbar with active tools or fan-out controls.",
       "nearMissExclusions": [
@@ -3615,6 +3671,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Chronicle Kernel tracing maintenance",
       "positiveTriggerIntent": "Use by Chronicle framework maintainers to add generated OpenTelemetry traces.",
       "nearMissExclusions": [
@@ -3724,6 +3782,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Cratis C# engineering conventions",
       "positiveTriggerIntent": "Use for Cratis-maintainer C# house standards and review policy.",
       "nearMissExclusions": [
@@ -3835,6 +3895,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Cratis documentation page creation",
       "positiveTriggerIntent": "Use by Cratis maintainers to add a source-owned product documentation page.",
       "nearMissExclusions": [
@@ -3947,6 +4009,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Cratis documentation authoring",
       "positiveTriggerIntent": "Use by Cratis maintainers to apply Diátaxis and documentation writing guidance.",
       "nearMissExclusions": [
@@ -4059,6 +4123,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Cratis documentation page editing",
       "positiveTriggerIntent": "Use by Cratis maintainers to edit the source-owned copy of an existing documentation page.",
       "nearMissExclusions": [
@@ -4171,6 +4237,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Cratis documentation visual QA",
       "positiveTriggerIntent": "Use by Cratis maintainers to render and inspect documentation in light and dark modes.",
       "nearMissExclusions": [
@@ -4282,6 +4350,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Cratis change shipping",
       "positiveTriggerIntent": "Use only after an explicit request to commit, push, open, or merge a Cratis pull request.",
       "nearMissExclusions": [
@@ -4392,6 +4462,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Event-model diagrams",
       "positiveTriggerIntent": "Use when creating or maintaining a Mermaid EventModel.md diagram for settled behavior.",
       "nearMissExclusions": [
@@ -4514,6 +4586,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Strongly typed Cratis concepts",
       "positiveTriggerIntent": "Use when creating a ConceptAs<T> value or EventSourceId<T> identity.",
       "nearMissExclusions": [
@@ -4633,6 +4707,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Cratis implementation discovery",
       "positiveTriggerIntent": "Use when a service must enumerate all implementations through IInstancesOf<T>.",
       "nearMissExclusions": [
@@ -4754,6 +4830,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Cratis performance review",
       "positiveTriggerIntent": "Use for focused Chronicle, database, .NET, or React scalability analysis.",
       "nearMissExclusions": [
@@ -4881,6 +4959,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Cratis security review",
       "positiveTriggerIntent": "Use for focused authentication, authorization, data exposure, event-sourcing, and frontend security review.",
       "nearMissExclusions": [
@@ -5006,6 +5086,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Cratis C# specification foundations",
       "positiveTriggerIntent": "Use for framework or library C# Specification by Example tests.",
       "nearMissExclusions": [
@@ -5131,6 +5213,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Cratis TypeScript specification foundations",
       "positiveTriggerIntent": "Use for framework or package TypeScript Specification by Example tests.",
       "nearMissExclusions": [
@@ -5253,6 +5337,8 @@
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
       "capability": "Skill authoring and evaluation",
       "positiveTriggerIntent": "Use by trusted maintainers to create, improve, and evaluate Agent Skills.",
       "nearMissExclusions": [

--- a/tooling/catalog-v2-validation.mjs
+++ b/tooling/catalog-v2-validation.mjs
@@ -31,6 +31,8 @@ export const v2CatalogPaths = {
     sourceContracts: "catalog/v2/source-contracts.json",
     bundles: "catalog/v2/bundles.json",
     upstreamCompanions: "catalog/v2/upstream-companions.json",
+    authoringContracts: "catalog/v2/authoring-contracts.json",
+    humanCatalog: "catalog/v2/human-catalog.json",
 };
 
 export const v2SchemaPath = "catalog/schemas/v2/catalog-v2.schema.json";
@@ -47,6 +49,8 @@ const schemaDefinitionByCatalog = {
     sourceContracts: "sourceContractsCatalog",
     bundles: "bundlesCatalog",
     upstreamCompanions: "upstreamCompanionsCatalog",
+    authoringContracts: "authoringContractsCatalog",
+    humanCatalog: "humanCatalogContract",
 };
 
 function duplicates(values) {
@@ -368,6 +372,12 @@ export function validateTargets(catalogs) {
             (companion) => companion.id,
         ),
     );
+    const authoringContractsById = new Map(
+        catalogs.authoringContracts.contracts.map((contract) => [
+            contract.id,
+            contract,
+        ]),
+    );
     const productIds = taxonomyIds(catalogs, "products");
     const languageIds = taxonomyIds(catalogs, "languages");
     const architectureIds = taxonomyIds(catalogs, "architectures");
@@ -594,6 +604,37 @@ export function validateTargets(catalogs) {
                 }
             }
         }
+        if (
+            target.authoringContractState === "unclassified" &&
+            target.authoringContractIds.length > 0
+        ) {
+            errors.push(
+                `${target.id}: authoring contracts require classified state`,
+            );
+        }
+        if (
+            target.authoringContractState === "classified" &&
+            target.authoringContractIds.length === 0
+        ) {
+            errors.push(
+                `${target.id}: classified authoring contracts cannot be empty`,
+            );
+        }
+        for (const authoringContractId of target.authoringContractIds) {
+            const authoringContract =
+                authoringContractsById.get(authoringContractId);
+            if (!authoringContract)
+                errors.push(
+                    `${target.id}: unknown authoring contract ${authoringContractId}`,
+                );
+            else if (
+                target.approval.state === "approved" &&
+                authoringContract.state !== "active"
+            )
+                errors.push(
+                    `${target.id}: approved target needs active authoring contract ${authoringContractId}`,
+                );
+        }
         for (const sourceId of target.sourceSkillIds) {
             if (!sourceIds.has(sourceId))
                 errors.push(`${target.id}: unknown source ${sourceId}`);
@@ -712,6 +753,18 @@ export function validateTargets(catalogs) {
             if (target.sourceContractState !== "classified")
                 errors.push(
                     `${target.id}: approved target needs classified source contracts`,
+                );
+            if (target.authoringContractState !== "classified")
+                errors.push(
+                    `${target.id}: approved target needs classified authoring contracts`,
+                );
+            if (
+                !target.authoringContractIds.includes(
+                    "cratis-skill-clean-room-v1",
+                )
+            )
+                errors.push(
+                    `${target.id}: approved target needs the Cratis clean-room authoring contract`,
                 );
             if (
                 target.audience === "public" &&
@@ -1168,6 +1221,29 @@ export function validateBundles(catalogs) {
         "bundles",
         catalogs.bundles.bundles.map((bundle) => bundle.id),
     );
+    const optionalCandidatesByRoot = new Map();
+    function optionalCandidatesForRoot(rootTargetId) {
+        const cached = optionalCandidatesByRoot.get(rootTargetId);
+        if (cached) return cached;
+        const optionalCandidates = new Set();
+        const visited = new Set();
+        const pending = [rootTargetId];
+        while (pending.length > 0) {
+            const targetId = pending.pop();
+            if (visited.has(targetId)) continue;
+            visited.add(targetId);
+            const target = targetsById.get(targetId);
+            if (target?.dependencyClassificationState !== "classified")
+                continue;
+            for (const edge of target.dependencyEdges) {
+                if (edge.category !== "target") continue;
+                if (edge.strength === "hard") pending.push(edge.dependencyId);
+                else optionalCandidates.add(edge.dependencyId);
+            }
+        }
+        optionalCandidatesByRoot.set(rootTargetId, optionalCandidates);
+        return optionalCandidates;
+    }
     for (const bundle of catalogs.bundles.bundles) {
         const selectedTargetIds = [
             ...bundle.rootTargetIds,
@@ -1204,24 +1280,9 @@ export function validateBundles(catalogs) {
             }
         }
         const optionalCandidates = new Set();
-        const visited = new Set();
-        const pending = [...bundle.rootTargetIds];
-        while (pending.length > 0) {
-            const targetId = pending.pop();
-            if (visited.has(targetId)) continue;
-            visited.add(targetId);
-            const target = targetsById.get(targetId);
-            if (target?.dependencyClassificationState !== "classified")
-                continue;
-            for (const edge of target.dependencyEdges) {
-                if (edge.category !== "target") continue;
-                if (edge.strength === "hard") {
-                    if (selectedTargets.has(edge.dependencyId))
-                        pending.push(edge.dependencyId);
-                } else {
-                    optionalCandidates.add(edge.dependencyId);
-                }
-            }
+        for (const rootTargetId of bundle.rootTargetIds) {
+            for (const targetId of optionalCandidatesForRoot(rootTargetId))
+                optionalCandidates.add(targetId);
         }
         for (const targetId of bundle.selectedSoftOrOptionalTargetIds) {
             if (!optionalCandidates.has(targetId))
@@ -1293,6 +1354,122 @@ export function validateUpstreamCompanions(catalogs) {
                 errors.push(`${companion.id}: unknown evidence ${evidenceId}`);
         }
     }
+    return errors;
+}
+
+export function validateAuthoringContracts(catalogs) {
+    const errors = [];
+    const evidenceIds = new Set(
+        catalogs.evidence.evidence.map((evidence) => evidence.id),
+    );
+    addDuplicateErrors(
+        errors,
+        "authoring contracts",
+        catalogs.authoringContracts.contracts.map((contract) => contract.id),
+    );
+    const activeContracts = catalogs.authoringContracts.contracts.filter(
+        (contract) => contract.state === "active",
+    );
+    if (activeContracts.length !== 1)
+        errors.push("exactly one authoring contract must be active");
+    const cleanRoom = catalogs.authoringContracts.contracts.find(
+        (contract) => contract.id === "cratis-skill-clean-room-v1",
+    );
+    if (!cleanRoom || cleanRoom.state !== "active")
+        errors.push("the Cratis clean-room skill contract must be active");
+    if (cleanRoom) {
+        if (
+            !equalStringSets(cleanRoom.outputPolicy.requiredFrontmatterKeys, [
+                "name",
+                "description",
+            ])
+        ) {
+            errors.push(
+                `${cleanRoom.id}: required frontmatter must be exactly name and description`,
+            );
+        }
+        const requiredEvidenceKinds = [
+            "behavior",
+            "positive-trigger",
+            "negative-trigger",
+            "collision",
+            "security",
+            "portability",
+            "source-review",
+        ];
+        if (
+            !equalStringSets(
+                cleanRoom.requiredEvidenceKinds,
+                requiredEvidenceKinds,
+            )
+        ) {
+            errors.push(
+                `${cleanRoom.id}: required evidence kinds must match the release gate`,
+            );
+        }
+    }
+    for (const contract of catalogs.authoringContracts.contracts) {
+        for (const evidenceId of contract.evidenceIds) {
+            if (!evidenceIds.has(evidenceId))
+                errors.push(`${contract.id}: unknown evidence ${evidenceId}`);
+        }
+    }
+    return errors;
+}
+
+function validateRelativeGeneratedPath(path, label, errors) {
+    const segments = path.split("/");
+    if (
+        isAbsolute(path) ||
+        path.includes("\\") ||
+        segments.some(
+            (segment) =>
+                segment === "" || segment === "." || segment === "..",
+        )
+    ) {
+        errors.push(`${label} must be a normalized relative path`);
+    }
+}
+
+export function validateHumanCatalogContract(catalogs) {
+    const errors = [];
+    const contract = catalogs.humanCatalog;
+    validateRelativeGeneratedPath(
+        contract.outputRoot,
+        "human catalog output root",
+        errors,
+    );
+    for (const [kind, path] of Object.entries(contract.generatedFiles))
+        validateRelativeGeneratedPath(path, `human catalog ${kind}`, errors);
+    if (!contract.outputRoot.startsWith("catalog/generated/"))
+        errors.push("human catalog output must remain under catalog/generated");
+    if (!equalStringSets(contract.includeAudiences, ["public"]))
+        errors.push("human catalog can include only public targets");
+    if (contract.includeRuntimePayloadBytes)
+        errors.push("human catalog can never include runtime payload bytes");
+    const requiredSections = [
+        "identity",
+        "purpose",
+        "when-to-use",
+        "when-not-to-use",
+        "invocation",
+        "applicability",
+        "dependencies",
+        "trust-and-effects",
+        "evidence-and-support",
+        "related-capabilities",
+        "bundle-membership",
+    ];
+    if (
+        !equalStringSets(
+            contract.requiredCapabilitySections,
+            requiredSections,
+        )
+    ) {
+        errors.push("human catalog sections must match the product contract");
+    }
+    if (!contract.disclaimer.includes("does not grant runtime permission"))
+        errors.push("human catalog disclaimer must deny runtime permission");
     return errors;
 }
 
@@ -1599,6 +1776,8 @@ export function validateV2Catalogs(root = defaultRepositoryRoot) {
     errors.push(...validateSourceContracts(catalogs));
     errors.push(...validateBundles(catalogs));
     errors.push(...validateUpstreamCompanions(catalogs));
+    errors.push(...validateAuthoringContracts(catalogs));
+    errors.push(...validateHumanCatalogContract(catalogs));
     errors.push(...validateArtifacts(catalogs));
     errors.push(...validateRepositoryInventory(catalogs, root));
     return errors;

--- a/tooling/generate-catalog-v2.mjs
+++ b/tooling/generate-catalog-v2.mjs
@@ -720,6 +720,8 @@ const targets = allTargetIds.map((targetId) => {
         sourceContractState: "unclassified",
         sourceContractIds: [],
         sourceAuthoritySubjects: [],
+        authoringContractState: "unclassified",
+        authoringContractIds: [],
         capability: profile[0],
         positiveTriggerIntent: profile[1],
         nearMissExclusions: profile[2],

--- a/tooling/generate-human-catalog.mjs
+++ b/tooling/generate-human-catalog.mjs
@@ -1,0 +1,511 @@
+#!/usr/bin/env node
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { isUtf8 } from "node:buffer";
+import { createHash } from "node:crypto";
+import {
+    existsSync,
+    mkdirSync,
+    readFileSync,
+    readdirSync,
+    renameSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { compareOrdinal } from "./catalog-ordering.mjs";
+import {
+    readCatalog,
+    validateAgainstSchema,
+} from "./catalog-validation.mjs";
+import { v2SchemaPath } from "./catalog-v2-validation.mjs";
+import { assertSafeContent } from "./public-artifact-materializer.mjs";
+
+const repositoryRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const inputPaths = [
+    "catalog/v2/authoring-contracts.json",
+    "catalog/v2/bundles.json",
+    "catalog/v2/evidence.json",
+    "catalog/v2/human-catalog.json",
+    "catalog/v2/source-contracts.json",
+    "catalog/v2/targets.json",
+    "catalog/v2/taxonomy.json",
+    "catalog/v2/upstream-companions.json",
+];
+
+function sha256(content) {
+    return createHash("sha256").update(content).digest("hex");
+}
+
+function inputDigest(contents) {
+    const hash = createHash("sha256");
+    for (const path of [...inputPaths].sort(compareOrdinal)) {
+        hash.update(path);
+        hash.update("\0");
+        hash.update(contents.get(path));
+        hash.update("\0");
+    }
+    return hash.digest("hex");
+}
+
+function parseInput(path, content) {
+    if (!isUtf8(content))
+        throw new Error(`Human catalog input must be valid UTF-8: ${path}`);
+    try {
+        return JSON.parse(content.toString("utf8"));
+    } catch (error) {
+        throw new Error(`Human catalog input must be strict JSON: ${path}`, {
+            cause: error,
+        });
+    }
+}
+
+function loadInputs() {
+    const contractPath = "catalog/v2/human-catalog.json";
+    const contractContent = readFileSync(join(repositoryRoot, contractPath));
+    if (contractContent.length > 1024 * 1024)
+        throw new Error("Human catalog contract exceeds bootstrap size limit");
+    const humanContract = parseInput(contractPath, contractContent);
+    if (contractContent.length > humanContract.limits.maximumInputBytes)
+        throw new Error("Human catalog inputs exceed maximum input bytes");
+    const contents = new Map([[contractPath, contractContent]]);
+    let totalBytes = contractContent.length;
+    for (const path of inputPaths) {
+        if (path === contractPath) continue;
+        const content = readFileSync(join(repositoryRoot, path));
+        totalBytes += content.length;
+        if (totalBytes > humanContract.limits.maximumInputBytes)
+            throw new Error("Human catalog inputs exceed maximum input bytes");
+        contents.set(path, content);
+    }
+    const catalogs = new Map([[contractPath, humanContract]]);
+    assertBounded(humanContract, humanContract.limits);
+    for (const [path, content] of contents) {
+        if (path === contractPath) continue;
+        const catalog = parseInput(path, content);
+        assertBounded(catalog, humanContract.limits);
+        catalogs.set(path, catalog);
+    }
+    return {
+        catalogs,
+        digest: inputDigest(contents),
+        humanContract,
+    };
+}
+
+function json(value) {
+    return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function assertBounded(value, limits, depth = 0) {
+    if (depth > limits.maximumJsonDepth)
+        throw new Error("Human catalog input exceeds maximum JSON depth");
+    if (typeof value === "string") {
+        if (Buffer.byteLength(value) > limits.maximumStringBytes)
+            throw new Error("Human catalog input exceeds maximum string size");
+        return;
+    }
+    if (Array.isArray(value)) {
+        if (value.length > limits.maximumItemsPerRegistry)
+            throw new Error("Human catalog input exceeds maximum registry size");
+        for (const item of value) assertBounded(item, limits, depth + 1);
+        return;
+    }
+    if (value && typeof value === "object") {
+        for (const item of Object.values(value))
+            assertBounded(item, limits, depth + 1);
+    }
+}
+
+export function markdownText(value) {
+    return value
+        .replaceAll("\\", "\\\\")
+        .replaceAll("`", "\\`")
+        .replaceAll("*", "\\*")
+        .replaceAll("_", "\\_")
+        .replaceAll("[", "\\[")
+        .replaceAll("]", "\\]")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replace(/[\r\n]+/g, " ");
+}
+
+function applicabilityText(applicability) {
+    if (applicability.state === "applicable")
+        return applicability.ids.join(", ");
+    if (applicability.state === "not-applicable")
+        return `Not applicable — ${markdownText(applicability.reason)}`;
+    return `Unclassified — ${markdownText(applicability.reason)}`;
+}
+
+function renderList(values, fallback = "None") {
+    return values.length > 0
+        ? values.map((value) => `- ${markdownText(value)}`)
+        : [`- ${markdownText(fallback)}`];
+}
+
+function renderCapability(capability) {
+    const sectionSuffix = ` — ${capability.id}`;
+    const lines = [
+        `## ${capability.semanticName}`,
+        "",
+        `- **ID:** \`${capability.id}\``,
+        `- **Audience:** ${capability.audience}`,
+        `- **Lifecycle:** ${capability.lifecycle}`,
+        `- **Approval:** ${capability.approvalState}`,
+        `- **Runtime eligible:** ${capability.runtimeEligible ? "yes" : "no"}`,
+        "",
+        `### Purpose${sectionSuffix}`,
+        "",
+        markdownText(capability.purpose),
+        "",
+        `### When to use${sectionSuffix}`,
+        "",
+        markdownText(capability.whenToUse),
+        "",
+        `### When not to use${sectionSuffix}`,
+        "",
+        ...renderList(capability.whenNotToUse),
+        "",
+        `### Invocation${sectionSuffix}`,
+        "",
+        `- Capability kind: ${capability.capabilityKind}`,
+        `- Invocation: ${capability.invocation}`,
+        "",
+        `### Applicability${sectionSuffix}`,
+        "",
+        `- Products: ${capability.products.join(", ")}`,
+        `- Languages: ${capability.languages.join(", ")}`,
+        `- Architectures: ${applicabilityText(capability.architectures)}`,
+        `- Personas: ${applicabilityText(capability.personas)}`,
+        `- Surfaces: ${applicabilityText(capability.surfaces)}`,
+        `- Repository profiles: ${applicabilityText(capability.repositoryProfiles)}`,
+        "",
+        `### Dependencies${sectionSuffix}`,
+        "",
+        ...renderList(
+            capability.dependencies.map(
+                (edge) =>
+                    `${edge.category}:${edge.dependencyId} (${edge.strength}; missing → ${edge.missingBehavior.action})`,
+            ),
+            "Unclassified",
+        ),
+        "",
+        `### Trust and effects${sectionSuffix}`,
+        "",
+        `- Trust class: ${capability.trust.class}`,
+        `- Assessment: ${capability.trust.assessmentState}`,
+        ...renderList(
+            capability.trust.effects.map(
+                (effect) =>
+                    `${effect.operation} ${effect.resourceBoundary}: ${effect.scope}`,
+            ),
+            "No assessed effects",
+        ),
+        "",
+        `### Evidence and support${sectionSuffix}`,
+        "",
+        ...renderList(
+            capability.authoringContractIds.map(
+                (id) => `Authoring contract: ${id}`,
+            ),
+            "Authoring contract unclassified",
+        ),
+        ...renderList(capability.evidenceIds.map((id) => `Evidence: ${id}`)),
+        "",
+        `### Related capabilities${sectionSuffix}`,
+        "",
+        ...renderList(capability.relatedTargetIds),
+        "",
+        `### Bundle membership${sectionSuffix}`,
+        "",
+        ...renderList(capability.bundleIds),
+    ];
+    return lines;
+}
+
+function renderCapabilities(capabilities) {
+    const lines = [];
+    capabilities.forEach((capability, index) => {
+        lines.push(...renderCapability(capability));
+        if (index + 1 < capabilities.length) lines.push("");
+    });
+    return lines;
+}
+
+function canonicalApplicability(applicability) {
+    return {
+        state: applicability.state,
+        ids: [...applicability.ids].sort(compareOrdinal),
+        reason: applicability.reason,
+    };
+}
+
+function canonicalEffect(effect) {
+    const record = {
+        id: effect.id,
+        operation: effect.operation,
+        resourceBoundary: effect.resourceBoundary,
+        scope: effect.scope,
+        dataClassifications: [...effect.dataClassifications].sort(compareOrdinal),
+        reversible: effect.reversible,
+        confirmation: {
+            required: effect.confirmation.required,
+            timing: effect.confirmation.timing,
+            reason: effect.confirmation.reason,
+        },
+        authorization: {
+            required: effect.authorization.required,
+            authority: effect.authorization.authority,
+            evidenceIds: [...effect.authorization.evidenceIds].sort(
+                compareOrdinal,
+            ),
+        },
+        evidenceIds: [...effect.evidenceIds].sort(compareOrdinal),
+    };
+    if (effect.rollbackOrCompensation)
+        Object.assign(record, {
+            rollbackOrCompensation: effect.rollbackOrCompensation,
+        });
+    return record;
+}
+
+function canonicalTrust(trust) {
+    return {
+        class: trust.class,
+        assessmentState: trust.assessmentState,
+        effects: trust.effects
+            .map(canonicalEffect)
+            .sort((left, right) => compareOrdinal(left.id, right.id)),
+    };
+}
+
+export function buildHumanCatalogOutputs() {
+    const schema = readCatalog(join(repositoryRoot, v2SchemaPath));
+    const { catalogs, digest, humanContract } = loadInputs();
+    const targets = catalogs.get("catalog/v2/targets.json").targets;
+    const bundles = catalogs.get("catalog/v2/bundles.json").bundles;
+
+    const publicTargetIds = new Set(
+        targets
+            .filter((target) => target.audience === "public")
+            .map((target) => target.id),
+    );
+    const bundleIdsByTarget = new Map();
+    for (const bundle of bundles) {
+        for (const targetId of [
+            ...bundle.rootTargetIds,
+            ...bundle.selectedSoftOrOptionalTargetIds,
+        ]) {
+            const ids = bundleIdsByTarget.get(targetId) ?? [];
+            ids.push(bundle.id);
+            bundleIdsByTarget.set(targetId, ids);
+        }
+    }
+    const capabilities = targets
+        .filter((target) =>
+            humanContract.includeAudiences.includes(target.audience),
+        )
+        .map((target) => ({
+            id: target.id,
+            semanticName: target.semanticName,
+            audience: target.audience,
+            purpose: target.capability,
+            whenToUse: target.positiveTriggerIntent,
+            whenNotToUse: [...target.nearMissExclusions].sort(compareOrdinal),
+            capabilityKind: target.capabilityKind,
+            invocation: target.invocation,
+            lifecycle: target.lifecycle,
+            approvalState: target.approval.state,
+            runtimeEligible: target.includeInRuntime,
+            products: [...target.products].sort(compareOrdinal),
+            languages: [...target.languages].sort(compareOrdinal),
+            architectures: canonicalApplicability(target.architectures),
+            personas: canonicalApplicability(target.personas),
+            surfaces: canonicalApplicability(target.surfaces),
+            repositoryProfiles: canonicalApplicability(
+                target.repositoryProfiles,
+            ),
+            trust: canonicalTrust(target.trust),
+            dependencies: [...target.dependencyEdges].sort((left, right) =>
+                compareOrdinal(
+                    `${left.category}:${left.dependencyId}`,
+                    `${right.category}:${right.dependencyId}`,
+                ),
+            ),
+            authoringContractIds: [...target.authoringContractIds].sort(
+                compareOrdinal,
+            ),
+            evidenceIds: [...target.evidenceIds].sort(compareOrdinal),
+            relatedTargetIds: [
+                ...new Set([
+                    ...target.collisionSet,
+                    ...target.dependencies.targets,
+                ]),
+            ]
+                .filter((targetId) => publicTargetIds.has(targetId))
+                .sort(compareOrdinal),
+            bundleIds: [...(bundleIdsByTarget.get(target.id) ?? [])].sort(
+                compareOrdinal,
+            ),
+        }))
+        .sort((left, right) => compareOrdinal(left.id, right.id));
+    const data = {
+        schemaVersion: 2,
+        contractVersion: humanContract.contractVersion,
+        disclaimer: humanContract.disclaimer,
+        inputDigest: digest,
+        capabilities,
+    };
+    const dataErrors = validateAgainstSchema(
+        data,
+        schema.$defs.generatedHumanCatalog,
+        schema,
+    );
+    if (dataErrors.length > 0)
+        throw new Error(`Generated human catalog is invalid: ${dataErrors.join("; ")}`);
+
+    const markdownLines = [
+        "# Cratis capability catalog",
+        "",
+        `> ${markdownText(humanContract.disclaimer)}`,
+        "",
+        "This catalog is generated from reviewed catalog metadata. It is a human",
+        "navigation surface, not source authority and not an installation artifact.",
+        "",
+        ...renderCapabilities(capabilities),
+    ];
+    const contents = new Map([
+        [humanContract.generatedFiles.data, Buffer.from(json(data))],
+        [
+            humanContract.generatedFiles.markdown,
+            Buffer.from(`${markdownLines.join("\n")}\n`),
+        ],
+    ]);
+    for (const [path, content] of contents)
+        assertSafeContent(`human-catalog/${path}`, content);
+    const files = [...contents.entries()]
+        .map(([path, content]) => ({
+            path,
+            size: content.length,
+            sha256: sha256(content),
+        }))
+        .sort((left, right) => compareOrdinal(left.path, right.path));
+    const manifest = {
+        schemaVersion: 2,
+        contractVersion: humanContract.contractVersion,
+        inputDigest: digest,
+        files,
+    };
+    const manifestErrors = validateAgainstSchema(
+        manifest,
+        schema.$defs.generatedHumanCatalogManifest,
+        schema,
+    );
+    if (manifestErrors.length > 0)
+        throw new Error(`Generated manifest is invalid: ${manifestErrors.join("; ")}`);
+    contents.set(humanContract.generatedFiles.manifest, Buffer.from(json(manifest)));
+    if (contents.size > humanContract.limits.maximumGeneratedFiles)
+        throw new Error("Human catalog exceeds maximum generated files");
+    const generatedBytes = [...contents.values()].reduce(
+        (total, content) => total + content.length,
+        0,
+    );
+    if (generatedBytes > humanContract.limits.maximumGeneratedBytes)
+        throw new Error("Human catalog exceeds maximum generated bytes");
+    return { contents, humanContract };
+}
+
+function currentFiles(root) {
+    if (!existsSync(root)) return [];
+    const paths = [];
+    function visit(current) {
+        for (const entry of readdirSync(current, { withFileTypes: true })) {
+            const absolutePath = join(current, entry.name);
+            if (entry.isDirectory()) visit(absolutePath);
+            else if (entry.isFile())
+                paths.push(relative(root, absolutePath).split(sep).join("/"));
+            else throw new Error("Generated human catalog contains a non-regular path");
+        }
+    }
+    visit(root);
+    return paths.sort(compareOrdinal);
+}
+
+export function checkHumanCatalogOutputs(outputs, root) {
+    const expectedPaths = [...outputs.keys()].sort(compareOrdinal);
+    const existingPaths = currentFiles(root);
+    if (JSON.stringify(existingPaths) !== JSON.stringify(expectedPaths))
+        throw new Error("Generated human catalog file inventory is stale");
+    for (const [path, content] of outputs) {
+        const current = readFileSync(join(root, path));
+        if (!current.equals(content))
+            throw new Error(`Generated human catalog is stale: ${path}`);
+    }
+}
+
+export function writeHumanCatalogOutputsAtomically(
+    outputs,
+    root,
+    options = {},
+) {
+    const manifestPath = "manifest.json";
+    if (!outputs.has(manifestPath))
+        throw new Error("Generated human catalog requires manifest.json");
+    mkdirSync(root, { recursive: true });
+    const partialPaths = new Map();
+    try {
+        for (const [path, content] of outputs) {
+            const partial = join(root, `${path}.partial-${process.pid}`);
+            mkdirSync(dirname(partial), { recursive: true });
+            writeFileSync(partial, content, { flag: "wx" });
+            partialPaths.set(path, partial);
+        }
+        let publishedDataFiles = 0;
+        for (const path of [...outputs.keys()]
+            .filter((path) => path !== manifestPath)
+            .sort(compareOrdinal)) {
+            renameSync(partialPaths.get(path), join(root, path));
+            publishedDataFiles += 1;
+            if (publishedDataFiles === options.failAfterDataFiles)
+                throw new Error("Injected failure after data publication");
+        }
+        renameSync(
+            partialPaths.get(manifestPath),
+            join(root, manifestPath),
+        );
+        const expectedPaths = new Set(outputs.keys());
+        for (const path of currentFiles(root)) {
+            if (!expectedPaths.has(path))
+                rmSync(join(root, path), { recursive: true, force: true });
+        }
+    } catch (error) {
+        for (const partial of partialPaths.values())
+            rmSync(partial, { force: true });
+        throw error;
+    }
+}
+
+function main() {
+    const { contents, humanContract } = buildHumanCatalogOutputs();
+    const outputRoot = join(repositoryRoot, humanContract.outputRoot);
+    if (process.argv.includes("--check")) {
+        checkHumanCatalogOutputs(contents, outputRoot);
+        process.stdout.write("Generated human catalog is current.\n");
+    } else {
+        mkdirSync(dirname(outputRoot), { recursive: true });
+        writeHumanCatalogOutputsAtomically(contents, outputRoot);
+        process.stdout.write(
+            `Generated human catalog: ${contents.size} files under ${humanContract.outputRoot}.\n`,
+        );
+    }
+}
+
+if (
+    process.argv[1] &&
+    resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+    main();
+}

--- a/tooling/generate-repository-inventory.mjs
+++ b/tooling/generate-repository-inventory.mjs
@@ -101,7 +101,7 @@ const unexpectedUntracked = admittedUntracked.filter(
     (path) =>
         !(
             /^AI-REPOSITORY-REDESIGN-[A-Z0-9-]+\.md$/.test(path) ||
-            /^Documentation\/(?:capability-catalog-v2|phase-0-verification|public-product-architecture|skill-classification-audit|project-context-bootstrap|redesign-foundation-validation)\.md$/.test(
+            /^Documentation\/(?:capability-catalog-v2|phase-0-verification|public-product-architecture|skill-authoring-contract|skill-classification-audit|project-context-bootstrap|redesign-foundation-validation)\.md$/.test(
                 path,
             ) ||
             /^Documentation\/evidence\/redesign-autonomous-execution-2026-08-20\//.test(
@@ -647,6 +647,27 @@ const definitions = [
         evidenceIds: ["option-a-plus-authority"],
     },
     {
+        id: "skill-authoring-documentation",
+        sourcePathPatterns: ["Documentation/skill-authoring-contract.md"],
+        artifactType: "documentation",
+        currentOwner: repositoryOwner,
+        targetOwner: repositoryOwner,
+        runtimeEligibility: "repository-only",
+        generatedStatus: "source",
+        adapterStatus: "none",
+        dependencies: [
+            "catalog/v2/authoring-contracts.json",
+            "catalog/v2/human-catalog.json",
+            "tooling/generate-human-catalog.mjs",
+        ],
+        risk: "medium",
+        migrationState: "retain",
+        evidenceIds: [
+            "ecosystem-use-cases",
+            "third-party-skills-evaluation",
+        ],
+    },
+    {
         id: "catalog-v1-scaffold",
         sourcePathPatterns: [
             "catalog/ecosystem-versions.json",
@@ -670,7 +691,9 @@ const definitions = [
     {
         id: "catalog-v2-authored-registries",
         sourcePathPatterns: [
+            "catalog/v2/authoring-contracts.json",
             "catalog/v2/bundles.json",
+            "catalog/v2/human-catalog.json",
             "catalog/v2/source-contracts.json",
             "catalog/v2/taxonomy.json",
             "catalog/v2/upstream-companions.json",
@@ -696,7 +719,9 @@ const definitions = [
         id: "catalog-v2-generated-surfaces",
         sourcePathPatterns: ["catalog/v2/**"],
         excludePathPatterns: [
+            "catalog/v2/authoring-contracts.json",
             "catalog/v2/bundles.json",
+            "catalog/v2/human-catalog.json",
             "catalog/v2/source-contracts.json",
             "catalog/v2/taxonomy.json",
             "catalog/v2/upstream-companions.json",
@@ -716,6 +741,25 @@ const definitions = [
         evidenceIds: ["reevaluation-authority"],
         generator:
             "tooling/generate-catalog-v2.mjs and tooling/generate-repository-inventory.mjs",
+    },
+    {
+        id: "generated-human-catalog",
+        sourcePathPatterns: ["catalog/generated/human-catalog/**"],
+        artifactType: "documentation",
+        currentOwner: repositoryOwner,
+        targetOwner: repositoryOwner,
+        runtimeEligibility: "repository-only",
+        generatedStatus: "generated",
+        adapterStatus: "none",
+        dependencies: [
+            "catalog/v2/human-catalog.json",
+            "catalog/v2/targets.json",
+            "tooling/generate-human-catalog.mjs",
+        ],
+        risk: "medium",
+        migrationState: "retain",
+        evidenceIds: ["option-a-plus-authority"],
+        generator: "tooling/generate-human-catalog.mjs",
     },
     {
         id: "catalog-v2-schema",

--- a/tooling/public-artifact-materializer.mjs
+++ b/tooling/public-artifact-materializer.mjs
@@ -239,7 +239,7 @@ function assertRegularContainedSource(sourceRoot, relativePath) {
     return current;
 }
 
-function assertSafeContent(path, content) {
+export function assertSafeContent(path, content) {
     if (!Buffer.isBuffer(content))
         throw new Error(`Payload content must be a byte buffer: ${path}`);
     if (content.includes(0))

--- a/tooling/specs/catalog-v2-validation.spec.mjs
+++ b/tooling/specs/catalog-v2-validation.spec.mjs
@@ -15,9 +15,11 @@ import {
     v2CatalogPaths,
     v2SchemaPath,
     validateArtifacts,
+    validateAuthoringContracts,
     validateBundles,
     validateEvidenceAndCoverage,
     validateMigrations,
+    validateHumanCatalogContract,
     validateRepositoryInventory,
     validateSourceContracts,
     validateSources,
@@ -104,6 +106,8 @@ test("legacy targets remain explicitly unclassified and runtime ineligible", () 
         assert.deepEqual(target.dependencyEdges, []);
         assert.equal(target.sourceContractState, "unclassified");
         assert.deepEqual(target.sourceContractIds, []);
+        assert.equal(target.authoringContractState, "unclassified");
+        assert.deepEqual(target.authoringContractIds, []);
         for (const field of [
             "architectures",
             "personas",
@@ -171,6 +175,8 @@ test("approval cannot omit revision, digest, reviewer, evaluations, or security 
         "needs assessed trust and effects",
         "needs classified dependencies",
         "needs classified source contracts",
+        "needs classified authoring contracts",
+        "needs the Cratis clean-room authoring contract",
     ]) {
         assert(errors.some((error) => error.includes(requirement)));
     }
@@ -437,6 +443,36 @@ test("upstream companions contain metadata but never upstream bytes", () => {
     assert(errors.some((error) => error.includes("expected constant false")));
 });
 
+test("the clean-room authoring contract cannot weaken its evidence or copy policy", () => {
+    const catalogs = loadCatalogs();
+    assert.deepEqual(validateAuthoringContracts(catalogs), []);
+    const contract = catalogs.authoringContracts.contracts[0];
+    contract.requiredEvidenceKinds.pop();
+    contract.outputPolicy.requiredFrontmatterKeys.push("license");
+    const errors = validateAuthoringContracts(catalogs);
+    assert(
+        errors.some((error) =>
+            error.includes("required evidence kinds must match"),
+        ),
+    );
+    assert(
+        errors.some((error) =>
+            error.includes("frontmatter must be exactly name and description"),
+        ),
+    );
+});
+
+test("the human catalog contract forbids runtime bytes and permission claims", () => {
+    const catalogs = loadCatalogs();
+    assert.deepEqual(validateHumanCatalogContract(catalogs), []);
+    const contract = catalogs.humanCatalog;
+    contract.includeRuntimePayloadBytes = true;
+    contract.disclaimer = "This catalog grants runtime permission.";
+    const errors = validateHumanCatalogContract(catalogs);
+    assert(errors.some((error) => error.includes("runtime payload bytes")));
+    assert(errors.some((error) => error.includes("deny runtime permission")));
+});
+
 test("unknown properties fail the closed catalog v2 schema", () => {
     const targets = readCatalog(
         join(defaultRepositoryRoot, v2CatalogPaths.targets),
@@ -512,6 +548,9 @@ test("all v2 catalog families reject dangling evidence", () => {
     catalogs.upstreamCompanions.companions[0].evidenceIds.push(
         "missing-evidence",
     );
+    catalogs.authoringContracts.contracts[0].evidenceIds.push(
+        "missing-evidence",
+    );
     assert(
         validateSources(catalogs, defaultRepositoryRoot).some((error) =>
             error.includes("unknown evidence missing-evidence"),
@@ -544,6 +583,11 @@ test("all v2 catalog families reject dangling evidence", () => {
     );
     assert(
         validateUpstreamCompanions(catalogs).some((error) =>
+            error.includes("unknown evidence missing-evidence"),
+        ),
+    );
+    assert(
+        validateAuthoringContracts(catalogs).some((error) =>
             error.includes("unknown evidence missing-evidence"),
         ),
     );

--- a/tooling/specs/human-catalog.spec.mjs
+++ b/tooling/specs/human-catalog.spec.mjs
@@ -1,0 +1,175 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import {
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { compareOrdinal } from "../catalog-ordering.mjs";
+import {
+    buildHumanCatalogOutputs,
+    checkHumanCatalogOutputs,
+    markdownText,
+    writeHumanCatalogOutputsAtomically,
+} from "../generate-human-catalog.mjs";
+
+const repositoryRoot = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    "../..",
+);
+const outputRoot = join(repositoryRoot, "catalog/generated/human-catalog");
+
+function readJson(name) {
+    return JSON.parse(readFileSync(join(outputRoot, name), "utf8"));
+}
+
+function sha256(content) {
+    return createHash("sha256").update(content).digest("hex");
+}
+
+const builtCatalog = buildHumanCatalogOutputs();
+
+test("human catalog Markdown escapes metadata expression", () => {
+    assert.equal(
+        markdownText("<script> [link](url) *bold*\nheading"),
+        "&lt;script&gt; \\[link\\](url) \\*bold\\* heading",
+    );
+});
+
+test("generated human catalog is current and deterministic", () => {
+    assert.doesNotThrow(() =>
+        execFileSync(
+            process.execPath,
+            ["tooling/generate-human-catalog.mjs", "--check"],
+            { cwd: repositoryRoot, stdio: "pipe" },
+        ),
+    );
+});
+
+test("human catalog check rejects extra generated files", () => {
+    const root = mkdtempSync(join(tmpdir(), "cratis-human-catalog-"));
+    const output = join(root, "output");
+    try {
+        const { contents } = builtCatalog;
+        mkdirSync(output);
+        for (const [path, content] of contents) {
+            const destination = join(output, path);
+            mkdirSync(dirname(destination), { recursive: true });
+            writeFileSync(destination, content);
+        }
+        writeFileSync(join(output, "unexpected.txt"), "unexpected");
+        assert.throws(
+            () => checkHumanCatalogOutputs(contents, output),
+            /file inventory is stale/,
+        );
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test("human catalog publishes the manifest last and removes stale files", () => {
+    const root = mkdtempSync(join(tmpdir(), "cratis-human-catalog-"));
+    const output = join(root, "output");
+    try {
+        mkdirSync(output);
+        writeFileSync(join(output, "old.txt"), "old");
+        const { contents } = builtCatalog;
+        writeHumanCatalogOutputsAtomically(contents, output);
+        checkHumanCatalogOutputs(contents, output);
+        assert.equal(existsSync(join(output, "old.txt")), false);
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test("human catalog manifest remains the activation pointer on interrupted publish", () => {
+    const root = mkdtempSync(join(tmpdir(), "cratis-human-catalog-"));
+    const output = join(root, "output");
+    try {
+        const { contents } = builtCatalog;
+        writeHumanCatalogOutputsAtomically(contents, output);
+        const activeManifest = readFileSync(join(output, "manifest.json"));
+        const interrupted = new Map(contents);
+        interrupted.set("catalog.json", Buffer.from("interrupted\n"));
+        assert.throws(
+            () =>
+                writeHumanCatalogOutputsAtomically(interrupted, output, {
+                    failAfterDataFiles: 2,
+                }),
+            /Injected failure/,
+        );
+        assert.equal(existsSync(output), true);
+        assert.equal(
+            readFileSync(join(output, "manifest.json")).equals(activeManifest),
+            true,
+        );
+        assert.throws(
+            () => checkHumanCatalogOutputs(contents, output),
+            /is stale/,
+        );
+        writeHumanCatalogOutputsAtomically(contents, output);
+        checkHumanCatalogOutputs(contents, output);
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test("generated human catalog exposes every target without granting runtime", () => {
+    const catalog = readJson("catalog.json");
+    const targets = JSON.parse(
+        readFileSync(join(repositoryRoot, "catalog/v2/targets.json"), "utf8"),
+    ).targets.filter((target) => target.audience === "public");
+    assert.equal(catalog.capabilities.length, targets.length);
+    assert.deepEqual(
+        catalog.capabilities.map((capability) => capability.id),
+        targets.map((target) => target.id).sort(compareOrdinal),
+    );
+    const publicTargetIds = new Set(targets.map((target) => target.id));
+    assert(
+        catalog.capabilities.every(
+            (capability) =>
+                capability.audience === "public" &&
+                capability.approvalState === "candidate" &&
+                capability.runtimeEligible === false &&
+                capability.relatedTargetIds.every((targetId) =>
+                    publicTargetIds.has(targetId),
+                ),
+        ),
+    );
+    assert.match(catalog.disclaimer, /does not grant runtime permission/);
+});
+
+test("human catalog manifest binds every generated product file", () => {
+    const manifest = readJson("manifest.json");
+    assert.deepEqual(
+        manifest.files.map((file) => file.path),
+        ["CATALOG.md", "catalog.json"],
+    );
+    for (const file of manifest.files) {
+        const content = readFileSync(join(outputRoot, file.path));
+        assert.equal(content.length, file.size);
+        assert.equal(sha256(content), file.sha256);
+    }
+    const catalog = readJson("catalog.json");
+    assert.equal(manifest.inputDigest, catalog.inputDigest);
+});
+
+test("human catalog Markdown separates approval and trust visibly", () => {
+    const markdown = readFileSync(join(outputRoot, "CATALOG.md"), "utf8");
+    assert.match(markdown, /^# Cratis capability catalog/m);
+    assert.match(markdown, /### Trust and effects/);
+    assert.match(markdown, /\*\*Approval:\*\* candidate/);
+    assert.match(markdown, /\*\*Runtime eligible:\*\* no/);
+    assert.match(markdown, /Unclassified —/);
+});

--- a/tooling/validate-catalogs.mjs
+++ b/tooling/validate-catalogs.mjs
@@ -14,6 +14,6 @@ if (errors.length > 0) {
     process.exitCode = 1;
 } else {
     process.stdout.write(
-        "Catalog validation passed: 3 legacy catalogs, 11 v2 catalogs, and 4 schemas are valid.\n",
+        "Catalog validation passed: 3 legacy catalogs, 13 v2 catalogs, and 4 schemas are valid.\n",
     );
 }


### PR DESCRIPTION
# Summary

Add the clean-room Cratis skill-authoring gate and a deterministic public capability catalog without creating or approving runtime skill bytes.

## Added

- Add a machine-enforced clean-room Agent Skill authoring contract with source, evidence, payload, similarity, and quality requirements. (#126)
- Add a bounded, offline, deterministic human-catalog generation contract and metadata-only catalog for all public candidates. (#126)
- Add generated JSON, Markdown, and SHA-256 manifest views that visibly separate candidate, approval, trust, and runtime state. (Cratis/Workflows#68)
- Add authoring and generated-catalog regression specifications, including stale-output and atomic replacement behavior. (#126)

## Changed

- Require an active clean-room authoring contract before any target can be approved. (#126)
- Extend pull-request verification with deterministic human-catalog generation and drift checks. (Cratis/Workflows#68)
- Keep engineering targets and runtime payload bytes outside the public human catalog. (#126)
