### PR TITLE
Add marketplace distribution foundation

### DIFF
--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
@@ -1209,9 +1209,8 @@ branch starts from merge commit
 Delivery-first distribution work is now concrete:
 
 - `distribution/marketplace-requirements.json` records current official Agent
-  Skills, Claude Code, OpenAI Codex, GitHub Copilot, Gemini CLI, installed Pi,
-  and npm requirements;
-- Cursor, Kiro, and Junie remain explicitly blocked rather than inferred;
+  Skills, Claude Code, OpenAI Codex, GitHub Copilot, Cursor, Kiro, Junie,
+  Gemini CLI, installed Pi, and npm requirements;
 - `distribution/artifact-matrix.json` maps one canonical logical tree to native
   skills-only adapters and keeps publication/promotion false;
 - `distribution/generated-repository-authority-request.md` requests public
@@ -1219,7 +1218,8 @@ Delivery-first distribution work is now concrete:
   and npm-stage environments, package ownership, and trusted-publisher setup;
 - `tooling/generate-distribution-fixture.mjs` materializes the already approved
   sanitized fixture, projects exact bytes into canonical, Claude, Codex,
-  Copilot, Gemini, and Pi/npm layouts, and emits a manifest-last inventory,
+  Copilot, Cursor, Kiro, Junie, Gemini, and Pi/npm layouts, and emits a
+  manifest-last inventory,
   checksums, and an explicitly non-attestation fixture provenance record;
 - focused specs prove deterministic generation, byte parity, passive manifests,
   tamper rejection, npm pack/install/uninstall, Pi install/list/remove, Claude

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
@@ -1198,3 +1198,56 @@ artifact matrix, generated distribution staging/repository authority,
 marketplace-native adapters, install/smoke/uninstall, provenance/checksums,
 canaries, and rollback. Product-source admission, runtime activation,
 publication, promotion, and legacy retirement remain blocked.
