### PR TITLE
Add fixture canary and rollback mechanics

### DIFF
--- a/.github/workflows/distribution-canary-rollback.yml
+++ b/.github/workflows/distribution-canary-rollback.yml
@@ -1,0 +1,70 @@
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+name: Verify Distribution Canary and Rollback
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: Fixture-only operation
+        required: true
+        default: simulate-canary-rollback
+        type: choice
+        options:
+          - verify-candidate
+          - simulate-canary-rollback
+
+permissions:
+  contents: read
+
+concurrency:
+  group: distribution-fixture-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-fixture:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out the canonical authoring repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      - name: Verify candidate staging
+        if: inputs.operation == 'verify-candidate'
+        run: |
+          set -euo pipefail
+          node tooling/stage-distribution-candidate.mjs \
+            --artifact sanitized-public-materializer-fixture \
+            --output "$RUNNER_TEMP/distribution-candidate" \
+            --record "$RUNNER_TEMP/distribution-candidate.json"
+          node tooling/generate-distribution-fixture.mjs \
+            "$RUNNER_TEMP/independent-distribution-candidate"
+          diff -u \
+            "$RUNNER_TEMP/distribution-candidate/distribution-manifest.json" \
+            "$RUNNER_TEMP/independent-distribution-candidate/distribution-manifest.json"
+
+      - name: Simulate canary promotion and rollback
+        if: inputs.operation == 'simulate-canary-rollback'
+        run: |
+          set -euo pipefail
+          node tooling/simulate-distribution-rollout.mjs \
+            "$RUNNER_TEMP/distribution-rollout"
+
+      - name: Run distribution specifications
+        run: |
+          node --test tooling/specs/distribution-fixture.spec.mjs
+          node --test tooling/specs/distribution-rollout.spec.mjs
+
+      - name: Confirm publication remains absent
+        run: |
+          set -euo pipefail
+          test "$(node -p "require('./distribution/rollout-policy.json').promotion.publicationEnabled")" = "false"
+          test "$(node -p "require('./distribution/rollout-policy.json').legacyRetirement.enabled")" = "false"

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
@@ -1251,3 +1251,47 @@ then add generated-repository canary/rollback workflow contracts and production
 materializer wiring that remains disabled until repository/credential and target
 approval gates pass. Runtime activation, publication, promotion, fleet rollout,
 legacy retirement, and freeze lifting remain blocked.
+
+## 34. Fixture canary and rollback mechanics — 2026-08-22
+
+The marketplace distribution foundation merged with green CI in Cratis/AI#140.
+AI#126 and Workflows#68 were updated, its branch/worktree were removed normally,
+and this branch starts from merge commit
+`00828efb80ac93b274c8a3bee7c844fdea19b4fb`.
+
+The next distribution unit adds mechanics rather than more general validation:
+
+- `distribution/rollout-policy.json` defines the bot-repository, candidate,
+  canary, promotion, rollback, emergency-disable, and legacy-retirement gates;
+- `tooling/stage-distribution-candidate.mjs` wires the artifact catalog to the
+  generator and allows only `sanitized-public-materializer-fixture`; the planned
+  passive public release still fails closed;
+- `tooling/simulate-distribution-rollout.mjs` stages immutable digest-addressed
+  fixture releases, records canary evidence, advances a fixture stable pin,
+  rolls back to a known release, preserves ordered audit history, and emergency
+  disables further fixture promotion;
+- `.github/workflows/distribution-canary-rollback.yml` is a read-only manual
+  workflow that verifies candidate reproducibility or runs the fixture canary /
+  rollback simulation; it has no write, environment, credential, publish,
+  promotion, or retirement permission;
+- focused specs reject failed-canary promotion, promotion after emergency
+  disable, unknown rollback releases, tampered candidates, duplicate releases,
+  and staging of the blocked public artifact.
+
+Local evidence in
+`distribution/evidence/local-canary-rollback-2026-08-22.json` records two staged
+fixture releases, two passing fixture canaries, two fixture promotions, one
+rollback, one emergency disable, and eight ordered audit entries. This is not
+production canary or rollback evidence.
+
+Fresh evidence is 8/8 focused rollout specs and 181/181 full repository specs.
+The manual workflow YAML parses, candidate and simulation CLIs pass, and catalog,
+stable inventory, syntax, strict JSON, LSP, structural, focused Markdown, and
+diff gates pass with only the unchanged legacy advisories.
+
+Merge this unit and then continue production materializer and generated-
+repository integration as far as deterministic local contracts allow.
+Actual bot writes, protected environments, package staging/publication, approved
+public targets, fleet canaries, rollback against consuming repositories, legacy
+retirement, and freeze lifting remain blocked on external repository/credential,
+source, target, and reviewer authority.

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
@@ -547,8 +547,10 @@ Evidence and exact next actions are in
   deterministic fixture-only local staging.
 - [x] Generate fixture-only canonical, Claude, Codex, Copilot, Cursor, Kiro,
   Junie, Gemini, and Pi/npm adapters from one approved sanitized logical tree.
