### PR TITLE
Format distribution tooling

### DIFF
--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "56b96a4251992fcc1ae48b5a16777cdb0aef6fa41a8c18032aac092c11aaa288",
+  "indexDigest": "e3836157dc3ac6b239b07f7cd9153dcf72065b6bf4dc4772c15bfe5b193dc1cf",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/tooling/generate-distribution-fixture.mjs
+++ b/tooling/generate-distribution-fixture.mjs
@@ -19,7 +19,9 @@ import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { materializeFixtureArtifact } from "./public-artifact-materializer.mjs";
 
-const defaultRepositoryRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const defaultRepositoryRoot = resolve(
+    fileURLToPath(new URL("..", import.meta.url)),
+);
 const approvedFiles = [
     "skills/cratis-example/LICENSE",
     "skills/cratis-example/SKILL.md",
@@ -56,11 +58,13 @@ function writeJson(path, value) {
 }
 
 function walkFiles(root, current = root) {
-    return readdirSync(current, { withFileTypes: true }).flatMap(entry => {
+    return readdirSync(current, { withFileTypes: true }).flatMap((entry) => {
         const path = join(current, entry.name);
-        if (entry.isSymbolicLink()) throw new Error(`Generated symlink is forbidden: ${path}`);
+        if (entry.isSymbolicLink())
+            throw new Error(`Generated symlink is forbidden: ${path}`);
         if (entry.isDirectory()) return walkFiles(root, path);
-        if (!entry.isFile()) throw new Error(`Generated special file is forbidden: ${path}`);
+        if (!entry.isFile())
+            throw new Error(`Generated special file is forbidden: ${path}`);
         return [relative(root, path).replaceAll("\\", "/")];
     });
 }
@@ -80,24 +84,52 @@ function manifestFile(root, path) {
 }
 
 function assertConfiguration(requirements, matrix) {
-    if (requirements.schemaVersion !== "1.0.0" || matrix.schemaVersion !== "1.0.0")
+    if (
+        requirements.schemaVersion !== "1.0.0" ||
+        matrix.schemaVersion !== "1.0.0"
+    )
         throw new Error("Distribution configuration version changed");
-    if (matrix.state !== "FIXTURE_ONLY_LOCAL_STAGING" || matrix.publicationEligible !== false || matrix.promotionEligible !== false)
-        throw new Error("Distribution fixture must remain publication and promotion ineligible");
-    if (matrix.repository?.status !== "BLOCKED_ON_BOT_REPOSITORY_AND_CREDENTIAL_AUTHORITY")
+    if (
+        matrix.state !== "FIXTURE_ONLY_LOCAL_STAGING" ||
+        matrix.publicationEligible !== false ||
+        matrix.promotionEligible !== false
+    )
+        throw new Error(
+            "Distribution fixture must remain publication and promotion ineligible",
+        );
+    if (
+        matrix.repository?.status !==
+        "BLOCKED_ON_BOT_REPOSITORY_AND_CREDENTIAL_AUTHORITY"
+    )
         throw new Error("Generated repository authority gate changed");
-    if (JSON.stringify(matrix.canonicalSource?.approvedFiles) !== JSON.stringify(approvedFiles))
+    if (
+        JSON.stringify(matrix.canonicalSource?.approvedFiles) !==
+        JSON.stringify(approvedFiles)
+    )
         throw new Error("Canonical fixture allowlist changed");
-    const requirementIds = new Set(requirements.requirements?.map(item => item.id));
-    if (matrix.targets.some(target => !requirementIds.has(target.requirementId)))
+    const requirementIds = new Set(
+        requirements.requirements?.map((item) => item.id),
+    );
+    if (
+        matrix.targets.some(
+            (target) => !requirementIds.has(target.requirementId),
+        )
+    )
         throw new Error("Artifact matrix contains an unknown requirement");
     const enabledRoots = matrix.targets
-        .filter(target => target.state === "FIXTURE_GENERATION_ENABLED")
-        .map(target => target.outputRoot)
+        .filter((target) => target.state === "FIXTURE_GENERATION_ENABLED")
+        .map((target) => target.outputRoot)
         .sort();
-    if (JSON.stringify(enabledRoots) !== JSON.stringify([...generatedTargets].sort()))
+    if (
+        JSON.stringify(enabledRoots) !==
+        JSON.stringify([...generatedTargets].sort())
+    )
         throw new Error("Generated fixture target inventory changed");
-    if (matrix.targets.filter(target => target.state === "BLOCKED").some(target => target.outputRoot !== null))
+    if (
+        matrix.targets
+            .filter((target) => target.state === "BLOCKED")
+            .some((target) => target.outputRoot !== null)
+    )
         throw new Error("Blocked targets must not receive output roots");
 }
 
@@ -129,9 +161,16 @@ export function generateDistributionFixture({
 } = {}) {
     if (!outputRoot) throw new Error("outputRoot is required");
     const root = resolve(outputRoot);
-    if (existsSync(root)) throw new Error(`Distribution stage must not exist: ${root}`);
-    const requirementsPath = join(repositoryRoot, "distribution/marketplace-requirements.json");
-    const matrixPath = join(repositoryRoot, "distribution/artifact-matrix.json");
+    if (existsSync(root))
+        throw new Error(`Distribution stage must not exist: ${root}`);
+    const requirementsPath = join(
+        repositoryRoot,
+        "distribution/marketplace-requirements.json",
+    );
+    const matrixPath = join(
+        repositoryRoot,
+        "distribution/artifact-matrix.json",
+    );
     const requirements = readJson(requirementsPath);
     const matrix = readJson(matrixPath);
     assertConfiguration(requirements, matrix);
@@ -140,7 +179,10 @@ export function generateDistributionFixture({
     try {
         const canonicalRoot = join(root, "canonical");
         materializeFixtureArtifact({
-            sourceRoot: join(repositoryRoot, "tooling/fixtures/public-artifact/valid-source"),
+            sourceRoot: join(
+                repositoryRoot,
+                "tooling/fixtures/public-artifact/valid-source",
+            ),
             stageRoot: canonicalRoot,
             approvedFiles,
         });
@@ -150,33 +192,46 @@ export function generateDistributionFixture({
         writeJson(join(claudeRoot, ".claude-plugin/marketplace.json"), {
             name: "cratis",
             owner: { name: "Cratis" },
-            metadata: { description: "Cratis skills-only fixture marketplace", version },
-            plugins: [{
-                name: "cratis",
-                description: "Passive Cratis skills fixture.",
+            metadata: {
+                description: "Cratis skills-only fixture marketplace",
                 version,
-                source: "./plugins/cratis",
-                strict: true,
-            }],
+            },
+            plugins: [
+                {
+                    name: "cratis",
+                    description: "Passive Cratis skills fixture.",
+                    version,
+                    source: "./plugins/cratis",
+                    strict: true,
+                },
+            ],
         });
-        writeJson(join(claudeRoot, "plugins/cratis/.claude-plugin/plugin.json"), {
-            name: "cratis",
-            version,
-            description: "Passive Cratis skills fixture.",
-            author: { name: "Cratis" },
-        });
+        writeJson(
+            join(claudeRoot, "plugins/cratis/.claude-plugin/plugin.json"),
+            {
+                name: "cratis",
+                version,
+                description: "Passive Cratis skills fixture.",
+                author: { name: "Cratis" },
+            },
+        );
 
         const codexRoot = join(root, "codex");
         copyCanonicalSkill(canonicalRoot, join(codexRoot, "plugins/cratis"));
         writeJson(join(codexRoot, ".agents/plugins/marketplace.json"), {
             name: "cratis",
             interface: { displayName: "Cratis" },
-            plugins: [{
-                name: "cratis",
-                source: { source: "local", path: "./plugins/cratis" },
-                policy: { installation: "AVAILABLE", authentication: "ON_INSTALL" },
-                category: "Developer Tools",
-            }],
+            plugins: [
+                {
+                    name: "cratis",
+                    source: { source: "local", path: "./plugins/cratis" },
+                    policy: {
+                        installation: "AVAILABLE",
+                        authentication: "ON_INSTALL",
+                    },
+                    category: "Developer Tools",
+                },
+            ],
         });
         writeJson(join(codexRoot, "plugins/cratis/.codex-plugin/plugin.json"), {
             name: "cratis",
@@ -190,14 +245,19 @@ export function generateDistributionFixture({
         writeJson(join(copilotRoot, ".github/plugin/marketplace.json"), {
             name: "cratis",
             owner: { name: "Cratis" },
-            metadata: { description: "Cratis skills-only fixture marketplace", version },
-            plugins: [{
-                name: "cratis",
-                description: "Passive Cratis skills fixture.",
+            metadata: {
+                description: "Cratis skills-only fixture marketplace",
                 version,
-                source: "./plugins/cratis",
-                strict: true,
-            }],
+            },
+            plugins: [
+                {
+                    name: "cratis",
+                    description: "Passive Cratis skills fixture.",
+                    version,
+                    source: "./plugins/cratis",
+                    strict: true,
+                },
+            ],
         });
         writeJson(join(copilotRoot, "plugins/cratis/plugin.json"), {
             name: "cratis",
@@ -211,20 +271,28 @@ export function generateDistributionFixture({
         writeJson(join(cursorRoot, ".cursor-plugin/marketplace.json"), {
             name: "cratis",
             owner: { name: "Cratis" },
-            metadata: { description: "Cratis skills-only fixture marketplace", version },
-            plugins: [{
-                name: "cratis",
-                description: "Passive Cratis skills fixture.",
+            metadata: {
+                description: "Cratis skills-only fixture marketplace",
                 version,
-                source: "./plugins/cratis",
-            }],
+            },
+            plugins: [
+                {
+                    name: "cratis",
+                    description: "Passive Cratis skills fixture.",
+                    version,
+                    source: "./plugins/cratis",
+                },
+            ],
         });
-        writeJson(join(cursorRoot, "plugins/cratis/.cursor-plugin/plugin.json"), {
-            name: "cratis",
-            version,
-            description: "Passive Cratis skills fixture.",
-            skills: "./skills/",
-        });
+        writeJson(
+            join(cursorRoot, "plugins/cratis/.cursor-plugin/plugin.json"),
+            {
+                name: "cratis",
+                version,
+                description: "Passive Cratis skills fixture.",
+                skills: "./skills/",
+            },
+        );
 
         const geminiRoot = join(root, "gemini");
         copyCanonicalSkill(canonicalRoot, geminiRoot);
@@ -237,7 +305,8 @@ export function generateDistributionFixture({
         const kiroRoot = join(root, "kiro");
         copyCanonicalSkill(canonicalRoot, kiroRoot);
         writeJson(join(kiroRoot, "plugin.json"), {
-            $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+            $schema:
+                "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
             name: "cratis",
             version,
             description: "Passive Cratis skills fixture.",
@@ -265,7 +334,9 @@ export function generateDistributionFixture({
             pi: { skills: ["./skills"] },
         });
 
-        const canonicalManifest = approvedFiles.map(path => manifestFile(canonicalRoot, path));
+        const canonicalManifest = approvedFiles.map((path) =>
+            manifestFile(canonicalRoot, path),
+        );
         writeJson(join(root, "provenance.json"), {
             schemaVersion: "1.0.0",
             state: "FIXTURE_ONLY_NOT_AN_ATTESTATION",
@@ -283,10 +354,14 @@ export function generateDistributionFixture({
 
         const checksumPaths = walkFiles(root).sort();
         const checksums = checksumPaths
-            .map(path => `${sha256(readFileSync(join(root, path)))}  ${path}`)
+            .map((path) => `${sha256(readFileSync(join(root, path)))}  ${path}`)
             .join("\n");
-        writeFileSync(join(root, "SHA256SUMS"), `${checksums}\n`, { flag: "wx" });
-        const files = walkFiles(root).sort().map(path => manifestFile(root, path));
+        writeFileSync(join(root, "SHA256SUMS"), `${checksums}\n`, {
+            flag: "wx",
+        });
+        const files = walkFiles(root)
+            .sort()
+            .map((path) => manifestFile(root, path));
         const manifest = {
             schemaVersion: "1.0.0",
             state: "FIXTURE_ONLY_LOCAL_STAGING",
@@ -308,16 +383,24 @@ export function generateDistributionFixture({
 export function validateDistributionFixture(outputRoot) {
     const root = realpathSync(outputRoot);
     const manifest = readJson(join(root, "distribution-manifest.json"));
-    if (manifest.state !== "FIXTURE_ONLY_LOCAL_STAGING" || manifest.publicationEligible !== false || manifest.promotionEligible !== false)
+    if (
+        manifest.state !== "FIXTURE_ONLY_LOCAL_STAGING" ||
+        manifest.publicationEligible !== false ||
+        manifest.promotionEligible !== false
+    )
         throw new Error("Generated distribution state changed");
-    const actualPaths = walkFiles(root).filter(path => path !== "distribution-manifest.json").sort();
-    const declaredPaths = manifest.files.map(file => file.path).sort();
+    const actualPaths = walkFiles(root)
+        .filter((path) => path !== "distribution-manifest.json")
+        .sort();
+    const declaredPaths = manifest.files.map((file) => file.path).sort();
     if (JSON.stringify(actualPaths) !== JSON.stringify(declaredPaths))
         throw new Error("Generated distribution manifest inventory changed");
     for (const file of manifest.files) {
         const content = readFileSync(join(root, file.path));
         if (content.length !== file.size || sha256(content) !== file.sha256)
-            throw new Error(`Generated distribution digest mismatch: ${file.path}`);
+            throw new Error(
+                `Generated distribution digest mismatch: ${file.path}`,
+            );
     }
     const canonicalRoot = join(root, "canonical");
     const targetSkillRoots = [
@@ -334,10 +417,15 @@ export function validateDistributionFixture(outputRoot) {
         const canonical = readFileSync(join(canonicalRoot, path));
         for (const targetRoot of targetSkillRoots) {
             const target = readFileSync(join(root, targetRoot, path));
-            if (!canonical.equals(target)) throw new Error(`Canonical byte parity failed: ${targetRoot}/${path}`);
+            if (!canonical.equals(target))
+                throw new Error(
+                    `Canonical byte parity failed: ${targetRoot}/${path}`,
+                );
         }
     }
-    const checksumLines = readFileSync(join(root, "SHA256SUMS"), "utf8").trim().split("\n");
+    const checksumLines = readFileSync(join(root, "SHA256SUMS"), "utf8")
+        .trim()
+        .split("\n");
     for (const line of checksumLines) {
         const match = /^([0-9a-f]{64}) {2}(.+)$/.exec(line);
         if (!match || sha256(readFileSync(join(root, match[2]))) !== match[1])
@@ -352,28 +440,58 @@ export function smokeNpmDistributionFixture(outputRoot, temporaryRoot) {
     const installRoot = join(temporaryRoot, "install");
     mkdirSync(packRoot, { recursive: true });
     mkdirSync(installRoot, { recursive: true });
-    writeJson(join(installRoot, "package.json"), { name: "fixture-consumer", version: "1.0.0", private: true });
+    writeJson(join(installRoot, "package.json"), {
+        name: "fixture-consumer",
+        version: "1.0.0",
+        private: true,
+    });
     let packed;
     try {
-        packed = JSON.parse(execFileSync("npm", ["pack", "--json", "--pack-destination", packRoot], {
-            cwd: packageRoot,
-            encoding: "utf8",
-            env: { ...process.env, npm_config_ignore_scripts: "true" },
-        }));
+        packed = JSON.parse(
+            execFileSync(
+                "npm",
+                ["pack", "--json", "--pack-destination", packRoot],
+                {
+                    cwd: packageRoot,
+                    encoding: "utf8",
+                    env: { ...process.env, npm_config_ignore_scripts: "true" },
+                },
+            ),
+        );
     } catch (error) {
-        throw new Error("Unable to pack the passive npm fixture", { cause: error });
+        throw new Error("Unable to pack the passive npm fixture", {
+            cause: error,
+        });
     }
     const tarball = join(packRoot, packed[0].filename);
-    execFileSync("npm", ["install", tarball, "--ignore-scripts", "--no-audit", "--no-fund"], {
-        cwd: installRoot,
-        stdio: "pipe",
-    });
-    const installedSkill = join(installRoot, "node_modules/@cratis/ai/skills/cratis-example/SKILL.md");
-    if (!lstatSync(installedSkill).isFile()) throw new Error("Installed npm fixture skill is missing");
-    execFileSync("npm", ["uninstall", "@cratis/ai", "--ignore-scripts", "--no-audit", "--no-fund"], {
-        cwd: installRoot,
-        stdio: "pipe",
-    });
+    execFileSync(
+        "npm",
+        ["install", tarball, "--ignore-scripts", "--no-audit", "--no-fund"],
+        {
+            cwd: installRoot,
+            stdio: "pipe",
+        },
+    );
+    const installedSkill = join(
+        installRoot,
+        "node_modules/@cratis/ai/skills/cratis-example/SKILL.md",
+    );
+    if (!lstatSync(installedSkill).isFile())
+        throw new Error("Installed npm fixture skill is missing");
+    execFileSync(
+        "npm",
+        [
+            "uninstall",
+            "@cratis/ai",
+            "--ignore-scripts",
+            "--no-audit",
+            "--no-fund",
+        ],
+        {
+            cwd: installRoot,
+            stdio: "pipe",
+        },
+    );
     if (existsSync(join(installRoot, "node_modules/@cratis/ai")))
         throw new Error("npm fixture uninstall left package content");
     return { tarball, installedSkill: "skills/cratis-example/SKILL.md" };
@@ -417,14 +535,22 @@ export function smokeClaudeDistributionFixture(
     const marketplaceRoot = join(outputRoot, "claude");
     const pluginRoot = join(marketplaceRoot, "plugins/cratis");
     const environment = { ...process.env, HOME: temporaryHome };
-    execFileSync(claudeCommand, ["plugin", "validate", pluginRoot, "--strict"], {
-        env: environment,
-        stdio: "pipe",
-    });
-    execFileSync(claudeCommand, ["plugin", "marketplace", "add", marketplaceRoot], {
-        env: environment,
-        stdio: "pipe",
-    });
+    execFileSync(
+        claudeCommand,
+        ["plugin", "validate", pluginRoot, "--strict"],
+        {
+            env: environment,
+            stdio: "pipe",
+        },
+    );
+    execFileSync(
+        claudeCommand,
+        ["plugin", "marketplace", "add", marketplaceRoot],
+        {
+            env: environment,
+            stdio: "pipe",
+        },
+    );
     execFileSync(claudeCommand, ["plugin", "install", "cratis@cratis"], {
         env: environment,
         stdio: "pipe",
@@ -453,10 +579,14 @@ export function smokeCopilotDistributionFixture(
 ) {
     const marketplaceRoot = join(outputRoot, "copilot");
     const environment = { ...process.env, HOME: temporaryHome };
-    execFileSync(copilotCommand, ["plugin", "marketplace", "add", marketplaceRoot], {
-        env: environment,
-        stdio: "pipe",
-    });
+    execFileSync(
+        copilotCommand,
+        ["plugin", "marketplace", "add", marketplaceRoot],
+        {
+            env: environment,
+            stdio: "pipe",
+        },
+    );
     execFileSync(copilotCommand, ["plugin", "install", "cratis@cratis"], {
         env: environment,
         stdio: "pipe",
@@ -471,10 +601,14 @@ export function smokeCopilotDistributionFixture(
         env: environment,
         stdio: "pipe",
     });
-    execFileSync(copilotCommand, ["plugin", "marketplace", "remove", "cratis"], {
-        env: environment,
-        stdio: "pipe",
-    });
+    execFileSync(
+        copilotCommand,
+        ["plugin", "marketplace", "remove", "cratis"],
+        {
+            env: environment,
+            stdio: "pipe",
+        },
+    );
     return { installed: true, removed: true };
 }
 
@@ -485,14 +619,22 @@ export function smokeCodexDistributionFixture(
 ) {
     const marketplaceRoot = join(outputRoot, "codex");
     const environment = { ...process.env, HOME: temporaryHome };
-    execFileSync(codexCommand, ["plugin", "marketplace", "add", marketplaceRoot], {
-        env: environment,
-        stdio: "pipe",
-    });
-    const listed = execFileSync(codexCommand, ["plugin", "marketplace", "list"], {
-        env: environment,
-        encoding: "utf8",
-    });
+    execFileSync(
+        codexCommand,
+        ["plugin", "marketplace", "add", marketplaceRoot],
+        {
+            env: environment,
+            stdio: "pipe",
+        },
+    );
+    const listed = execFileSync(
+        codexCommand,
+        ["plugin", "marketplace", "list"],
+        {
+            env: environment,
+            encoding: "utf8",
+        },
+    );
     if (!listed.includes("cratis"))
         throw new Error("Codex fixture marketplace was not observable");
     execFileSync(codexCommand, ["plugin", "marketplace", "remove", "cratis"], {
@@ -514,10 +656,14 @@ export function smokeGeminiDistributionFixture(
         HOME: temporaryHome,
         GEMINI_API_KEY: process.env.GEMINI_API_KEY ?? "fixture-not-used",
     };
-    execFileSync(geminiCommand, ["extensions", "link", extensionRoot, "--consent"], {
-        env: environment,
-        stdio: "pipe",
-    });
+    execFileSync(
+        geminiCommand,
+        ["extensions", "link", extensionRoot, "--consent"],
+        {
+            env: environment,
+            stdio: "pipe",
+        },
+    );
     const installedRoot = join(temporaryHome, ".gemini/extensions/cratis");
     if (!existsSync(installedRoot))
         throw new Error("Gemini fixture extension was not observable");
@@ -533,12 +679,16 @@ export function smokeGeminiDistributionFixture(
 function main() {
     const outputRoot = process.argv[2];
     if (!outputRoot) {
-        process.stderr.write("Usage: node tooling/generate-distribution-fixture.mjs <empty-output-path>\n");
+        process.stderr.write(
+            "Usage: node tooling/generate-distribution-fixture.mjs <empty-output-path>\n",
+        );
         process.exitCode = 1;
         return;
     }
     const manifest = generateDistributionFixture({ outputRoot });
-    process.stdout.write(`Generated fixture-only distribution: ${manifest.files.length} files across ${manifest.generatedTargets.length} targets.\n`);
+    process.stdout.write(
+        `Generated fixture-only distribution: ${manifest.files.length} files across ${manifest.generatedTargets.length} targets.\n`,
+    );
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/tooling/generate-repository-inventory.mjs
+++ b/tooling/generate-repository-inventory.mjs
@@ -32,9 +32,7 @@ function gitPaths(args) {
 
 function pathDigest(paths) {
     return createHash("sha256")
-        .update(
-            `${sortedOrdinal(paths).join("\n")}\n`,
-        )
+        .update(`${sortedOrdinal(paths).join("\n")}\n`)
         .digest("hex");
 }
 
@@ -79,9 +77,7 @@ function changesSinceBase(baseRevision) {
         if (!path) throw new Error("Git returned an incomplete change record");
         changes.push({ path, status });
     }
-    return changes.sort((left, right) =>
-        compareOrdinal(left.path, right.path),
-    );
+    return changes.sort((left, right) => compareOrdinal(left.path, right.path));
 }
 
 const excludedRuntimePrefixes = [".pi/delegate/", ".pi/fusion/", ".pi/tasks/"];
@@ -447,16 +443,10 @@ const definitions = [
         runtimeEligibility: "repository-only",
         generatedStatus: "source",
         adapterStatus: "none",
-        dependencies: [
-            "tooling/validate-catalogs.mjs",
-            "tooling/specs/**",
-        ],
+        dependencies: ["tooling/validate-catalogs.mjs", "tooling/specs/**"],
         risk: "high",
         migrationState: "retain",
-        evidenceIds: [
-            "repo-main-b795d53",
-            "option-a-plus-authority",
-        ],
+        evidenceIds: ["repo-main-b795d53", "option-a-plus-authority"],
     },
     {
         id: "repository-github-metadata-and-cleanup",
@@ -668,10 +658,7 @@ const definitions = [
         ],
         risk: "medium",
         migrationState: "retain",
-        evidenceIds: [
-            "ecosystem-use-cases",
-            "third-party-skills-evaluation",
-        ],
+        evidenceIds: ["ecosystem-use-cases", "third-party-skills-evaluation"],
     },
     {
         id: "code-review-pilot-source",
@@ -854,10 +841,7 @@ const definitions = [
         ],
         risk: "high",
         migrationState: "retain",
-        evidenceIds: [
-            "ecosystem-use-cases",
-            "third-party-skills-evaluation",
-        ],
+        evidenceIds: ["ecosystem-use-cases", "third-party-skills-evaluation"],
     },
     {
         id: "catalog-v2-generated-surfaces",

--- a/tooling/simulate-distribution-rollout.mjs
+++ b/tooling/simulate-distribution-rollout.mjs
@@ -19,7 +19,9 @@ import {
     validateDistributionFixture,
 } from "./generate-distribution-fixture.mjs";
 
-const defaultRepositoryRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const defaultRepositoryRoot = resolve(
+    fileURLToPath(new URL("..", import.meta.url)),
+);
 
 function sha256(content) {
     return createHash("sha256").update(content).digest("hex");
@@ -116,7 +118,7 @@ export function recordFixtureCanary(
     if (
         !Array.isArray(checks) ||
         checks.length === 0 ||
-        checks.some(check => typeof check !== "string" || check.length === 0)
+        checks.some((check) => typeof check !== "string" || check.length === 0)
     ) {
         throw new Error("Canary checks must be nonempty strings");
     }
@@ -150,7 +152,9 @@ export function promoteFixtureStable(rolloutRoot, releaseId) {
     if (state.emergencyDisabled)
         throw new Error("Fixture rollout is emergency disabled");
     if (state.canaryReleaseId !== releaseId)
-        throw new Error("Only the active canary can enter fixture stable state");
+        throw new Error(
+            "Only the active canary can enter fixture stable state",
+        );
     const evidence = readJson(
         join(rolloutRoot, "canary-evidence", `${releaseId}.json`),
     );
@@ -188,8 +192,7 @@ export function simulateDistributionCanaryRollback({
     repositoryRoot = defaultRepositoryRoot,
     simulationRoot,
 } = {}) {
-    if (!simulationRoot)
-        throw new Error("simulationRoot is required");
+    if (!simulationRoot) throw new Error("simulationRoot is required");
     if (existsSync(simulationRoot))
         throw new Error(`Simulation root must not exist: ${simulationRoot}`);
     mkdirSync(simulationRoot, { recursive: false });

--- a/tooling/specs/distribution-fixture.spec.mjs
+++ b/tooling/specs/distribution-fixture.spec.mjs
@@ -26,7 +26,10 @@ import {
     validateDistributionFixture,
 } from "../generate-distribution-fixture.mjs";
 
-const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const repositoryRoot = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    "../..",
+);
 function commandAvailable(command) {
     try {
         execFileSync(command, ["--version"], { stdio: "pipe" });
@@ -69,8 +72,8 @@ test("distribution requirements and artifact matrix stay authority bounded", () 
         ),
     );
     const verified = requirements.requirements
-        .filter(item => item.status.startsWith("VERIFIED"))
-        .map(item => item.id);
+        .filter((item) => item.status.startsWith("VERIFIED"))
+        .map((item) => item.id);
     assert.deepEqual(verified, [
         "agent-skills-open-standard",
         "claude-code-marketplace",
@@ -85,8 +88,11 @@ test("distribution requirements and artifact matrix stay authority bounded", () 
     ]);
     assert.deepEqual(
         requirements.requirements
-            .filter(item => item.status === "BLOCKED_NO_AUTHORITATIVE_REQUIREMENTS")
-            .map(item => item.id),
+            .filter(
+                (item) =>
+                    item.status === "BLOCKED_NO_AUTHORITATIVE_REQUIREMENTS",
+            )
+            .map((item) => item.id),
         [],
     );
     assert.equal(matrix.state, "FIXTURE_ONLY_LOCAL_STAGING");
@@ -96,20 +102,30 @@ test("distribution requirements and artifact matrix stay authority bounded", () 
         matrix.repository.status,
         "BLOCKED_ON_BOT_REPOSITORY_AND_CREDENTIAL_AUTHORITY",
     );
-    const requirementIds = new Set(requirements.requirements.map(item => item.id));
-    assert(matrix.targets.every(target => requirementIds.has(target.requirementId)));
+    const requirementIds = new Set(
+        requirements.requirements.map((item) => item.id),
+    );
+    assert(
+        matrix.targets.every((target) =>
+            requirementIds.has(target.requirementId),
+        ),
+    );
     assert(
         matrix.targets
-            .filter(target => target.state === "BLOCKED")
-            .every(target => target.outputRoot === null),
+            .filter((target) => target.state === "BLOCKED")
+            .every((target) => target.outputRoot === null),
     );
     assert.equal(localEvidence.publicationEligible, false);
     assert.equal(localEvidence.promotionEligible, false);
-    assert(localEvidence.results.every(result => result.status.startsWith("PASS")));
+    assert(
+        localEvidence.results.every((result) =>
+            result.status.startsWith("PASS"),
+        ),
+    );
 });
 
 test("distribution fixture generation is deterministic across native adapters", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const firstRoot = join(root, "first");
         const secondRoot = join(root, "second");
         const first = generateDistributionFixture({
@@ -143,7 +159,7 @@ test("distribution fixture generation is deterministic across native adapters", 
 });
 
 test("generated marketplace manifests remain passive and idiomatic", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const stage = join(root, "stage");
         generateDistributionFixture({ repositoryRoot, outputRoot: stage });
         const claude = readJson(
@@ -201,7 +217,7 @@ test("generated marketplace manifests remain passive and idiomatic", () => {
 });
 
 test("distribution fixture detects payload and checksum tampering", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const stage = join(root, "stage");
         generateDistributionFixture({ repositoryRoot, outputRoot: stage });
         const path = join(
@@ -217,7 +233,7 @@ test("distribution fixture detects payload and checksum tampering", () => {
 });
 
 test("passive npm fixture packs installs and uninstalls without scripts", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const stage = join(root, "stage");
         const smokeRoot = join(root, "smoke");
         generateDistributionFixture({ repositoryRoot, outputRoot: stage });
@@ -228,97 +244,92 @@ test("passive npm fixture packs installs and uninstalls without scripts", () => 
     });
 });
 
-test(
-    "passive Pi fixture installs lists and removes in an isolated home",
-    { skip: !piAvailable },
-    () => {
-        withTemporaryDirectory(root => {
-            const stage = join(root, "stage");
-            const isolatedHome = join(root, "home");
-            generateDistributionFixture({ repositoryRoot, outputRoot: stage });
-            mkdirSync(isolatedHome);
-            assert.deepEqual(
-                smokePiDistributionFixture(stage, isolatedHome),
-                { installed: true, removed: true },
-            );
+test("passive Pi fixture installs lists and removes in an isolated home", {
+    skip: !piAvailable,
+}, () => {
+    withTemporaryDirectory((root) => {
+        const stage = join(root, "stage");
+        const isolatedHome = join(root, "home");
+        generateDistributionFixture({ repositoryRoot, outputRoot: stage });
+        mkdirSync(isolatedHome);
+        assert.deepEqual(smokePiDistributionFixture(stage, isolatedHome), {
+            installed: true,
+            removed: true,
         });
-    },
-);
+    });
+});
 
-test(
-    "Claude fixture validates installs and removes in an isolated home",
-    { skip: !claudeAvailable },
-    () => {
-        withTemporaryDirectory(root => {
-            const stage = join(root, "stage");
-            const isolatedHome = join(root, "home");
-            generateDistributionFixture({ repositoryRoot, outputRoot: stage });
-            mkdirSync(isolatedHome);
-            assert.deepEqual(
-                smokeClaudeDistributionFixture(stage, isolatedHome),
-                { validated: true, installed: true, removed: true },
-            );
+test("Claude fixture validates installs and removes in an isolated home", {
+    skip: !claudeAvailable,
+}, () => {
+    withTemporaryDirectory((root) => {
+        const stage = join(root, "stage");
+        const isolatedHome = join(root, "home");
+        generateDistributionFixture({ repositoryRoot, outputRoot: stage });
+        mkdirSync(isolatedHome);
+        assert.deepEqual(smokeClaudeDistributionFixture(stage, isolatedHome), {
+            validated: true,
+            installed: true,
+            removed: true,
         });
-    },
-);
+    });
+});
 
-test(
-    "Copilot fixture installs and removes in an isolated home",
-    { skip: !copilotAvailable },
-    () => {
-        withTemporaryDirectory(root => {
-            const stage = join(root, "stage");
-            const isolatedHome = join(root, "home");
-            generateDistributionFixture({ repositoryRoot, outputRoot: stage });
-            mkdirSync(isolatedHome);
-            assert.deepEqual(
-                smokeCopilotDistributionFixture(stage, isolatedHome),
-                { installed: true, removed: true },
-            );
+test("Copilot fixture installs and removes in an isolated home", {
+    skip: !copilotAvailable,
+}, () => {
+    withTemporaryDirectory((root) => {
+        const stage = join(root, "stage");
+        const isolatedHome = join(root, "home");
+        generateDistributionFixture({ repositoryRoot, outputRoot: stage });
+        mkdirSync(isolatedHome);
+        assert.deepEqual(smokeCopilotDistributionFixture(stage, isolatedHome), {
+            installed: true,
+            removed: true,
         });
-    },
-);
+    });
+});
 
-test(
-    "Codex fixture marketplace adds and removes in an isolated home",
-    { skip: !codexAvailable },
-    () => {
-        withTemporaryDirectory(root => {
-            const stage = join(root, "stage");
-            const isolatedHome = join(root, "home");
-            generateDistributionFixture({ repositoryRoot, outputRoot: stage });
-            mkdirSync(isolatedHome);
-            assert.deepEqual(
-                smokeCodexDistributionFixture(stage, isolatedHome),
-                { added: true, removed: true },
-            );
+test("Codex fixture marketplace adds and removes in an isolated home", {
+    skip: !codexAvailable,
+}, () => {
+    withTemporaryDirectory((root) => {
+        const stage = join(root, "stage");
+        const isolatedHome = join(root, "home");
+        generateDistributionFixture({ repositoryRoot, outputRoot: stage });
+        mkdirSync(isolatedHome);
+        assert.deepEqual(smokeCodexDistributionFixture(stage, isolatedHome), {
+            added: true,
+            removed: true,
         });
-    },
-);
+    });
+});
 
-test(
-    "Gemini fixture links and removes in an isolated home",
-    { skip: !geminiAvailable },
-    () => {
-        withTemporaryDirectory(root => {
-            const stage = join(root, "stage");
-            const isolatedHome = join(root, "home");
-            generateDistributionFixture({ repositoryRoot, outputRoot: stage });
-            mkdirSync(isolatedHome);
-            assert.deepEqual(
-                smokeGeminiDistributionFixture(stage, isolatedHome),
-                { linked: true, removed: true },
-            );
+test("Gemini fixture links and removes in an isolated home", {
+    skip: !geminiAvailable,
+}, () => {
+    withTemporaryDirectory((root) => {
+        const stage = join(root, "stage");
+        const isolatedHome = join(root, "home");
+        generateDistributionFixture({ repositoryRoot, outputRoot: stage });
+        mkdirSync(isolatedHome);
+        assert.deepEqual(smokeGeminiDistributionFixture(stage, isolatedHome), {
+            linked: true,
+            removed: true,
         });
-    },
-);
+    });
+});
 
 test("distribution generator refuses an existing destination", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const stage = join(root, "stage");
         mkdirSync(stage);
         assert.throws(
-            () => generateDistributionFixture({ repositoryRoot, outputRoot: stage }),
+            () =>
+                generateDistributionFixture({
+                    repositoryRoot,
+                    outputRoot: stage,
+                }),
             /must not exist/,
         );
     });

--- a/tooling/specs/distribution-rollout.spec.mjs
+++ b/tooling/specs/distribution-rollout.spec.mjs
@@ -2,12 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import assert from "node:assert/strict";
-import {
-    mkdtempSync,
-    readFileSync,
-    rmSync,
-    writeFileSync,
-} from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { test } from "node:test";
@@ -24,7 +19,10 @@ import {
 } from "../simulate-distribution-rollout.mjs";
 import { stageDistributionCandidate } from "../stage-distribution-candidate.mjs";
 
-const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const repositoryRoot = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    "../..",
+);
 
 function withTemporaryDirectory(callback) {
     const root = mkdtempSync(join(tmpdir(), "cratis-rollout-"));
@@ -48,11 +46,15 @@ test("rollout policy keeps production promotion and retirement blocked", () => {
     assert.equal(policy.promotion.stableEnabled, false);
     assert.equal(policy.promotion.publicationEnabled, false);
     assert.equal(policy.legacyRetirement.enabled, false);
-    assert(policy.legacyRetirement.blockedOn.includes("NO_PRODUCTION_ROLLBACK_EVIDENCE"));
+    assert(
+        policy.legacyRetirement.blockedOn.includes(
+            "NO_PRODUCTION_ROLLBACK_EVIDENCE",
+        ),
+    );
 });
 
 test("candidate staging allows only the authorized sanitized fixture", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const stage = join(root, "stage");
         const recordPath = join(root, "candidate.json");
         const record = stageDistributionCandidate({
@@ -79,7 +81,7 @@ test("candidate staging allows only the authorized sanitized fixture", () => {
 });
 
 test("fixture rollout canaries promotes rolls back and emergency disables", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const result = simulateDistributionCanaryRollback({
             repositoryRoot,
             simulationRoot: join(root, "simulation"),
@@ -92,7 +94,7 @@ test("fixture rollout canaries promotes rolls back and emergency disables", () =
         );
         assert.equal(result.finalState.emergencyDisabled, true);
         assert.deepEqual(
-            result.finalState.history.map(item => item.operation),
+            result.finalState.history.map((item) => item.operation),
             [
                 "STAGE_RELEASE",
                 "STAGE_RELEASE",
@@ -108,7 +110,7 @@ test("fixture rollout canaries promotes rolls back and emergency disables", () =
 });
 
 test("failed canary cannot enter fixture stable state", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const rollout = join(root, "rollout");
         const candidate = join(root, "candidate");
         initializeDistributionRollout(rollout);
@@ -130,7 +132,7 @@ test("failed canary cannot enter fixture stable state", () => {
 });
 
 test("emergency disable blocks fixture promotion", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const rollout = join(root, "rollout");
         const candidate = join(root, "candidate");
         initializeDistributionRollout(rollout);
@@ -149,7 +151,7 @@ test("emergency disable blocks fixture promotion", () => {
 });
 
 test("rollback requires a known noncurrent fixture release", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const rollout = join(root, "rollout");
         initializeDistributionRollout(rollout);
         assert.throws(
@@ -160,7 +162,7 @@ test("rollback requires a known noncurrent fixture release", () => {
 });
 
 test("tampered candidate cannot be staged as a fixture release", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const rollout = join(root, "rollout");
         const candidate = join(root, "candidate");
         initializeDistributionRollout(rollout);
@@ -177,7 +179,7 @@ test("tampered candidate cannot be staged as a fixture release", () => {
 });
 
 test("duplicate fixture release staging fails without overwriting", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const rollout = join(root, "rollout");
         const candidate = join(root, "candidate");
         initializeDistributionRollout(rollout);

--- a/tooling/stage-distribution-candidate.mjs
+++ b/tooling/stage-distribution-candidate.mjs
@@ -11,7 +11,9 @@ import {
     validateDistributionConfiguration,
 } from "./generate-distribution-fixture.mjs";
 
-const defaultRepositoryRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const defaultRepositoryRoot = resolve(
+    fileURLToPath(new URL("..", import.meta.url)),
+);
 const fixtureArtifactId = "sanitized-public-materializer-fixture";
 
 function sha256(content) {
@@ -36,12 +38,17 @@ export function stageDistributionCandidate({
     version = "0.0.0-fixture",
 } = {}) {
     if (!artifactId || !outputRoot || !candidateRecordPath)
-        throw new Error("artifactId, outputRoot, and candidateRecordPath are required");
+        throw new Error(
+            "artifactId, outputRoot, and candidateRecordPath are required",
+        );
     if (existsSync(outputRoot))
         throw new Error(`Candidate output must not exist: ${outputRoot}`);
     if (existsSync(candidateRecordPath))
-        throw new Error(`Candidate record must not exist: ${candidateRecordPath}`);
-    const configurationErrors = validateDistributionConfiguration(repositoryRoot);
+        throw new Error(
+            `Candidate record must not exist: ${candidateRecordPath}`,
+        );
+    const configurationErrors =
+        validateDistributionConfiguration(repositoryRoot);
     if (configurationErrors.length > 0)
         throw new Error(configurationErrors.join("; "));
     const artifactCatalog = readJson(
@@ -51,9 +58,10 @@ export function stageDistributionCandidate({
         join(repositoryRoot, "distribution/rollout-policy.json"),
     );
     const artifact = artifactCatalog.artifacts?.find(
-        candidate => candidate.id === artifactId,
+        (candidate) => candidate.id === artifactId,
     );
-    if (!artifact) throw new Error(`Unknown distribution artifact: ${artifactId}`);
+    if (!artifact)
+        throw new Error(`Unknown distribution artifact: ${artifactId}`);
     if (
         artifact.materializationAllowed !== true ||
         artifact.runtimeEligible !== false ||


### PR DESCRIPTION
# Summary

Preserves formatter output produced after the rollout merge and refreshes its generated inventory digest. Distribution behavior is unchanged.

## Changed

- Apply repository formatting to the distribution generator, rollout tools, and focused specs (#126)