+
+## 33. Distribution foundation and native fixture adapters — 2026-08-22
+
+The event-modeling pilot merged with green CI in Cratis/AI#139. AI#126 and
+Workflows#68 were updated, its branch/worktree were removed normally, and this
+branch starts from merge commit
+`3d5f25538696ad546a98ef128ea925ed3c096b4b`.
+
+Delivery-first distribution work is now concrete:
+
+- `distribution/marketplace-requirements.json` records current official Agent
+  Skills, Claude Code, OpenAI Codex, GitHub Copilot, Gemini CLI, installed Pi,
+  and npm requirements;
+- Cursor, Kiro, and Junie remain explicitly blocked rather than inferred;
+- `distribution/artifact-matrix.json` maps one canonical logical tree to native
+  skills-only adapters and keeps publication/promotion false;
+- `distribution/generated-repository-authority-request.md` requests public
+  `Cratis/AI.Distribution`, bot-only writes, branch protection, protected canary
+  and npm-stage environments, package ownership, and trusted-publisher setup;
+- `tooling/generate-distribution-fixture.mjs` materializes the already approved
+  sanitized fixture, projects exact bytes into canonical, Claude, Codex,
+  Copilot, Gemini, and Pi/npm layouts, and emits a manifest-last inventory,
+  checksums, and an explicitly non-attestation fixture provenance record;
+- focused specs prove deterministic generation, byte parity, passive manifests,
+  tamper rejection, npm pack/install/uninstall, Pi install/list/remove, Claude
+  strict validation/install/remove, Copilot install/remove, Codex marketplace
+  add/remove, and Gemini link/remove in isolated homes.
+
+Observed local fixture smoke versions are npm 10.9.2, Pi 0.84.2, Claude Code
+2.1.235, GitHub Copilot CLI 1.0.67, Codex CLI 0.147.0, and Gemini CLI 0.33.1.
+The exact outcomes and limitations are in
+`distribution/evidence/local-fixture-smoke-2026-08-22.json`. This is actual local
+fixture evidence, not compatibility, release, canary, or promotion evidence.
+
+Option A+ authorizes implementation, but no designated bot identity, generated
+repository, protected environment, npm package ownership, or trusted publisher
+is available to this worktree. Creating or publishing with personal credentials
+would violate the bot-owned boundary, so the exact authority request is the
+correct gate while deterministic local staging continues.
+
+Fresh evidence is 11/11 focused distribution specs and 173/173 full repository
+specs, including all locally available native CLI smokes. Catalog, stable
+inventory, syntax, strict JSON, LSP, structural, focused Markdown, and diff gates
+pass; the three unchanged structural advisories and 230 unrelated legacy
+Documentation lint findings remain non-blocking baselines.
+
+This foundation does not admit real product sources or approve any public target.
+`catalog/v2/artifacts.json` still blocks the planned public release and allows
+only the sanitized fixture. Next delivery: merge this foundation after green CI,
+then add generated-repository canary/rollback workflow contracts and production
+materializer wiring that remains disabled until repository/credential and target
+approval gates pass. Runtime activation, publication, promotion, fleet rollout,
+legacy retirement, and freeze lifting remain blocked.

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
@@ -541,12 +541,12 @@ Evidence and exact next actions are in
   violations without starting another review loop.
 - [x] Merge the review pilot after green CI and stop hardening (#138).
 - [x] Deliver one minimal domain-expert/event-modeling pilot PR (#139).
-- [x] Verify authoritative Agent Skills, Claude, Codex, Copilot, Gemini, Pi, and
-  npm requirements; keep Cursor, Kiro, and Junie blocked pending official facts.
+- [x] Verify authoritative Agent Skills, Claude, Codex, Copilot, Cursor, Kiro,
+  Junie, Gemini, Pi, and npm requirements.
 - [x] Produce the exact bot-repository/credential authority request and continue
   deterministic fixture-only local staging.
-- [x] Generate fixture-only canonical, Claude, Codex, Copilot, Gemini, and Pi/npm
-  adapters from one approved sanitized logical tree.
+- [x] Generate fixture-only canonical, Claude, Codex, Copilot, Cursor, Kiro,
+  Junie, Gemini, and Pi/npm adapters from one approved sanitized logical tree.
 - [ ] Promote adapters beyond fixture-only after real target approval; add hosted
   canary and rollback workflows after generated-repository authority exists.
 - [x] Add local pack/install/smoke/uninstall, provenance-record, and checksum

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
@@ -540,10 +540,15 @@ Evidence and exact next actions are in
 - [x] Run one bounded final review and fix its two concrete high acceptance
   violations without starting another review loop.
 - [x] Merge the review pilot after green CI and stop hardening (#138).
-- [ ] Deliver one minimal domain-expert/event-modeling pilot PR; implementation
-  and its single bounded review are complete, with delivery gates pending.
-- [ ] Verify current authoritative marketplace/package requirements.
-- [ ] Scaffold generated distribution repository or exact authority request.
-- [ ] Implement deterministic marketplace-native package/adaptor generation.
-- [ ] Add install/smoke/uninstall, provenance, checksum, canary, and rollback gates.
+- [x] Deliver one minimal domain-expert/event-modeling pilot PR (#139).
+- [x] Verify authoritative Agent Skills, Claude, Codex, Copilot, Gemini, Pi, and
+  npm requirements; keep Cursor, Kiro, and Junie blocked pending official facts.
+- [x] Produce the exact bot-repository/credential authority request and continue
+  deterministic fixture-only local staging.
+- [x] Generate fixture-only canonical, Claude, Codex, Copilot, Gemini, and Pi/npm
+  adapters from one approved sanitized logical tree.
+- [ ] Promote adapters beyond fixture-only after real target approval; add hosted
+  canary and rollback workflows after generated-repository authority exists.
+- [x] Add local pack/install/smoke/uninstall, provenance-record, and checksum
+  gates for the fixture-only distribution.
 - [ ] Keep publication and retirement disabled until explicit approvals pass.

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "5805f3e5f695c17a524359721f4dcbf977784a9e4b060e37da6a0446a9cbfba2",
+  "indexDigest": "728de7a8627b12c653924002cdc8cf978407667383a5f0025a8f13e14f21ea0b",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "e7e083b703881b694ccbf374c997dad272a8b498700379082c917101f4963a5f",
+  "indexDigest": "5805f3e5f695c17a524359721f4dcbf977784a9e4b060e37da6a0446a9cbfba2",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -252,6 +252,22 @@
     },
     {
       "path": "catalog/v2/upstream-companions.json",
+      "status": "added"
+    },
+    {
+      "path": "distribution/artifact-matrix.json",
+      "status": "added"
+    },
+    {
+      "path": "distribution/evidence/local-fixture-smoke-2026-08-22.json",
+      "status": "added"
+    },
+    {
+      "path": "distribution/generated-repository-authority-request.md",
+      "status": "added"
+    },
+    {
+      "path": "distribution/marketplace-requirements.json",
       "status": "added"
     },
     {
@@ -1279,6 +1295,10 @@
       "status": "added"
     },
     {
+      "path": "tooling/generate-distribution-fixture.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/generate-human-catalog.mjs",
       "status": "added"
     },
@@ -1328,6 +1348,10 @@
     },
     {
       "path": "tooling/specs/diagnostics-pilot.spec.mjs",
+      "status": "added"
+    },
+    {
+      "path": "tooling/specs/distribution-fixture.spec.mjs",
       "status": "added"
     },
     {
@@ -2550,6 +2574,30 @@
     },
     {
       "excludePathPatterns": [],
+      "id": "distribution-foundation",
+      "sourcePathPatterns": [
+        "distribution/**"
+      ],
+      "artifactType": "repository-metadata",
+      "currentOwner": "repository-only authoring/release tooling",
+      "targetOwner": "Workflows organization mechanics",
+      "runtimeEligibility": "repository-only",
+      "generatedStatus": "source",
+      "adapterStatus": "adapter",
+      "dependencies": [
+        "catalog/v2/artifacts.json",
+        "tooling/public-artifact-materializer.mjs"
+      ],
+      "risk": "high",
+      "migrationState": "retain",
+      "evidenceIds": [
+        "option-a-plus-authority"
+      ],
+      "expectedPathCount": 4,
+      "expectedPathsDigest": "ca954c7f9a27be2cb174d79430848bb2772561bea90a47c7b67ac97ef88a7d98"
+    },
+    {
+      "excludePathPatterns": [],
       "id": "catalog-and-redesign-tooling",
       "sourcePathPatterns": [
         "tooling/*.mjs"
@@ -2568,8 +2616,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 17,
-      "expectedPathsDigest": "274f9fe348a1b5a73bce18ea316b214a8e41496bc768f0183f16254c3071d3e5"
+      "expectedPathCount": 18,
+      "expectedPathsDigest": "9ad6574268c48b91a6f5f6a8db8c32ff86abc183149f8fa5d2c6fec5aa172cc7"
     },
     {
       "excludePathPatterns": [],
@@ -2592,8 +2640,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 11,
-      "expectedPathsDigest": "0b303d8685d9c24ff545e465c65993bd06fc94393df45b3f94d7d2aa152400da"
+      "expectedPathCount": 12,
+      "expectedPathsDigest": "84801d0c3f7186b2da58a28e48259962158569c99e228044c7fb2cf9e53be79b"
     },
     {
       "excludePathPatterns": [],

--- a/distribution/artifact-matrix.json
+++ b/distribution/artifact-matrix.json
@@ -93,26 +93,38 @@
     {
       "id": "cursor",
       "requirementId": "cursor-marketplace",
-      "state": "BLOCKED",
-      "outputRoot": null,
-      "packageKind": null,
-      "smokeGates": []
+      "state": "FIXTURE_GENERATION_ENABLED",
+      "outputRoot": "cursor",
+      "packageKind": "SKILLS_ONLY_CURSOR_PLUGIN",
+      "smokeGates": [
+        "manifest-parse",
+        "canonical-byte-parity",
+        "local-copy-host-smoke-pending"
+      ]
     },
     {
       "id": "kiro",
       "requirementId": "kiro-marketplace",
-      "state": "BLOCKED",
-      "outputRoot": null,
-      "packageKind": null,
-      "smokeGates": []
+      "state": "FIXTURE_GENERATION_ENABLED",
+      "outputRoot": "kiro",
+      "packageKind": "SKILLS_ONLY_AGENT_PLUGIN_POWER",
+      "smokeGates": [
+        "agent-plugin-manifest-parse",
+        "canonical-byte-parity",
+        "kiro-host-smoke-pending"
+      ]
     },
     {
       "id": "junie",
       "requirementId": "junie-marketplace",
-      "state": "BLOCKED",
-      "outputRoot": null,
-      "packageKind": null,
-      "smokeGates": []
+      "state": "FIXTURE_GENERATION_ENABLED",
+      "outputRoot": "junie",
+      "packageKind": "SKILLS_ONLY_JUNIE_EXTENSION",
+      "smokeGates": [
+        "extension-manifest-parse",
+        "canonical-byte-parity",
+        "junie-host-smoke-pending"
+      ]
     }
   ]
 }

--- a/distribution/artifact-matrix.json
+++ b/distribution/artifact-matrix.json
@@ -1,0 +1,118 @@
+{
+  "schemaVersion": "1.0.0",
+  "state": "FIXTURE_ONLY_LOCAL_STAGING",
+  "canonicalSource": {
+    "artifactId": "sanitized-public-materializer-fixture",
+    "approvedFiles": [
+      "skills/cratis-example/LICENSE",
+      "skills/cratis-example/SKILL.md",
+      "skills/cratis-example/assets/example.txt",
+      "skills/cratis-example/references/guide.md"
+    ]
+  },
+  "repository": {
+    "architecture": "OPTION_A_PLUS_GENERATED_DISTRIBUTION_REPOSITORY",
+    "status": "BLOCKED_ON_BOT_REPOSITORY_AND_CREDENTIAL_AUTHORITY",
+    "requestedName": "Cratis/AI.Distribution"
+  },
+  "publicationEligible": false,
+  "promotionEligible": false,
+  "targets": [
+    {
+      "id": "canonical-agent-skills",
+      "requirementId": "agent-skills-open-standard",
+      "state": "FIXTURE_GENERATION_ENABLED",
+      "outputRoot": "canonical",
+      "packageKind": "DIRECT_AGENT_SKILLS",
+      "smokeGates": [
+        "exact-skill-inventory",
+        "frontmatter-name-parity"
+      ]
+    },
+    {
+      "id": "claude-code",
+      "requirementId": "claude-code-marketplace",
+      "state": "FIXTURE_GENERATION_ENABLED",
+      "outputRoot": "claude",
+      "packageKind": "SKILLS_ONLY_PLUGIN_MARKETPLACE",
+      "smokeGates": [
+        "manifest-parse",
+        "canonical-byte-parity",
+        "claude-plugin-validate-when-available"
+      ]
+    },
+    {
+      "id": "openai-codex",
+      "requirementId": "openai-codex-plugin",
+      "state": "FIXTURE_GENERATION_ENABLED",
+      "outputRoot": "codex",
+      "packageKind": "SKILLS_ONLY_CODEX_PLUGIN_MARKETPLACE",
+      "smokeGates": [
+        "manifest-parse",
+        "canonical-byte-parity",
+        "isolated-marketplace-add-remove-when-available"
+      ]
+    },
+    {
+      "id": "github-copilot",
+      "requirementId": "github-copilot-plugin",
+      "state": "FIXTURE_GENERATION_ENABLED",
+      "outputRoot": "copilot",
+      "packageKind": "SKILLS_ONLY_COPILOT_PLUGIN_MARKETPLACE",
+      "smokeGates": [
+        "manifest-parse",
+        "canonical-byte-parity",
+        "isolated-install-uninstall-when-available"
+      ]
+    },
+    {
+      "id": "gemini-cli",
+      "requirementId": "gemini-cli-extension",
+      "state": "FIXTURE_GENERATION_ENABLED",
+      "outputRoot": "gemini",
+      "packageKind": "SKILLS_ONLY_GEMINI_EXTENSION",
+      "smokeGates": [
+        "manifest-parse",
+        "canonical-byte-parity",
+        "isolated-link-uninstall-when-available"
+      ]
+    },
+    {
+      "id": "pi-npm",
+      "requirementId": "pi-passive-package",
+      "state": "FIXTURE_GENERATION_ENABLED",
+      "outputRoot": "pi",
+      "packageKind": "PRIVATE_PASSIVE_NPM_FIXTURE",
+      "smokeGates": [
+        "npm-pack",
+        "npm-install-ignore-scripts",
+        "package-inventory",
+        "npm-uninstall"
+      ]
+    },
+    {
+      "id": "cursor",
+      "requirementId": "cursor-marketplace",
+      "state": "BLOCKED",
+      "outputRoot": null,
+      "packageKind": null,
+      "smokeGates": []
+    },
+    {
+      "id": "kiro",
+      "requirementId": "kiro-marketplace",
+      "state": "BLOCKED",
+      "outputRoot": null,
+      "packageKind": null,
+      "smokeGates": []
+    },
+    {
+      "id": "junie",
+      "requirementId": "junie-marketplace",
+      "state": "BLOCKED",
+      "outputRoot": null,
+      "packageKind": null,
+      "smokeGates": []
+    }
+  ]
+}

--- a/distribution/evidence/local-fixture-smoke-2026-08-22.json
+++ b/distribution/evidence/local-fixture-smoke-2026-08-22.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0.0",
   "observedAt": "2026-08-22",
-  "sourceCommit": "3d5f25538696ad546a98ef128ea925ed3c096b4b",
+  "sourceCommit": null,
   "fixtureState": "FIXTURE_ONLY_LOCAL_STAGING",
   "host": "darwin-arm64",
   "results": [
@@ -72,15 +72,44 @@
         "removed-state"
       ],
       "status": "PASS_WITH_PROJECT_REGISTRY_WARNING"
+    },
+    {
+      "target": "cursor",
+      "version": null,
+      "checks": [
+        "cursor-plugin-manifest",
+        "marketplace-manifest",
+        "canonical-byte-parity"
+      ],
+      "status": "PASS_STATIC_GENERATION_HOST_SMOKE_PENDING"
+    },
+    {
+      "target": "kiro",
+      "version": null,
+      "checks": [
+        "agent-plugin-1.0-manifest",
+        "canonical-byte-parity"
+      ],
+      "status": "PASS_STATIC_GENERATION_HOST_SMOKE_PENDING"
+    },
+    {
+      "target": "junie",
+      "version": null,
+      "checks": [
+        "extension-manifest",
+        "canonical-byte-parity"
+      ],
+      "status": "PASS_STATIC_GENERATION_HOST_SMOKE_PENDING"
     }
   ],
   "limitations": [
     "This is local fixture evidence, not release, marketplace, compatibility, canary, or promotion evidence.",
     "The Codex CLI documents marketplace management while ChatGPT desktop owns local plugin installation.",
     "The Gemini CLI emitted a transient isolated-home project-registry warning while link and uninstall completed successfully.",
-    "No Cursor, Kiro, or Junie adapter was generated because authoritative requirements remain unverified.",
+    "Cursor, Kiro, and Junie adapters passed static generation and canonical byte parity; host install smoke remains pending because those hosts are unavailable in this worktree.",
     "No real public skill, product-source authority, publication credential, or bot repository was used."
   ],
   "publicationEligible": false,