-- [ ] Promote adapters beyond fixture-only after real target approval; add hosted
-  canary and rollback workflows after generated-repository authority exists.
+- [ ] Promote adapters beyond fixture-only after real target approval; activate
+  hosted canary and rollback only after generated-repository authority exists.
 - [x] Add local pack/install/smoke/uninstall, provenance-record, and checksum
   gates for the fixture-only distribution.
+- [x] Add fixture-only candidate staging, canary evidence, stable-pin simulation,
+  rollback, emergency disable, audit history, and a read-only manual workflow.
 - [ ] Keep publication and retirement disabled until explicit approvals pass.

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,11 +1,15 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "728de7a8627b12c653924002cdc8cf978407667383a5f0025a8f13e14f21ea0b",
+  "indexDigest": "56b96a4251992fcc1ae48b5a16777cdb0aef6fa41a8c18032aac092c11aaa288",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
   "changesSinceBase": [
+    {
+      "path": ".github/workflows/distribution-canary-rollback.yml",
+      "status": "added"
+    },
     {
       "path": ".github/workflows/verify-ai-corpus.yml",
       "status": "added"
@@ -259,6 +263,10 @@
       "status": "added"
     },
     {
+      "path": "distribution/evidence/local-canary-rollback-2026-08-22.json",
+      "status": "added"
+    },
+    {
       "path": "distribution/evidence/local-fixture-smoke-2026-08-22.json",
       "status": "added"
     },
@@ -268,6 +276,10 @@
     },
     {
       "path": "distribution/marketplace-requirements.json",
+      "status": "added"
+    },
+    {
+      "path": "distribution/rollout-policy.json",
       "status": "added"
     },
     {
@@ -1323,6 +1335,10 @@
       "status": "added"
     },
     {
+      "path": "tooling/simulate-distribution-rollout.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/source-evidence-contract-validation.mjs",
       "status": "added"
     },
@@ -1355,6 +1371,10 @@
       "status": "added"
     },
     {
+      "path": "tooling/specs/distribution-rollout.spec.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/specs/domain-expert-event-modeling-pilot.spec.mjs",
       "status": "added"
     },