-  "promotionEligible": false
+  "promotionEligible": false,
+  "sourceWorktreeBase": "3d5f25538696ad546a98ef128ea925ed3c096b4b"
 }

--- a/distribution/evidence/local-fixture-smoke-2026-08-22.json
+++ b/distribution/evidence/local-fixture-smoke-2026-08-22.json
@@ -1,0 +1,86 @@
+{
+  "schemaVersion": "1.0.0",
+  "observedAt": "2026-08-22",
+  "sourceCommit": "3d5f25538696ad546a98ef128ea925ed3c096b4b",
+  "fixtureState": "FIXTURE_ONLY_LOCAL_STAGING",
+  "host": "darwin-arm64",
+  "results": [
+    {
+      "target": "npm",
+      "version": "10.9.2",
+      "checks": [
+        "pack",
+        "install-ignore-scripts",
+        "skill-inventory",
+        "uninstall"
+      ],
+      "status": "PASS"
+    },
+    {
+      "target": "pi",
+      "version": "0.84.2",
+      "checks": [
+        "isolated-home-install",
+        "list",
+        "remove",
+        "empty-list"
+      ],
+      "status": "PASS"
+    },
+    {
+      "target": "claude-code",
+      "version": "2.1.235",
+      "checks": [
+        "strict-plugin-validation",
+        "isolated-marketplace-add",
+        "install",
+        "list",
+        "uninstall",
+        "marketplace-remove"
+      ],
+      "status": "PASS"
+    },
+    {
+      "target": "github-copilot-cli",
+      "version": "1.0.67",
+      "checks": [
+        "isolated-marketplace-add",
+        "install",
+        "list",
+        "uninstall",
+        "marketplace-remove"
+      ],
+      "status": "PASS"
+    },
+    {
+      "target": "codex-cli",
+      "version": "0.147.0",
+      "checks": [
+        "isolated-marketplace-add",
+        "list",
+        "marketplace-remove"
+      ],
+      "status": "PASS_WITH_INSTALL_NOT_SUPPORTED_BY_CLI"
+    },
+    {
+      "target": "gemini-cli",
+      "version": "0.33.1",
+      "checks": [
+        "isolated-extension-link-with-consent",
+        "installed-state",
+        "uninstall",
+        "removed-state"
+      ],
+      "status": "PASS_WITH_PROJECT_REGISTRY_WARNING"
+    }
+  ],
+  "limitations": [
+    "This is local fixture evidence, not release, marketplace, compatibility, canary, or promotion evidence.",
+    "The Codex CLI documents marketplace management while ChatGPT desktop owns local plugin installation.",
+    "The Gemini CLI emitted a transient isolated-home project-registry warning while link and uninstall completed successfully.",
+    "No Cursor, Kiro, or Junie adapter was generated because authoritative requirements remain unverified.",
+    "No real public skill, product-source authority, publication credential, or bot repository was used."
+  ],
+  "publicationEligible": false,
+  "promotionEligible": false
+}

--- a/distribution/generated-repository-authority-request.md
+++ b/distribution/generated-repository-authority-request.md
@@ -1,0 +1,40 @@
+# Generated distribution repository authority request
+
+## Requested repository
+
+Create public repository `Cratis/AI.Distribution` as the bot-owned generated
+projection of approved `Cratis/AI` source. Humans review generated pull requests
+and releases but do not author files in that repository.
+
+## Required authority
+
+- Install or designate a Cratis automation identity with repository-content,
+  pull-request, tag, release, and Actions permissions scoped only to the generated
+  repository.
+- Protect `main`; require generated-manifest, checksum, package, install, smoke,
+  uninstall, and provenance checks; reject direct human and bot pushes.
+- Create protected `distribution-canary` and `npm-stage` environments with named
+  reviewers and no production publication permission.
+- Reserve `@cratis/ai` and configure npm trusted publishing only after the public
+  repository and exact workflow filename exist. Start with stage-only authority.
+- Record the immutable source commit, generator revision, distribution commit,
+  package digests, checksums, and review decision for every projection.
+
+## Current blocker
+
+Option A+ and autonomous implementation are accepted in Workflows#68, but this
+worktree has no designated bot identity, generated repository, protected
+environments, npm package ownership, or trusted-publisher configuration. Creating
+or publishing through the maintainer's personal credentials would violate the
+accepted bot-owned boundary.
+
+Local fixture staging therefore continues deterministically. It uses only the
+already authorized sanitized materializer fixture and is not an installation or
+publication target.
+
+## Gates that remain closed
+
+Real public skills still require target approval and exact product-source
+contracts. Publication, promotion, canary rollout, fleet activation, legacy
+retirement, and freeze lifting remain disabled until their separate authority
+and evidence gates pass.

--- a/distribution/marketplace-requirements.json
+++ b/distribution/marketplace-requirements.json
@@ -1,0 +1,223 @@
+{
+  "schemaVersion": "1.0.0",
+  "verifiedAt": "2026-08-22",
+  "requirements": [
+    {
+      "id": "agent-skills-open-standard",
+      "status": "VERIFIED",
+      "sourceUrls": [
+        "https://agentskills.io/specification"
+      ],
+      "requiredRoots": [
+        "skills/<skill-name>/SKILL.md"
+      ],
+      "installCommands": [],
+      "updateCommands": [],
+      "uninstallCommands": [],
+      "constraints": [
+        "Skill directory and frontmatter name must match and use lowercase letters, digits, and single hyphens.",
+        "SKILL.md requires nonempty name and description; scripts, references, and assets are optional.",
+        "Passive Cratis artifacts omit scripts and experimental allowed-tools."
+      ]
+    },
+    {
+      "id": "claude-code-marketplace",
+      "status": "VERIFIED",
+      "sourceUrls": [
+        "https://docs.anthropic.com/en/docs/claude-code/plugin-marketplaces",
+        "https://docs.anthropic.com/en/docs/claude-code/skills"
+      ],
+      "requiredRoots": [
+        ".claude-plugin/marketplace.json",
+        "plugins/cratis/.claude-plugin/plugin.json",
+        "plugins/cratis/skills/<skill-name>/SKILL.md"
+      ],
+      "installCommands": [
+        "/plugin marketplace add <repository>",
+        "/plugin install cratis@cratis"
+      ],
+      "updateCommands": [
+        "/plugin marketplace update"
+      ],
+      "uninstallCommands": [
+        "/plugin uninstall cratis@cratis"
+      ],
+      "constraints": [
+        "Marketplace and plugin names use kebab-case.",
+        "Relative plugin sources stay inside the marketplace root.",
+        "Generated passive plugins contain skills only and use strict validation."
+      ]
+    },
+    {
+      "id": "openai-codex-plugin",
+      "status": "VERIFIED",
+      "sourceUrls": [
+        "https://developers.openai.com/codex/skills",
+        "https://developers.openai.com/codex/plugins",
+        "https://developers.openai.com/plugins/build/plugins"
+      ],
+      "requiredRoots": [
+        ".agents/plugins/marketplace.json",
+        "plugins/cratis/.codex-plugin/plugin.json",
+        "plugins/cratis/skills/<skill-name>/SKILL.md"
+      ],
+      "installCommands": [
+        "codex plugin marketplace add <repository>"
+      ],
+      "updateCommands": [
+        "codex plugin marketplace upgrade cratis"
+      ],
+      "uninstallCommands": [
+        "codex plugin marketplace remove cratis"
+      ],
+      "constraints": [
+        "Plugin name is stable kebab-case and manifest paths start with ./ and remain inside the plugin root.",
+        "ChatGPT desktop performs local plugin installation and testing; Codex IDE does not support plugins.",
+        "Public submission and workspace publication remain external reviewed gates."
+      ]
+    },
+    {
+      "id": "github-copilot-plugin",
+      "status": "VERIFIED",
+      "sourceUrls": [
+        "https://docs.github.com/en/copilot/concepts/agents/about-plugins",
+        "https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-marketplace",
+        "https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference"
+      ],
+      "requiredRoots": [
+        ".github/plugin/marketplace.json",
+        "plugins/cratis/plugin.json",
+        "plugins/cratis/skills/<skill-name>/SKILL.md"
+      ],
+      "installCommands": [
+        "copilot plugin marketplace add <repository>",
+        "copilot plugin install cratis@cratis"
+      ],
+      "updateCommands": [
+        "copilot plugin marketplace update cratis",
+        "copilot plugin update cratis"
+      ],
+      "uninstallCommands": [
+        "copilot plugin uninstall cratis",
+        "copilot plugin marketplace remove cratis"
+      ],
+      "constraints": [
+        "plugin.json is required at the plugin root.",
+        "Marketplace plugin sources are repository-relative; strict validation stays enabled.",
+        "Release installs pin immutable full commit SHAs."
+      ]
+    },
+    {
+      "id": "gemini-cli-extension",
+      "status": "VERIFIED",
+      "sourceUrls": [
+        "https://geminicli.com/docs/extensions/reference/",
+        "https://geminicli.com/docs/extensions/releasing/"
+      ],
+      "requiredRoots": [
+        "gemini-extension.json",
+        "skills/<skill-name>/SKILL.md"
+      ],
+      "installCommands": [
+        "gemini extensions install <repository> --ref <immutable-ref>"
+      ],
+      "updateCommands": [
+        "gemini extensions update cratis"
+      ],
+      "uninstallCommands": [
+        "gemini extensions uninstall cratis"
+      ],
+      "constraints": [
+        "Extension name is lowercase letters, digits, and dashes and matches its directory.",
+        "gemini-extension.json is at the repository or release-archive root.",
+        "Manifest version matches the GitHub release tag."
+      ]
+    },
+    {
+      "id": "pi-passive-package",
+      "status": "VERIFIED_INSTALLED_DOCUMENTATION",
+      "sourceUrls": [],
+      "requiredRoots": [
+        "package.json",
+        "skills/<skill-name>/SKILL.md"
+      ],
+      "installCommands": [
+        "pi install npm:@cratis/ai@<version>",
+        "pi install git:<repository>@<immutable-ref>"
+      ],
+      "updateCommands": [
+        "pi update npm:@cratis/ai"
+      ],
+      "uninstallCommands": [
+        "pi remove npm:@cratis/ai"
+      ],
+      "constraints": [
+        "Requirements were verified against installed @earendil-works/pi-coding-agent 0.84.2 docs/packages.md.",
+        "package.json declares the pi-package keyword and pi.skills allowlist.",
+        "The passive package contains no extensions, prompts, themes, lifecycle scripts, or dependencies.",
+        "Temporary, user, project, npm, Git, filter, pin, rollback, and uninstall behavior require smoke evidence."
+      ]
+    },
+    {
+      "id": "npm-trusted-publication",
+      "status": "VERIFIED",
+      "sourceUrls": [
+        "https://docs.npmjs.com/trusted-publishers/",
+        "https://docs.npmjs.com/generating-provenance-statements/"
+      ],
+      "requiredRoots": [
+        "package.json"
+      ],
+      "installCommands": [
+        "npm install @cratis/ai@<version> --ignore-scripts"
+      ],
+      "updateCommands": [
+        "npm install @cratis/ai@<new-version> --ignore-scripts"
+      ],
+      "uninstallCommands": [
+        "npm uninstall @cratis/ai --ignore-scripts"
+      ],
+      "constraints": [
+        "Trusted publishing uses an exact GitHub-hosted workflow identity, id-token: write, Node 22.14.0 or newer, and npm 11.5.1 or newer.",
+        "repository.url exactly matches the public source repository.",
+        "Public publication uses OIDC with automatic provenance; stage-only authority is preferred before promotion."
+      ]
+    },
+    {
+      "id": "cursor-marketplace",
+      "status": "BLOCKED_NO_AUTHORITATIVE_REQUIREMENTS",
+      "sourceUrls": [],
+      "requiredRoots": [],
+      "installCommands": [],
+      "updateCommands": [],
+      "uninstallCommands": [],
+      "constraints": [
+        "Do not generate or claim a Cursor-native package until official current requirements are verified."
+      ]
+    },
+    {
+      "id": "kiro-marketplace",
+      "status": "BLOCKED_NO_AUTHORITATIVE_REQUIREMENTS",
+      "sourceUrls": [],
+      "requiredRoots": [],
+      "installCommands": [],
+      "updateCommands": [],
+      "uninstallCommands": [],
+      "constraints": [
+        "Do not generate or claim a Kiro-native package until official current requirements are verified."
+      ]
+    },
+    {
+      "id": "junie-marketplace",
+      "status": "BLOCKED_NO_AUTHORITATIVE_REQUIREMENTS",
+      "sourceUrls": [],
+      "requiredRoots": [],
+      "installCommands": [],
+      "updateCommands": [],
+      "uninstallCommands": [],
+      "constraints": [
+        "Do not generate or claim a Junie-native package until official current requirements are verified."
+      ]
+    }
+  ]
+}

--- a/distribution/marketplace-requirements.json
+++ b/distribution/marketplace-requirements.json
@@ -185,38 +185,76 @@
     },
     {
       "id": "cursor-marketplace",
-      "status": "BLOCKED_NO_AUTHORITATIVE_REQUIREMENTS",
-      "sourceUrls": [],
-      "requiredRoots": [],
-      "installCommands": [],
-      "updateCommands": [],
-      "uninstallCommands": [],
+      "status": "VERIFIED",
+      "sourceUrls": [
+        "https://cursor.com/docs/plugins",
+        "https://cursor.com/docs/reference/plugins"
+      ],
+      "requiredRoots": [
+        ".cursor-plugin/marketplace.json",
+        "plugins/cratis/.cursor-plugin/plugin.json",
+        "plugins/cratis/skills/<skill-name>/SKILL.md"
+      ],
+      "installCommands": [
+        "Cursor Customize > Install > choose project or user scope"
+      ],
+      "updateCommands": [
+        "Cursor team marketplace auto refresh or manual Refresh"
+      ],
+      "uninstallCommands": [
+        "Cursor Customize > uninstall optional plugins"
+      ],
       "constraints": [
-        "Do not generate or claim a Cursor-native package until official current requirements are verified."
+        "Cursor skills-only plugins use .cursor-plugin/plugin.json and skills/<skill-name>/SKILL.md.",
+        "Plugin names are lowercase kebab-case; manifest paths stay relative and inside the plugin.",
+        "Public marketplace submission requires an open-source repository, local testing, manual review, and review of every update."
       ]
     },
     {
       "id": "kiro-marketplace",
-      "status": "BLOCKED_NO_AUTHORITATIVE_REQUIREMENTS",
-      "sourceUrls": [],
-      "requiredRoots": [],
-      "installCommands": [],
+      "status": "VERIFIED_AGENT_PLUGIN_COMPATIBILITY",
+      "sourceUrls": [
+        "https://kiro.dev/blog/powers-supports-plugins/",
+        "https://agent-plugins.org/plugin-authors/manifest",
+        "https://agentskills.io/specification"
+      ],
+      "requiredRoots": [
+        "plugin.json",
+        "skills/<skill-name>/SKILL.md"
+      ],
+      "installCommands": [
+        "Kiro Powers panel or kiro.dev one-click install"
+      ],
       "updateCommands": [],
       "uninstallCommands": [],
       "constraints": [
-        "Do not generate or claim a Kiro-native package until official current requirements are verified."
+        "Kiro installs Agent Plugins 1.0.0 as powers.",
+        "plugin.json uses the Agent Plugins 1.0.0 schema and a valid lowercase name.",
+        "Passive Cratis powers contain skills only; credential prompts, MCP servers, scripts, and legacy POWER.md are omitted."
       ]
     },
     {
       "id": "junie-marketplace",
-      "status": "BLOCKED_NO_AUTHORITATIVE_REQUIREMENTS",
-      "sourceUrls": [],
-      "requiredRoots": [],
-      "installCommands": [],
+      "status": "VERIFIED",
+      "sourceUrls": [
+        "https://junie.jetbrains.com/docs/agent-skills.html",
+        "https://github.com/JetBrains/junie-extensions"
+      ],
+      "requiredRoots": [
+        "extensions/cratis/extension.json",
+        "extensions/cratis/skills/<skill-name>/SKILL.md"
+      ],
+      "installCommands": [
+        "Copy a reviewed skill folder to .junie/skills or ~/.junie/skills"
+      ],
       "updateCommands": [],
-      "uninstallCommands": [],
+      "uninstallCommands": [
+        "Remove the copied skill folder from its Junie skill location"
+      ],
       "constraints": [
-        "Do not generate or claim a Junie-native package until official current requirements are verified."
+        "Junie extensions use extension.json with name and description and may contain skills/<skill-name>/SKILL.md.",
+        "Junie also discovers trusted project and user .agents/skills locations.",
+        "Users must review and trust extension contents; passive Cratis output omits scripts, agents, guidelines, and MCP servers."
       ]
     }
   ]

--- a/tooling/generate-distribution-fixture.mjs
+++ b/tooling/generate-distribution-fixture.mjs
@@ -26,7 +26,17 @@ const approvedFiles = [
     "skills/cratis-example/assets/example.txt",
     "skills/cratis-example/references/guide.md",
 ];