@@ -1376,6 +1396,10 @@
     },
     {
       "path": "tooling/specs/source-evidence-contract.spec.mjs",
+      "status": "added"
+    },
+    {
+      "path": "tooling/stage-distribution-candidate.mjs",
       "status": "added"
     },
     {
@@ -1910,6 +1934,7 @@
       "excludePathPatterns": [],
       "id": "repository-validation-workflow",
       "sourcePathPatterns": [
+        ".github/workflows/distribution-canary-rollback.yml",
         ".github/workflows/verify-ai-corpus.yml"
       ],
       "artifactType": "workflow",
@@ -1928,8 +1953,8 @@
         "repo-main-b795d53",
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 1,
-      "expectedPathsDigest": "cbb1eb65a59cd4dccc252f948c4352d7fb442a8442f59bde81094f983763e9c2"
+      "expectedPathCount": 2,
+      "expectedPathsDigest": "fd74711f49c8c23ac1ea288bbf7c16a039bcc6d2608f5f3f794a4c2b608ef738"
     },
     {
       "excludePathPatterns": [],
@@ -2593,8 +2618,8 @@
       "evidenceIds": [
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 4,
-      "expectedPathsDigest": "ca954c7f9a27be2cb174d79430848bb2772561bea90a47c7b67ac97ef88a7d98"
+      "expectedPathCount": 6,
+      "expectedPathsDigest": "fadcc1dd51593bf2e9557c4ab06719adee4876441b0ce43d7038db68ca95d685"
     },
     {
       "excludePathPatterns": [],
@@ -2616,8 +2641,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 18,
-      "expectedPathsDigest": "9ad6574268c48b91a6f5f6a8db8c32ff86abc183149f8fa5d2c6fec5aa172cc7"
+      "expectedPathCount": 20,
+      "expectedPathsDigest": "67beb4ea95016f01915c3818e904e877592606b61819946673627d667d87a117"
     },
     {
       "excludePathPatterns": [],
@@ -2640,8 +2665,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 12,
-      "expectedPathsDigest": "84801d0c3f7186b2da58a28e48259962158569c99e228044c7fb2cf9e53be79b"
+      "expectedPathCount": 13,
+      "expectedPathsDigest": "49857b600828a3be4340bf44b96e180feb5e13a23572efc384ed6aaeb1316b24"
     },
     {
       "excludePathPatterns": [],

--- a/distribution/evidence/local-canary-rollback-2026-08-22.json
+++ b/distribution/evidence/local-canary-rollback-2026-08-22.json
@@ -1,0 +1,40 @@
+{
+  "schemaVersion": "1.0.0",
+  "observedAt": "2026-08-22",
+  "sourceCommit": null,
+  "sourceWorktreeBase": "00828efb80ac93b274c8a3bee7c844fdea19b4fb",
+  "state": "FIXTURE_ONLY_ROLLOUT_SIMULATION",
+  "candidate": {
+    "artifactId": "sanitized-public-materializer-fixture",
+    "status": "PASS",
+    "publicationEligible": false,
+    "promotionEligible": false
+  },
+  "rollout": {
+    "stagedReleases": 2,
+    "passingCanaries": 2,
+    "fixturePromotions": 2,
+    "rollbacks": 1,
+    "emergencyDisables": 1,
+    "auditHistoryEntries": 8,
+    "finalStableIsFirstRelease": true,
+    "finalEmergencyDisabled": true,
+    "status": "PASS"
+  },
+  "negativeChecks": [
+    "planned public release staging remains blocked",
+    "failed canary cannot promote",
+    "emergency disable blocks promotion",
+    "unknown rollback release fails",
+    "tampered candidate fails",
+    "duplicate release cannot overwrite"
+  ],
+  "limitations": [
+    "This is deterministic local fixture simulation, not a production canary or rollback.",
+    "No generated repository, bot credential, protected environment, approved public target, package publication, fleet target, or legacy wrapper was used.",
+    "Stable and promotion terms in simulator state are fixture-only and do not grant production promotion eligibility."
+  ],
+  "publicationEligible": false,
+  "promotionEligible": false,
+  "legacyRetirementEligible": false
+}

--- a/distribution/rollout-policy.json
+++ b/distribution/rollout-policy.json
@@ -1,0 +1,57 @@
+{
+  "schemaVersion": "1.0.0",
+  "state": "FIXTURE_ONLY_ROLLOUT_SIMULATION",
+  "generatedRepository": {
+    "name": "Cratis/AI.Distribution",
+    "status": "BLOCKED_ON_BOT_REPOSITORY_AND_CREDENTIAL_AUTHORITY",
+    "botOnlyWrites": true,
+    "protectedMain": true
+  },
+  "candidate": {
+    "allowedArtifactIds": [
+      "sanitized-public-materializer-fixture"
+    ],
+    "blockedArtifactIds": [
+      "planned-passive-public-release"
+    ],
+    "requiredChecks": [
+      "exact-inventory",
+      "canonical-byte-parity",
+      "native-manifest-parse",
+      "checksums",
+      "fixture-provenance-record",
+      "pack-install-smoke-uninstall"
+    ]
+  },
+  "canary": {
+    "enabledTargets": [
+      "local-fixture-simulator"
+    ],
+    "requiredStatus": "PASS",
+    "productionTargetsEnabled": false
+  },
+  "promotion": {
+    "stableEnabled": false,
+    "publicationEnabled": false,
+    "requiresProtectedEnvironment": "distribution-canary",
+    "requiresTargetApproval": true,
+    "requiresProductSourceAuthority": true
+  },
+  "rollback": {
+    "fixtureSimulationEnabled": true,
+    "requiresKnownRelease": true,
+    "preserveAuditHistory": true,
+    "emergencyDisableSupported": true
+  },
+  "legacyRetirement": {
+    "enabled": false,
+    "blockedOn": [
+      "NO_GENERATED_REPOSITORY",
+      "NO_BOT_CREDENTIAL",
+      "NO_PRODUCTION_CANARY",
+      "NO_PRODUCTION_ROLLBACK_EVIDENCE",
+      "NO_APPROVED_PUBLIC_TARGETS",
+      "PROPAGATION_FREEZE_REMAINS_ACTIVE"
+    ]
+  }
+}

--- a/tooling/generate-repository-inventory.mjs
+++ b/tooling/generate-repository-inventory.mjs
@@ -100,6 +100,7 @@ const admittedUntracked = gitPaths([
 const unexpectedUntracked = admittedUntracked.filter(
     (path) =>
         !(
+            path === ".github/workflows/distribution-canary-rollback.yml" ||
             /^AI-REPOSITORY-REDESIGN-[A-Z0-9-]+\.md$/.test(path) ||
             /^Documentation\/(?:capability-catalog-v2|phase-0-verification|public-product-architecture|skill-authoring-contract|skill-classification-audit|project-context-bootstrap|redesign-foundation-validation|source-evidence-contract)\.md$/.test(
                 path,
@@ -437,6 +438,7 @@ const definitions = [
     {
         id: "repository-validation-workflow",
         sourcePathPatterns: [
+            ".github/workflows/distribution-canary-rollback.yml",
             ".github/workflows/verify-ai-corpus.yml",
         ],
         artifactType: "workflow",

--- a/tooling/simulate-distribution-rollout.mjs
+++ b/tooling/simulate-distribution-rollout.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { createHash } from "node:crypto";
+import {
+    cpSync,
+    existsSync,
+    mkdirSync,
+    readFileSync,
+    renameSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+    generateDistributionFixture,
+    validateDistributionFixture,
+} from "./generate-distribution-fixture.mjs";
+
+const defaultRepositoryRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+
+function sha256(content) {
+    return createHash("sha256").update(content).digest("hex");
+}
+
+function readJson(path) {
+    try {
+        return JSON.parse(readFileSync(path, "utf8"));
+    } catch (error) {
+        throw new Error(`Unable to parse rollout state: ${path}`, {
+            cause: error,
+        });
+    }
+}
+
+function statePath(rolloutRoot) {
+    return join(rolloutRoot, "state.json");
+}
+
+function readState(rolloutRoot) {
+    return readJson(statePath(rolloutRoot));
+}
+
+function writeState(rolloutRoot, state) {
+    const path = statePath(rolloutRoot);
+    const temporaryPath = `${path}.partial`;
+    writeFileSync(temporaryPath, `${JSON.stringify(state, null, 2)}\n`, {
+        flag: "wx",
+    });
+    renameSync(temporaryPath, path);
+}
+
+function appendHistory(state, operation, releaseId = null) {
+    state.sequence += 1;
+    state.history.push({ sequence: state.sequence, operation, releaseId });
+}
+
+function releaseRoot(rolloutRoot, releaseId) {
+    if (!/^[0-9a-f]{64}$/.test(releaseId))
+        throw new Error(`Invalid rollout release id: ${releaseId}`);
+    return join(rolloutRoot, "releases", releaseId);
+}
+
+export function initializeDistributionRollout(rolloutRoot) {
+    if (existsSync(rolloutRoot))
+        throw new Error(`Rollout root must not exist: ${rolloutRoot}`);
+    mkdirSync(join(rolloutRoot, "releases"), { recursive: true });
+    mkdirSync(join(rolloutRoot, "canary-evidence"), { recursive: true });
+    writeState(rolloutRoot, {
+        schemaVersion: "1.0.0",
+        state: "FIXTURE_ONLY_ROLLOUT_SIMULATION",
+        sequence: 0,
+        canaryReleaseId: null,
+        stableReleaseId: null,
+        previousStableReleaseId: null,
+        emergencyDisabled: false,
+        history: [],
+        publicationEligible: false,
+        promotionEligible: false,
+    });
+    return readState(rolloutRoot);
+}
+
+export function stageFixtureRelease(rolloutRoot, candidateRoot) {
+    validateDistributionFixture(candidateRoot);
+    const manifestBytes = readFileSync(
+        join(candidateRoot, "distribution-manifest.json"),
+    );
+    const releaseId = sha256(manifestBytes);
+    const destination = releaseRoot(rolloutRoot, releaseId);
+    if (existsSync(destination))
+        throw new Error(`Fixture release already exists: ${releaseId}`);
+    cpSync(candidateRoot, destination, {
+        recursive: true,
+        errorOnExist: true,
+    });
+    validateDistributionFixture(destination);
+    const state = readState(rolloutRoot);
+    appendHistory(state, "STAGE_RELEASE", releaseId);
+    writeState(rolloutRoot, state);
+    return releaseId;
+}
+
+export function recordFixtureCanary(
+    rolloutRoot,
+    releaseId,
+    { status, checks },
+) {
+    const destination = releaseRoot(rolloutRoot, releaseId);
+    if (!existsSync(destination))
+        throw new Error(`Unknown fixture release: ${releaseId}`);
+    if (!["PASS", "FAIL"].includes(status))
+        throw new Error(`Invalid canary status: ${status}`);
+    if (
+        !Array.isArray(checks) ||
+        checks.length === 0 ||
+        checks.some(check => typeof check !== "string" || check.length === 0)
+    ) {
+        throw new Error("Canary checks must be nonempty strings");
+    }
+    const evidencePath = join(
+        rolloutRoot,
+        "canary-evidence",
+        `${releaseId}.json`,
+    );
+    if (existsSync(evidencePath))
+        throw new Error(`Canary evidence already exists: ${releaseId}`);
+    const evidence = {
+        schemaVersion: "1.0.0",
+        releaseId,
+        status,
+        checks,
+        fixtureOnly: true,
+        productionCanary: false,
+    };
+    writeFileSync(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`, {
+        flag: "wx",
+    });
+    const state = readState(rolloutRoot);
+    state.canaryReleaseId = releaseId;
+    appendHistory(state, `CANARY_${status}`, releaseId);
+    writeState(rolloutRoot, state);
+    return evidence;
+}
+
+export function promoteFixtureStable(rolloutRoot, releaseId) {
+    const state = readState(rolloutRoot);
+    if (state.emergencyDisabled)
+        throw new Error("Fixture rollout is emergency disabled");
+    if (state.canaryReleaseId !== releaseId)
+        throw new Error("Only the active canary can enter fixture stable state");
+    const evidence = readJson(
+        join(rolloutRoot, "canary-evidence", `${releaseId}.json`),
+    );
+    if (evidence.status !== "PASS")
+        throw new Error("A passing fixture canary is required");
+    state.previousStableReleaseId = state.stableReleaseId;
+    state.stableReleaseId = releaseId;
+    appendHistory(state, "PROMOTE_FIXTURE_STABLE", releaseId);
+    writeState(rolloutRoot, state);
+    return readState(rolloutRoot);
+}
+
+export function rollbackFixtureStable(rolloutRoot, releaseId) {
+    const state = readState(rolloutRoot);
+    if (!existsSync(releaseRoot(rolloutRoot, releaseId)))
+        throw new Error(`Unknown rollback release: ${releaseId}`);
+    if (state.stableReleaseId === releaseId)
+        throw new Error("Rollback release is already fixture stable");
+    state.previousStableReleaseId = state.stableReleaseId;
+    state.stableReleaseId = releaseId;
+    appendHistory(state, "ROLLBACK_FIXTURE_STABLE", releaseId);
+    writeState(rolloutRoot, state);
+    return readState(rolloutRoot);
+}
+
+export function emergencyDisableFixtureRollout(rolloutRoot) {
+    const state = readState(rolloutRoot);
+    state.emergencyDisabled = true;
+    appendHistory(state, "EMERGENCY_DISABLE");
+    writeState(rolloutRoot, state);
+    return readState(rolloutRoot);
+}
+
+export function simulateDistributionCanaryRollback({
+    repositoryRoot = defaultRepositoryRoot,
+    simulationRoot,
+} = {}) {
+    if (!simulationRoot)
+        throw new Error("simulationRoot is required");
+    if (existsSync(simulationRoot))
+        throw new Error(`Simulation root must not exist: ${simulationRoot}`);
+    mkdirSync(simulationRoot, { recursive: false });
+    try {
+        const rolloutRoot = join(simulationRoot, "rollout");
+        initializeDistributionRollout(rolloutRoot);
+        const firstCandidate = join(simulationRoot, "candidate-v1");
+        const secondCandidate = join(simulationRoot, "candidate-v2");
+        generateDistributionFixture({
+            repositoryRoot,
+            outputRoot: firstCandidate,
+            version: "0.0.1-fixture",
+        });
+        generateDistributionFixture({
+            repositoryRoot,
+            outputRoot: secondCandidate,
+            version: "0.0.2-fixture",
+        });
+        const firstRelease = stageFixtureRelease(rolloutRoot, firstCandidate);
+        const secondRelease = stageFixtureRelease(rolloutRoot, secondCandidate);
+        recordFixtureCanary(rolloutRoot, firstRelease, {
+            status: "PASS",
+            checks: ["manifest", "checksums", "smoke"],
+        });
+        promoteFixtureStable(rolloutRoot, firstRelease);
+        recordFixtureCanary(rolloutRoot, secondRelease, {
+            status: "PASS",
+            checks: ["manifest", "checksums", "smoke"],
+        });
+        promoteFixtureStable(rolloutRoot, secondRelease);
+        rollbackFixtureStable(rolloutRoot, firstRelease);
+        const finalState = emergencyDisableFixtureRollout(rolloutRoot);
+        return {
+            firstRelease,
+            secondRelease,
+            finalState,
+        };
+    } catch (error) {
+        rmSync(simulationRoot, { recursive: true, force: true });
+        throw error;
+    }
+}
+
+function main() {
+    const simulationRoot = process.argv[2];
+    if (!simulationRoot) {
+        process.stderr.write(
+            "Usage: node tooling/simulate-distribution-rollout.mjs <empty-simulation-path>\n",
+        );
+        process.exitCode = 1;
+        return;
+    }
+    try {
+        const result = simulateDistributionCanaryRollback({ simulationRoot });
+        process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    } catch (error) {
+        process.stderr.write(
+            `${error instanceof Error ? error.message : "Rollout simulation failed"}\n`,
+        );
+        process.exitCode = 1;
+    }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/tooling/specs/distribution-rollout.spec.mjs
+++ b/tooling/specs/distribution-rollout.spec.mjs
@@ -1,0 +1,191 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert from "node:assert/strict";
+import {
+    mkdtempSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { generateDistributionFixture } from "../generate-distribution-fixture.mjs";
+import {
+    emergencyDisableFixtureRollout,
+    initializeDistributionRollout,
+    promoteFixtureStable,
+    recordFixtureCanary,
+    rollbackFixtureStable,
+    simulateDistributionCanaryRollback,
+    stageFixtureRelease,
+} from "../simulate-distribution-rollout.mjs";
+import { stageDistributionCandidate } from "../stage-distribution-candidate.mjs";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+function withTemporaryDirectory(callback) {
+    const root = mkdtempSync(join(tmpdir(), "cratis-rollout-"));
+    try {
+        return callback(root);
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+}
+
+test("rollout policy keeps production promotion and retirement blocked", () => {
+    const policy = JSON.parse(
+        readFileSync(
+            join(repositoryRoot, "distribution/rollout-policy.json"),
+            "utf8",
+        ),
+    );
+    assert.equal(policy.state, "FIXTURE_ONLY_ROLLOUT_SIMULATION");
+    assert.equal(policy.generatedRepository.botOnlyWrites, true);
+    assert.equal(policy.canary.productionTargetsEnabled, false);
+    assert.equal(policy.promotion.stableEnabled, false);
+    assert.equal(policy.promotion.publicationEnabled, false);
+    assert.equal(policy.legacyRetirement.enabled, false);
+    assert(policy.legacyRetirement.blockedOn.includes("NO_PRODUCTION_ROLLBACK_EVIDENCE"));
+});
+
+test("candidate staging allows only the authorized sanitized fixture", () => {
+    withTemporaryDirectory(root => {
+        const stage = join(root, "stage");
+        const recordPath = join(root, "candidate.json");
+        const record = stageDistributionCandidate({
+            repositoryRoot,
+            artifactId: "sanitized-public-materializer-fixture",
+            outputRoot: stage,
+            candidateRecordPath: recordPath,
+        });
+        assert.equal(record.state, "FIXTURE_CANDIDATE_ONLY");
+        assert.equal(record.publicationEligible, false);
+        assert.equal(record.promotionEligible, false);
+        assert.deepEqual(JSON.parse(readFileSync(recordPath, "utf8")), record);
+        assert.throws(
+            () =>
+                stageDistributionCandidate({
+                    repositoryRoot,
+                    artifactId: "planned-passive-public-release",
+                    outputRoot: join(root, "public-stage"),
+                    candidateRecordPath: join(root, "public-candidate.json"),
+                }),
+            /not authorized for fixture staging/,
+        );
+    });
+});
+
+test("fixture rollout canaries promotes rolls back and emergency disables", () => {
+    withTemporaryDirectory(root => {
+        const result = simulateDistributionCanaryRollback({
+            repositoryRoot,
+            simulationRoot: join(root, "simulation"),
+        });
+        assert.notEqual(result.firstRelease, result.secondRelease);
+        assert.equal(result.finalState.stableReleaseId, result.firstRelease);
+        assert.equal(
+            result.finalState.previousStableReleaseId,
+            result.secondRelease,
+        );
+        assert.equal(result.finalState.emergencyDisabled, true);
+        assert.deepEqual(
+            result.finalState.history.map(item => item.operation),
+            [
+                "STAGE_RELEASE",
+                "STAGE_RELEASE",
+                "CANARY_PASS",
+                "PROMOTE_FIXTURE_STABLE",
+                "CANARY_PASS",
+                "PROMOTE_FIXTURE_STABLE",
+                "ROLLBACK_FIXTURE_STABLE",
+                "EMERGENCY_DISABLE",
+            ],
+        );
+    });
+});
+
+test("failed canary cannot enter fixture stable state", () => {
+    withTemporaryDirectory(root => {
+        const rollout = join(root, "rollout");
+        const candidate = join(root, "candidate");
+        initializeDistributionRollout(rollout);
+        generateDistributionFixture({
+            repositoryRoot,
+            outputRoot: candidate,
+            version: "0.0.3-fixture",
+        });
+        const release = stageFixtureRelease(rollout, candidate);
+        recordFixtureCanary(rollout, release, {
+            status: "FAIL",
+            checks: ["smoke"],
+        });
+        assert.throws(
+            () => promoteFixtureStable(rollout, release),
+            /passing fixture canary is required/,
+        );
+    });
+});
+
+test("emergency disable blocks fixture promotion", () => {
+    withTemporaryDirectory(root => {
+        const rollout = join(root, "rollout");
+        const candidate = join(root, "candidate");
+        initializeDistributionRollout(rollout);
+        generateDistributionFixture({ repositoryRoot, outputRoot: candidate });
+        const release = stageFixtureRelease(rollout, candidate);
+        recordFixtureCanary(rollout, release, {
+            status: "PASS",
+            checks: ["manifest", "smoke"],
+        });
+        emergencyDisableFixtureRollout(rollout);
+        assert.throws(
+            () => promoteFixtureStable(rollout, release),
+            /emergency disabled/,
+        );
+    });
+});
+
+test("rollback requires a known noncurrent fixture release", () => {
+    withTemporaryDirectory(root => {
+        const rollout = join(root, "rollout");
+        initializeDistributionRollout(rollout);
+        assert.throws(
+            () => rollbackFixtureStable(rollout, "0".repeat(64)),
+            /Unknown rollback release/,
+        );
+    });
+});
+
+test("tampered candidate cannot be staged as a fixture release", () => {
+    withTemporaryDirectory(root => {
+        const rollout = join(root, "rollout");
+        const candidate = join(root, "candidate");
+        initializeDistributionRollout(rollout);
+        generateDistributionFixture({ repositoryRoot, outputRoot: candidate });
+        writeFileSync(
+            join(candidate, "canonical/skills/cratis-example/SKILL.md"),
+            "tampered\n",
+        );
+        assert.throws(
+            () => stageFixtureRelease(rollout, candidate),
+            /digest mismatch|byte parity|Checksum verification/,
+        );
+    });
+});
+
+test("duplicate fixture release staging fails without overwriting", () => {
+    withTemporaryDirectory(root => {
+        const rollout = join(root, "rollout");
+        const candidate = join(root, "candidate");
+        initializeDistributionRollout(rollout);
+        generateDistributionFixture({ repositoryRoot, outputRoot: candidate });
+        stageFixtureRelease(rollout, candidate);
+        assert.throws(
+            () => stageFixtureRelease(rollout, candidate),
+            /already exists/,
+        );
+    });
+});

--- a/tooling/stage-distribution-candidate.mjs
+++ b/tooling/stage-distribution-candidate.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+    generateDistributionFixture,
+    validateDistributionConfiguration,
+} from "./generate-distribution-fixture.mjs";
+
+const defaultRepositoryRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const fixtureArtifactId = "sanitized-public-materializer-fixture";
+
+function sha256(content) {
+    return createHash("sha256").update(content).digest("hex");
+}
+
+function readJson(path) {
+    try {
+        return JSON.parse(readFileSync(path, "utf8"));
+    } catch (error) {
+        throw new Error(`Unable to parse candidate input: ${path}`, {
+            cause: error,
+        });
+    }
+}
+
+export function stageDistributionCandidate({
+    repositoryRoot = defaultRepositoryRoot,
+    artifactId,
+    outputRoot,
+    candidateRecordPath,
+    version = "0.0.0-fixture",
+} = {}) {
+    if (!artifactId || !outputRoot || !candidateRecordPath)
+        throw new Error("artifactId, outputRoot, and candidateRecordPath are required");
+    if (existsSync(outputRoot))
+        throw new Error(`Candidate output must not exist: ${outputRoot}`);
+    if (existsSync(candidateRecordPath))
+        throw new Error(`Candidate record must not exist: ${candidateRecordPath}`);
+    const configurationErrors = validateDistributionConfiguration(repositoryRoot);
+    if (configurationErrors.length > 0)
+        throw new Error(configurationErrors.join("; "));
+    const artifactCatalog = readJson(
+        join(repositoryRoot, "catalog/v2/artifacts.json"),
+    );
+    const policy = readJson(
+        join(repositoryRoot, "distribution/rollout-policy.json"),
+    );
+    const artifact = artifactCatalog.artifacts?.find(
+        candidate => candidate.id === artifactId,
+    );
+    if (!artifact) throw new Error(`Unknown distribution artifact: ${artifactId}`);
+    if (
+        artifact.materializationAllowed !== true ||
+        artifact.runtimeEligible !== false ||
+        artifact.fixtureOnly !== true ||
+        !policy.candidate.allowedArtifactIds.includes(artifactId)
+    ) {
+        throw new Error(
+            `Distribution artifact is not authorized for fixture staging: ${artifactId}`,
+        );
+    }
+    if (artifactId !== fixtureArtifactId)
+        throw new Error(`No generator is bound to artifact: ${artifactId}`);
+    const manifest = generateDistributionFixture({
+        repositoryRoot,
+        outputRoot,
+        version,
+    });
+    const manifestPath = join(outputRoot, "distribution-manifest.json");
+    const manifestBytes = readFileSync(manifestPath);
+    const record = {
+        schemaVersion: "1.0.0",
+        state: "FIXTURE_CANDIDATE_ONLY",
+        artifactId,
+        version,
+        manifestSha256: sha256(manifestBytes),
+        manifestFiles: manifest.files.length,
+        sourceCommit: null,
+        generatedRepository: policy.generatedRepository.name,
+        generatedRepositoryStatus: policy.generatedRepository.status,
+        publicationEligible: false,
+        promotionEligible: false,
+    };
+    writeFileSync(candidateRecordPath, `${JSON.stringify(record, null, 2)}\n`, {
+        flag: "wx",
+    });
+    return record;
+}
+
+function parseArguments(arguments_) {
+    const values = new Map();
+    for (let index = 0; index < arguments_.length; index += 2) {
+        const name = arguments_[index];
+        const value = arguments_[index + 1];
+        if (!name?.startsWith("--") || value === undefined)
+            throw new Error("Arguments must be --name value pairs");
+        values.set(name.slice(2), value);
+    }
+    return values;
+}
+
+function main() {
+    try {
+        const arguments_ = parseArguments(process.argv.slice(2));
+        const record = stageDistributionCandidate({
+            artifactId: arguments_.get("artifact"),
+            outputRoot: arguments_.get("output"),
+            candidateRecordPath: arguments_.get("record"),
+            version: arguments_.get("version") ?? "0.0.0-fixture",
+        });
+        process.stdout.write(
+            `Staged ${record.state} ${record.artifactId} at ${record.version}.\n`,
+        );
+    } catch (error) {
+        process.stderr.write(
+            `${error instanceof Error ? error.message : "Candidate staging failed"}\n`,
+        );
+        process.exitCode = 1;
+    }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();


### PR DESCRIPTION
# Summary

Adds executable fixture-only candidate, canary, rollback, and emergency-disable mechanics while every production, publication, promotion, and retirement gate remains closed.

## Added

- Add artifact-catalog-bound candidate staging that permits only the authorized sanitized fixture (#126)
- Add digest-addressed fixture canary, stable-pin, rollback, emergency-disable, and audit-history simulation (Cratis/Workflows#68)
- Add a read-only manual workflow for candidate reproducibility and canary/rollback simulation (Cratis/Workflows#68)
- Add focused negative gates and local rollout evidence without claiming production canary status (#126)