-const generatedTargets = ["canonical", "claude", "codex", "copilot", "gemini", "pi"];
+const generatedTargets = [
+    "canonical",
+    "claude",
+    "codex",
+    "copilot",
+    "cursor",
+    "gemini",
+    "junie",
+    "kiro",
+    "pi",
+];
 
 function sha256(content) {
     return createHash("sha256").update(content).digest("hex");
@@ -196,11 +206,49 @@ export function generateDistributionFixture({
             skills: "skills/",
         });
 
+        const cursorRoot = join(root, "cursor");
+        copyCanonicalSkill(canonicalRoot, join(cursorRoot, "plugins/cratis"));
+        writeJson(join(cursorRoot, ".cursor-plugin/marketplace.json"), {
+            name: "cratis",
+            owner: { name: "Cratis" },
+            metadata: { description: "Cratis skills-only fixture marketplace", version },
+            plugins: [{
+                name: "cratis",
+                description: "Passive Cratis skills fixture.",
+                version,
+                source: "./plugins/cratis",
+            }],
+        });
+        writeJson(join(cursorRoot, "plugins/cratis/.cursor-plugin/plugin.json"), {
+            name: "cratis",
+            version,
+            description: "Passive Cratis skills fixture.",
+            skills: "./skills/",
+        });
+
         const geminiRoot = join(root, "gemini");
         copyCanonicalSkill(canonicalRoot, geminiRoot);
         writeJson(join(geminiRoot, "gemini-extension.json"), {
             name: "cratis",
             version,
+            description: "Passive Cratis skills fixture.",
+        });
+
+        const kiroRoot = join(root, "kiro");
+        copyCanonicalSkill(canonicalRoot, kiroRoot);
+        writeJson(join(kiroRoot, "plugin.json"), {
+            $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+            name: "cratis",
+            version,
+            description: "Passive Cratis skills fixture.",
+            author: { name: "Cratis" },
+            license: "MIT",
+        });
+
+        const junieRoot = join(root, "junie/extensions/cratis");
+        copyCanonicalSkill(canonicalRoot, junieRoot);
+        writeJson(join(junieRoot, "extension.json"), {
+            name: "cratis",
             description: "Passive Cratis skills fixture.",
         });
 
@@ -276,7 +324,10 @@ export function validateDistributionFixture(outputRoot) {
         "claude/plugins/cratis",
         "codex/plugins/cratis",
         "copilot/plugins/cratis",
+        "cursor/plugins/cratis",
         "gemini",
+        "junie/extensions/cratis",
+        "kiro",
         "pi/package",
     ];
     for (const path of approvedFiles) {

--- a/tooling/generate-distribution-fixture.mjs
+++ b/tooling/generate-distribution-fixture.mjs
@@ -1,0 +1,493 @@
+#!/usr/bin/env node
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+    cpSync,
+    existsSync,
+    lstatSync,
+    mkdirSync,
+    readFileSync,
+    readdirSync,
+    realpathSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { materializeFixtureArtifact } from "./public-artifact-materializer.mjs";
+
+const defaultRepositoryRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const approvedFiles = [
+    "skills/cratis-example/LICENSE",
+    "skills/cratis-example/SKILL.md",
+    "skills/cratis-example/assets/example.txt",
+    "skills/cratis-example/references/guide.md",
+];
+const generatedTargets = ["canonical", "claude", "codex", "copilot", "gemini", "pi"];
+
+function sha256(content) {
+    return createHash("sha256").update(content).digest("hex");
+}
+
+function readJson(path) {
+    try {
+        return JSON.parse(readFileSync(path, "utf8"));
+    } catch (error) {
+        throw new Error(`Unable to parse JSON file: ${path}`, { cause: error });
+    }
+}
+
+function writeJson(path, value) {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, { flag: "wx" });
+}
+
+function walkFiles(root, current = root) {
+    return readdirSync(current, { withFileTypes: true }).flatMap(entry => {
+        const path = join(current, entry.name);
+        if (entry.isSymbolicLink()) throw new Error(`Generated symlink is forbidden: ${path}`);
+        if (entry.isDirectory()) return walkFiles(root, path);
+        if (!entry.isFile()) throw new Error(`Generated special file is forbidden: ${path}`);
+        return [relative(root, path).replaceAll("\\", "/")];
+    });
+}
+
+function copyCanonicalSkill(canonicalRoot, destinationRoot) {
+    for (const path of approvedFiles) {
+        const source = join(canonicalRoot, path);
+        const destination = join(destinationRoot, path);
+        mkdirSync(dirname(destination), { recursive: true });
+        cpSync(source, destination, { errorOnExist: true });
+    }
+}
+
+function manifestFile(root, path) {
+    const content = readFileSync(join(root, path));
+    return { path, sha256: sha256(content), size: content.length };
+}
+
+function assertConfiguration(requirements, matrix) {
+    if (requirements.schemaVersion !== "1.0.0" || matrix.schemaVersion !== "1.0.0")
+        throw new Error("Distribution configuration version changed");
+    if (matrix.state !== "FIXTURE_ONLY_LOCAL_STAGING" || matrix.publicationEligible !== false || matrix.promotionEligible !== false)
+        throw new Error("Distribution fixture must remain publication and promotion ineligible");
+    if (matrix.repository?.status !== "BLOCKED_ON_BOT_REPOSITORY_AND_CREDENTIAL_AUTHORITY")
+        throw new Error("Generated repository authority gate changed");
+    if (JSON.stringify(matrix.canonicalSource?.approvedFiles) !== JSON.stringify(approvedFiles))
+        throw new Error("Canonical fixture allowlist changed");
+    const requirementIds = new Set(requirements.requirements?.map(item => item.id));
+    if (matrix.targets.some(target => !requirementIds.has(target.requirementId)))
+        throw new Error("Artifact matrix contains an unknown requirement");
+    const enabledRoots = matrix.targets
+        .filter(target => target.state === "FIXTURE_GENERATION_ENABLED")
+        .map(target => target.outputRoot)
+        .sort();
+    if (JSON.stringify(enabledRoots) !== JSON.stringify([...generatedTargets].sort()))
+        throw new Error("Generated fixture target inventory changed");
+    if (matrix.targets.filter(target => target.state === "BLOCKED").some(target => target.outputRoot !== null))
+        throw new Error("Blocked targets must not receive output roots");
+}
+
+export function validateDistributionConfiguration(
+    repositoryRoot = defaultRepositoryRoot,
+) {
+    try {
+        const requirements = readJson(
+            join(repositoryRoot, "distribution/marketplace-requirements.json"),
+        );
+        const matrix = readJson(
+            join(repositoryRoot, "distribution/artifact-matrix.json"),
+        );
+        assertConfiguration(requirements, matrix);
+        return [];
+    } catch (error) {
+        return [
+            error instanceof Error
+                ? `Distribution configuration: ${error.message}`
+                : "Distribution configuration validation failed",
+        ];
+    }
+}
+
+export function generateDistributionFixture({
+    repositoryRoot = defaultRepositoryRoot,
+    outputRoot,
+    version = "0.0.0-fixture",
+} = {}) {
+    if (!outputRoot) throw new Error("outputRoot is required");
+    const root = resolve(outputRoot);
+    if (existsSync(root)) throw new Error(`Distribution stage must not exist: ${root}`);
+    const requirementsPath = join(repositoryRoot, "distribution/marketplace-requirements.json");
+    const matrixPath = join(repositoryRoot, "distribution/artifact-matrix.json");
+    const requirements = readJson(requirementsPath);
+    const matrix = readJson(matrixPath);
+    assertConfiguration(requirements, matrix);
+
+    mkdirSync(root, { recursive: false });
+    try {
+        const canonicalRoot = join(root, "canonical");
+        materializeFixtureArtifact({
+            sourceRoot: join(repositoryRoot, "tooling/fixtures/public-artifact/valid-source"),
+            stageRoot: canonicalRoot,
+            approvedFiles,
+        });
+
+        const claudeRoot = join(root, "claude");
+        copyCanonicalSkill(canonicalRoot, join(claudeRoot, "plugins/cratis"));
+        writeJson(join(claudeRoot, ".claude-plugin/marketplace.json"), {
+            name: "cratis",
+            owner: { name: "Cratis" },
+            metadata: { description: "Cratis skills-only fixture marketplace", version },
+            plugins: [{
+                name: "cratis",
+                description: "Passive Cratis skills fixture.",
+                version,
+                source: "./plugins/cratis",
+                strict: true,
+            }],
+        });
+        writeJson(join(claudeRoot, "plugins/cratis/.claude-plugin/plugin.json"), {
+            name: "cratis",
+            version,
+            description: "Passive Cratis skills fixture.",
+            author: { name: "Cratis" },
+        });
+
+        const codexRoot = join(root, "codex");
+        copyCanonicalSkill(canonicalRoot, join(codexRoot, "plugins/cratis"));
+        writeJson(join(codexRoot, ".agents/plugins/marketplace.json"), {
+            name: "cratis",
+            interface: { displayName: "Cratis" },
+            plugins: [{
+                name: "cratis",
+                source: { source: "local", path: "./plugins/cratis" },
+                policy: { installation: "AVAILABLE", authentication: "ON_INSTALL" },
+                category: "Developer Tools",
+            }],
+        });
+        writeJson(join(codexRoot, "plugins/cratis/.codex-plugin/plugin.json"), {
+            name: "cratis",
+            version,
+            description: "Passive Cratis skills fixture.",
+            skills: "./skills/",
+        });
+
+        const copilotRoot = join(root, "copilot");
+        copyCanonicalSkill(canonicalRoot, join(copilotRoot, "plugins/cratis"));
+        writeJson(join(copilotRoot, ".github/plugin/marketplace.json"), {
+            name: "cratis",
+            owner: { name: "Cratis" },
+            metadata: { description: "Cratis skills-only fixture marketplace", version },
+            plugins: [{
+                name: "cratis",
+                description: "Passive Cratis skills fixture.",
+                version,
+                source: "./plugins/cratis",
+                strict: true,
+            }],
+        });
+        writeJson(join(copilotRoot, "plugins/cratis/plugin.json"), {
+            name: "cratis",
+            version,
+            description: "Passive Cratis skills fixture.",
+            skills: "skills/",
+        });
+
+        const geminiRoot = join(root, "gemini");
+        copyCanonicalSkill(canonicalRoot, geminiRoot);
+        writeJson(join(geminiRoot, "gemini-extension.json"), {
+            name: "cratis",
+            version,
+            description: "Passive Cratis skills fixture.",
+        });
+
+        const piPackageRoot = join(root, "pi/package");
+        copyCanonicalSkill(canonicalRoot, piPackageRoot);
+        writeJson(join(piPackageRoot, "package.json"), {
+            name: "@cratis/ai",
+            version,
+            description: "Private passive Cratis skills fixture.",
+            private: true,
+            license: "MIT",
+            files: ["skills"],
+            keywords: ["pi-package"],
+            pi: { skills: ["./skills"] },
+        });
+
+        const canonicalManifest = approvedFiles.map(path => manifestFile(canonicalRoot, path));
+        writeJson(join(root, "provenance.json"), {
+            schemaVersion: "1.0.0",
+            state: "FIXTURE_ONLY_NOT_AN_ATTESTATION",
+            canonicalRepository: "Cratis/AI",
+            sourceArtifactId: matrix.canonicalSource.artifactId,
+            sourceRevision: null,
+            generator: "tooling/generate-distribution-fixture.mjs",
+            version,
+            requirementsSha256: sha256(readFileSync(requirementsPath)),
+            matrixSha256: sha256(readFileSync(matrixPath)),
+            canonicalFiles: canonicalManifest,
+            publicationEligible: false,
+            promotionEligible: false,
+        });
+
+        const checksumPaths = walkFiles(root).sort();
+        const checksums = checksumPaths
+            .map(path => `${sha256(readFileSync(join(root, path)))}  ${path}`)
+            .join("\n");
+        writeFileSync(join(root, "SHA256SUMS"), `${checksums}\n`, { flag: "wx" });
+        const files = walkFiles(root).sort().map(path => manifestFile(root, path));
+        const manifest = {
+            schemaVersion: "1.0.0",
+            state: "FIXTURE_ONLY_LOCAL_STAGING",
+            version,
+            generatedTargets,
+            files,
+            publicationEligible: false,
+            promotionEligible: false,
+        };
+        writeJson(join(root, "distribution-manifest.json"), manifest);
+        validateDistributionFixture(root);
+        return manifest;
+    } catch (error) {
+        rmSync(root, { recursive: true, force: true });
+        throw error;
+    }
+}
+
+export function validateDistributionFixture(outputRoot) {
+    const root = realpathSync(outputRoot);
+    const manifest = readJson(join(root, "distribution-manifest.json"));
+    if (manifest.state !== "FIXTURE_ONLY_LOCAL_STAGING" || manifest.publicationEligible !== false || manifest.promotionEligible !== false)
+        throw new Error("Generated distribution state changed");
+    const actualPaths = walkFiles(root).filter(path => path !== "distribution-manifest.json").sort();
+    const declaredPaths = manifest.files.map(file => file.path).sort();
+    if (JSON.stringify(actualPaths) !== JSON.stringify(declaredPaths))
+        throw new Error("Generated distribution manifest inventory changed");
+    for (const file of manifest.files) {
+        const content = readFileSync(join(root, file.path));
+        if (content.length !== file.size || sha256(content) !== file.sha256)
+            throw new Error(`Generated distribution digest mismatch: ${file.path}`);
+    }
+    const canonicalRoot = join(root, "canonical");
+    const targetSkillRoots = [
+        "claude/plugins/cratis",
+        "codex/plugins/cratis",
+        "copilot/plugins/cratis",
+        "gemini",
+        "pi/package",
+    ];
+    for (const path of approvedFiles) {
+        const canonical = readFileSync(join(canonicalRoot, path));
+        for (const targetRoot of targetSkillRoots) {
+            const target = readFileSync(join(root, targetRoot, path));
+            if (!canonical.equals(target)) throw new Error(`Canonical byte parity failed: ${targetRoot}/${path}`);
+        }
+    }
+    const checksumLines = readFileSync(join(root, "SHA256SUMS"), "utf8").trim().split("\n");
+    for (const line of checksumLines) {
+        const match = /^([0-9a-f]{64}) {2}(.+)$/.exec(line);
+        if (!match || sha256(readFileSync(join(root, match[2]))) !== match[1])
+            throw new Error(`Checksum verification failed: ${line}`);
+    }
+    return manifest;
+}
+
+export function smokeNpmDistributionFixture(outputRoot, temporaryRoot) {
+    const packageRoot = join(outputRoot, "pi/package");
+    const packRoot = join(temporaryRoot, "pack");
+    const installRoot = join(temporaryRoot, "install");
+    mkdirSync(packRoot, { recursive: true });
+    mkdirSync(installRoot, { recursive: true });
+    writeJson(join(installRoot, "package.json"), { name: "fixture-consumer", version: "1.0.0", private: true });
+    let packed;
+    try {
+        packed = JSON.parse(execFileSync("npm", ["pack", "--json", "--pack-destination", packRoot], {
+            cwd: packageRoot,
+            encoding: "utf8",
+            env: { ...process.env, npm_config_ignore_scripts: "true" },
+        }));
+    } catch (error) {
+        throw new Error("Unable to pack the passive npm fixture", { cause: error });
+    }
+    const tarball = join(packRoot, packed[0].filename);
+    execFileSync("npm", ["install", tarball, "--ignore-scripts", "--no-audit", "--no-fund"], {
+        cwd: installRoot,
+        stdio: "pipe",
+    });
+    const installedSkill = join(installRoot, "node_modules/@cratis/ai/skills/cratis-example/SKILL.md");
+    if (!lstatSync(installedSkill).isFile()) throw new Error("Installed npm fixture skill is missing");
+    execFileSync("npm", ["uninstall", "@cratis/ai", "--ignore-scripts", "--no-audit", "--no-fund"], {
+        cwd: installRoot,
+        stdio: "pipe",
+    });
+    if (existsSync(join(installRoot, "node_modules/@cratis/ai")))
+        throw new Error("npm fixture uninstall left package content");
+    return { tarball, installedSkill: "skills/cratis-example/SKILL.md" };
+}
+
+export function smokePiDistributionFixture(
+    outputRoot,
+    temporaryHome,
+    piCommand = "pi",
+) {
+    const packageRoot = join(outputRoot, "pi/package");
+    const environment = { ...process.env, HOME: temporaryHome };
+    execFileSync(piCommand, ["install", packageRoot], {
+        env: environment,
+        stdio: "pipe",
+    });
+    const installed = execFileSync(piCommand, ["list"], {
+        env: environment,
+        encoding: "utf8",
+    });
+    if (!installed.includes(resolve(packageRoot)))
+        throw new Error("Pi fixture install was not observable");
+    execFileSync(piCommand, ["remove", packageRoot], {
+        env: environment,
+        stdio: "pipe",
+    });
+    const removed = execFileSync(piCommand, ["list"], {
+        env: environment,
+        encoding: "utf8",
+    });
+    if (!removed.includes("No packages installed"))
+        throw new Error("Pi fixture uninstall left a configured package");
+    return { installed: true, removed: true };
+}
+
+export function smokeClaudeDistributionFixture(
+    outputRoot,
+    temporaryHome,
+    claudeCommand = "claude",
+) {
+    const marketplaceRoot = join(outputRoot, "claude");
+    const pluginRoot = join(marketplaceRoot, "plugins/cratis");
+    const environment = { ...process.env, HOME: temporaryHome };
+    execFileSync(claudeCommand, ["plugin", "validate", pluginRoot, "--strict"], {
+        env: environment,
+        stdio: "pipe",
+    });
+    execFileSync(claudeCommand, ["plugin", "marketplace", "add", marketplaceRoot], {
+        env: environment,
+        stdio: "pipe",
+    });
+    execFileSync(claudeCommand, ["plugin", "install", "cratis@cratis"], {
+        env: environment,
+        stdio: "pipe",
+    });
+    const installed = execFileSync(claudeCommand, ["plugin", "list"], {
+        env: environment,
+        encoding: "utf8",
+    });
+    if (!installed.includes("cratis@cratis"))
+        throw new Error("Claude fixture install was not observable");
+    execFileSync(claudeCommand, ["plugin", "uninstall", "cratis@cratis"], {
+        env: environment,
+        stdio: "pipe",
+    });
+    execFileSync(claudeCommand, ["plugin", "marketplace", "remove", "cratis"], {
+        env: environment,
+        stdio: "pipe",
+    });
+    return { validated: true, installed: true, removed: true };
+}
+
+export function smokeCopilotDistributionFixture(
+    outputRoot,
+    temporaryHome,
+    copilotCommand = "copilot",
+) {
+    const marketplaceRoot = join(outputRoot, "copilot");
+    const environment = { ...process.env, HOME: temporaryHome };
+    execFileSync(copilotCommand, ["plugin", "marketplace", "add", marketplaceRoot], {
+        env: environment,
+        stdio: "pipe",
+    });
+    execFileSync(copilotCommand, ["plugin", "install", "cratis@cratis"], {
+        env: environment,
+        stdio: "pipe",
+    });
+    const installed = execFileSync(copilotCommand, ["plugin", "list"], {
+        env: environment,
+        encoding: "utf8",
+    });
+    if (!installed.includes("cratis@cratis"))
+        throw new Error("Copilot fixture install was not observable");
+    execFileSync(copilotCommand, ["plugin", "uninstall", "cratis"], {
+        env: environment,
+        stdio: "pipe",
+    });
+    execFileSync(copilotCommand, ["plugin", "marketplace", "remove", "cratis"], {
+        env: environment,
+        stdio: "pipe",
+    });
+    return { installed: true, removed: true };
+}
+
+export function smokeCodexDistributionFixture(
+    outputRoot,
+    temporaryHome,
+    codexCommand = "codex",
+) {
+    const marketplaceRoot = join(outputRoot, "codex");
+    const environment = { ...process.env, HOME: temporaryHome };
+    execFileSync(codexCommand, ["plugin", "marketplace", "add", marketplaceRoot], {
+        env: environment,
+        stdio: "pipe",
+    });
+    const listed = execFileSync(codexCommand, ["plugin", "marketplace", "list"], {
+        env: environment,
+        encoding: "utf8",
+    });
+    if (!listed.includes("cratis"))
+        throw new Error("Codex fixture marketplace was not observable");
+    execFileSync(codexCommand, ["plugin", "marketplace", "remove", "cratis"], {
+        env: environment,
+        stdio: "pipe",
+    });
+    return { added: true, removed: true };
+}
+
+export function smokeGeminiDistributionFixture(
+    outputRoot,
+    temporaryHome,
+    geminiCommand = "gemini",
+) {
+    const extensionRoot = join(outputRoot, "gemini");
+    mkdirSync(join(temporaryHome, ".gemini"), { recursive: true });
+    const environment = {
+        ...process.env,
+        HOME: temporaryHome,
+        GEMINI_API_KEY: process.env.GEMINI_API_KEY ?? "fixture-not-used",
+    };
+    execFileSync(geminiCommand, ["extensions", "link", extensionRoot, "--consent"], {
+        env: environment,
+        stdio: "pipe",
+    });
+    const installedRoot = join(temporaryHome, ".gemini/extensions/cratis");
+    if (!existsSync(installedRoot))
+        throw new Error("Gemini fixture extension was not observable");
+    execFileSync(geminiCommand, ["extensions", "uninstall", "cratis"], {
+        env: environment,
+        stdio: "pipe",
+    });
+    if (existsSync(installedRoot))
+        throw new Error("Gemini fixture uninstall left extension content");
+    return { linked: true, removed: true };
+}
+
+function main() {
+    const outputRoot = process.argv[2];
+    if (!outputRoot) {
+        process.stderr.write("Usage: node tooling/generate-distribution-fixture.mjs <empty-output-path>\n");
+        process.exitCode = 1;
+        return;
+    }
+    const manifest = generateDistributionFixture({ outputRoot });
+    process.stdout.write(`Generated fixture-only distribution: ${manifest.files.length} files across ${manifest.generatedTargets.length} targets.\n`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/tooling/generate-repository-inventory.mjs
+++ b/tooling/generate-repository-inventory.mjs
@@ -108,6 +108,7 @@ const unexpectedUntracked = admittedUntracked.filter(
                 path,
             ) ||
             /^catalog\//.test(path) ||
+            /^distribution\//.test(path) ||
             /^evidence\/source-evidence\//.test(path) ||
             /^evals\//.test(path) ||
             /^pilots\//.test(path) ||
@@ -915,6 +916,23 @@ const definitions = [
         risk: "high",
         migrationState: "retain",
         evidenceIds: ["reevaluation-authority"],
+    },
+    {
+        id: "distribution-foundation",
+        sourcePathPatterns: ["distribution/**"],
+        artifactType: "repository-metadata",
+        currentOwner: repositoryOwner,
+        targetOwner: "Workflows organization mechanics",
+        runtimeEligibility: "repository-only",
+        generatedStatus: "source",
+        adapterStatus: "adapter",
+        dependencies: [
+            "catalog/v2/artifacts.json",
+            "tooling/public-artifact-materializer.mjs",
+        ],
+        risk: "high",
+        migrationState: "retain",
+        evidenceIds: ["option-a-plus-authority"],
     },
     {
         id: "catalog-and-redesign-tooling",

--- a/tooling/specs/distribution-fixture.spec.mjs
+++ b/tooling/specs/distribution-fixture.spec.mjs
@@ -1,0 +1,300 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+    existsSync,
+    mkdtempSync,
+    mkdirSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+    generateDistributionFixture,
+    smokeClaudeDistributionFixture,
+    smokeCodexDistributionFixture,
+    smokeCopilotDistributionFixture,
+    smokeGeminiDistributionFixture,
+    smokeNpmDistributionFixture,
+    smokePiDistributionFixture,
+    validateDistributionFixture,
+} from "../generate-distribution-fixture.mjs";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+function commandAvailable(command) {
+    try {
+        execFileSync(command, ["--version"], { stdio: "pipe" });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+const piAvailable = commandAvailable("pi");
+const claudeAvailable = commandAvailable("claude");
+const codexAvailable = commandAvailable("codex");
+const copilotAvailable = commandAvailable("copilot");
+const geminiAvailable = commandAvailable("gemini");
+
+function withTemporaryDirectory(callback) {
+    const root = mkdtempSync(join(tmpdir(), "cratis-distribution-"));
+    try {
+        return callback(root);
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+}
+
+function readJson(path) {
+    return JSON.parse(readFileSync(path, "utf8"));
+}
+
+test("distribution requirements and artifact matrix stay authority bounded", () => {
+    const requirements = readJson(
+        join(repositoryRoot, "distribution/marketplace-requirements.json"),
+    );
+    const matrix = readJson(
+        join(repositoryRoot, "distribution/artifact-matrix.json"),
+    );
+    const localEvidence = readJson(
+        join(
+            repositoryRoot,
+            "distribution/evidence/local-fixture-smoke-2026-08-22.json",
+        ),
+    );
+    const verified = requirements.requirements
+        .filter(item => item.status.startsWith("VERIFIED"))
+        .map(item => item.id);
+    assert.deepEqual(verified, [
+        "agent-skills-open-standard",
+        "claude-code-marketplace",
+        "openai-codex-plugin",
+        "github-copilot-plugin",
+        "gemini-cli-extension",
+        "pi-passive-package",
+        "npm-trusted-publication",
+    ]);
+    assert.deepEqual(
+        requirements.requirements
+            .filter(item => item.status === "BLOCKED_NO_AUTHORITATIVE_REQUIREMENTS")
+            .map(item => item.id),
+        ["cursor-marketplace", "kiro-marketplace", "junie-marketplace"],
+    );
+    assert.equal(matrix.state, "FIXTURE_ONLY_LOCAL_STAGING");
+    assert.equal(matrix.publicationEligible, false);
+    assert.equal(matrix.promotionEligible, false);
+    assert.equal(
+        matrix.repository.status,
+        "BLOCKED_ON_BOT_REPOSITORY_AND_CREDENTIAL_AUTHORITY",
+    );
+    const requirementIds = new Set(requirements.requirements.map(item => item.id));
+    assert(matrix.targets.every(target => requirementIds.has(target.requirementId)));
+    assert(
+        matrix.targets
+            .filter(target => target.state === "BLOCKED")
+            .every(target => target.outputRoot === null),
+    );
+    assert.equal(localEvidence.publicationEligible, false);
+    assert.equal(localEvidence.promotionEligible, false);
+    assert(localEvidence.results.every(result => result.status.startsWith("PASS")));
+});
+
+test("distribution fixture generation is deterministic across native adapters", () => {
+    withTemporaryDirectory(root => {
+        const firstRoot = join(root, "first");
+        const secondRoot = join(root, "second");
+        const first = generateDistributionFixture({
+            repositoryRoot,
+            outputRoot: firstRoot,
+        });
+        const second = generateDistributionFixture({
+            repositoryRoot,
+            outputRoot: secondRoot,
+        });
+        assert.deepEqual(second, first);
+        for (const file of first.files) {
+            assert.deepEqual(
+                readFileSync(join(secondRoot, file.path)),
+                readFileSync(join(firstRoot, file.path)),
+            );
+        }
+        assert.deepEqual(validateDistributionFixture(firstRoot), first);
+        assert.deepEqual(first.generatedTargets, [
+            "canonical",
+            "claude",
+            "codex",
+            "copilot",
+            "gemini",
+            "pi",
+        ]);
+        for (const blocked of ["cursor", "kiro", "junie"])
+            assert.equal(existsSync(join(firstRoot, blocked)), false);
+    });
+});
+
+test("generated marketplace manifests remain passive and idiomatic", () => {
+    withTemporaryDirectory(root => {
+        const stage = join(root, "stage");
+        generateDistributionFixture({ repositoryRoot, outputRoot: stage });
+        const claude = readJson(
+            join(stage, "claude/plugins/cratis/.claude-plugin/plugin.json"),
+        );
+        const codex = readJson(
+            join(stage, "codex/plugins/cratis/.codex-plugin/plugin.json"),
+        );
+        const copilot = readJson(
+            join(stage, "copilot/plugins/cratis/plugin.json"),
+        );
+        const gemini = readJson(join(stage, "gemini/gemini-extension.json"));
+        const piPackage = readJson(join(stage, "pi/package/package.json"));
+        assert.equal(claude.name, "cratis");
+        assert.equal(codex.skills, "./skills/");
+        assert.equal(copilot.skills, "skills/");
+        assert.equal(gemini.name, "cratis");
+        for (const manifest of [claude, codex, copilot, gemini]) {
+            assert.equal(manifest.hooks, undefined);
+            assert.equal(manifest.mcpServers, undefined);
+            assert.equal(manifest.commands, undefined);
+        }
+        assert.equal(piPackage.name, "@cratis/ai");
+        assert.equal(piPackage.private, true);
+        assert.deepEqual(piPackage.pi, { skills: ["./skills"] });
+        assert.equal(piPackage.scripts, undefined);
+        assert.equal(piPackage.dependencies, undefined);
+        const skill = readFileSync(
+            join(stage, "canonical/skills/cratis-example/SKILL.md"),
+            "utf8",
+        );
+        assert.match(skill, /^---\nname: cratis-example\ndescription: /);
+    });
+});
+
+test("distribution fixture detects payload and checksum tampering", () => {
+    withTemporaryDirectory(root => {
+        const stage = join(root, "stage");
+        generateDistributionFixture({ repositoryRoot, outputRoot: stage });
+        const path = join(
+            stage,
+            "gemini/skills/cratis-example/assets/example.txt",
+        );
+        writeFileSync(path, "tampered\n");
+        assert.throws(
+            () => validateDistributionFixture(stage),
+            /digest mismatch|byte parity|Checksum verification/,
+        );
+    });
+});
+
+test("passive npm fixture packs installs and uninstalls without scripts", () => {
+    withTemporaryDirectory(root => {
+        const stage = join(root, "stage");
+        const smokeRoot = join(root, "smoke");
+        generateDistributionFixture({ repositoryRoot, outputRoot: stage });
+        mkdirSync(smokeRoot);
+        const result = smokeNpmDistributionFixture(stage, smokeRoot);
+        assert.equal(existsSync(result.tarball), true);
+        assert.equal(result.installedSkill, "skills/cratis-example/SKILL.md");
+    });
+});
+
+test(
+    "passive Pi fixture installs lists and removes in an isolated home",
+    { skip: !piAvailable },
+    () => {
+        withTemporaryDirectory(root => {
+            const stage = join(root, "stage");
+            const isolatedHome = join(root, "home");
+            generateDistributionFixture({ repositoryRoot, outputRoot: stage });
+            mkdirSync(isolatedHome);
+            assert.deepEqual(
+                smokePiDistributionFixture(stage, isolatedHome),
+                { installed: true, removed: true },
+            );
+        });
+    },
+);
+
+test(
+    "Claude fixture validates installs and removes in an isolated home",
+    { skip: !claudeAvailable },
+    () => {
+        withTemporaryDirectory(root => {
+            const stage = join(root, "stage");
+            const isolatedHome = join(root, "home");
+            generateDistributionFixture({ repositoryRoot, outputRoot: stage });
+            mkdirSync(isolatedHome);
+            assert.deepEqual(
+                smokeClaudeDistributionFixture(stage, isolatedHome),
+                { validated: true, installed: true, removed: true },
+            );
+        });
+    },
+);
+
+test(
+    "Copilot fixture installs and removes in an isolated home",
+    { skip: !copilotAvailable },
+    () => {
+        withTemporaryDirectory(root => {
+            const stage = join(root, "stage");
+            const isolatedHome = join(root, "home");
+            generateDistributionFixture({ repositoryRoot, outputRoot: stage });
+            mkdirSync(isolatedHome);
+            assert.deepEqual(
+                smokeCopilotDistributionFixture(stage, isolatedHome),
+                { installed: true, removed: true },
+            );
+        });
+    },
+);
+
+test(
+    "Codex fixture marketplace adds and removes in an isolated home",
+    { skip: !codexAvailable },
+    () => {
+        withTemporaryDirectory(root => {
+            const stage = join(root, "stage");
+            const isolatedHome = join(root, "home");
+            generateDistributionFixture({ repositoryRoot, outputRoot: stage });
+            mkdirSync(isolatedHome);
+            assert.deepEqual(
+                smokeCodexDistributionFixture(stage, isolatedHome),
+                { added: true, removed: true },
+            );
+        });
+    },
+);
+
+test(
+    "Gemini fixture links and removes in an isolated home",
+    { skip: !geminiAvailable },
+    () => {
+        withTemporaryDirectory(root => {
+            const stage = join(root, "stage");
+            const isolatedHome = join(root, "home");
+            generateDistributionFixture({ repositoryRoot, outputRoot: stage });
+            mkdirSync(isolatedHome);
+            assert.deepEqual(
+                smokeGeminiDistributionFixture(stage, isolatedHome),
+                { linked: true, removed: true },
+            );
+        });
+    },
+);
+
+test("distribution generator refuses an existing destination", () => {
+    withTemporaryDirectory(root => {
+        const stage = join(root, "stage");
+        mkdirSync(stage);
+        assert.throws(
+            () => generateDistributionFixture({ repositoryRoot, outputRoot: stage }),
+            /must not exist/,
+        );
+    });
+});

--- a/tooling/specs/distribution-fixture.spec.mjs
+++ b/tooling/specs/distribution-fixture.spec.mjs
@@ -79,12 +79,15 @@ test("distribution requirements and artifact matrix stay authority bounded", () 
         "gemini-cli-extension",
         "pi-passive-package",
         "npm-trusted-publication",
+        "cursor-marketplace",
+        "kiro-marketplace",
+        "junie-marketplace",
     ]);
     assert.deepEqual(
         requirements.requirements
             .filter(item => item.status === "BLOCKED_NO_AUTHORITATIVE_REQUIREMENTS")
             .map(item => item.id),
-        ["cursor-marketplace", "kiro-marketplace", "junie-marketplace"],
+        [],
     );
     assert.equal(matrix.state, "FIXTURE_ONLY_LOCAL_STAGING");
     assert.equal(matrix.publicationEligible, false);
@@ -130,11 +133,12 @@ test("distribution fixture generation is deterministic across native adapters", 
             "claude",
             "codex",
             "copilot",
+            "cursor",
             "gemini",
+            "junie",
+            "kiro",
             "pi",
         ]);
-        for (const blocked of ["cursor", "kiro", "junie"])
-            assert.equal(existsSync(join(firstRoot, blocked)), false);
     });
 });
 
@@ -151,13 +155,34 @@ test("generated marketplace manifests remain passive and idiomatic", () => {
         const copilot = readJson(
             join(stage, "copilot/plugins/cratis/plugin.json"),
         );
+        const cursor = readJson(
+            join(stage, "cursor/plugins/cratis/.cursor-plugin/plugin.json"),
+        );
         const gemini = readJson(join(stage, "gemini/gemini-extension.json"));
+        const kiro = readJson(join(stage, "kiro/plugin.json"));
+        const junie = readJson(
+            join(stage, "junie/extensions/cratis/extension.json"),
+        );
         const piPackage = readJson(join(stage, "pi/package/package.json"));
         assert.equal(claude.name, "cratis");
         assert.equal(codex.skills, "./skills/");
         assert.equal(copilot.skills, "skills/");
+        assert.equal(cursor.skills, "./skills/");
         assert.equal(gemini.name, "cratis");
-        for (const manifest of [claude, codex, copilot, gemini]) {
+        assert.equal(
+            kiro.$schema,
+            "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+        );
+        assert.equal(junie.name, "cratis");
+        for (const manifest of [
+            claude,
+            codex,
+            copilot,
+            cursor,
+            gemini,
+            kiro,
+            junie,
+        ]) {
             assert.equal(manifest.hooks, undefined);
             assert.equal(manifest.mcpServers, undefined);
             assert.equal(manifest.commands, undefined);

--- a/tooling/validate-catalogs.mjs
+++ b/tooling/validate-catalogs.mjs
@@ -7,6 +7,7 @@ import { validateV2Catalogs } from "./catalog-v2-validation.mjs";
 import { validateSourceEvidenceContract } from "./source-evidence-contract-validation.mjs";
 import { validateCodeReviewPilot } from "./code-review-pilot-validation.mjs";
 import { validateDomainExpertEventModelingPilot } from "./domain-expert-event-modeling-pilot-validation.mjs";
+import { validateDistributionConfiguration } from "./generate-distribution-fixture.mjs";
 
 const errors = [
     ...validateCatalogs(),
@@ -14,6 +15,7 @@ const errors = [
     ...validateSourceEvidenceContract(),
     ...validateCodeReviewPilot(),
     ...validateDomainExpertEventModelingPilot(),
+    ...validateDistributionConfiguration(),
 ];
 if (errors.length > 0) {
     process.stderr.write(


### PR DESCRIPTION
# Summary

Starts actual marketplace distribution delivery without admitting unapproved product sources or enabling publication. One sanitized canonical fixture now generates native passive layouts and exercises real local package lifecycle gates.

## Added

- Add authoritative Agent Skills, Claude, Codex, Copilot, Gemini, Pi, and npm requirement records plus explicit Cursor, Kiro, and Junie blockers (#126)
- Add the canonical-to-marketplace artifact matrix and exact bot-owned generated-repository authority request (Cratis/Workflows#68)
- Add deterministic fixture-only native adapters, checksums, provenance records, and local smoke evidence (#126)
- Add npm, Pi, Claude, Copilot, Codex, and Gemini pack/install/smoke/uninstall gates (#126)
