### PR TITLE
Add generated repository simulation

### DIFF
--- a/.github/workflows/distribution-canary-rollback.yml
+++ b/.github/workflows/distribution-canary-rollback.yml
@@ -14,6 +14,7 @@ on:
         options:
           - verify-candidate
           - simulate-canary-rollback
+          - simulate-generated-repository
 
 permissions:
   contents: read
@@ -58,10 +59,21 @@ jobs:
           node tooling/simulate-distribution-rollout.mjs \
             "$RUNNER_TEMP/distribution-rollout"
 
+      - name: Simulate the bot-owned generated repository
+        if: inputs.operation == 'simulate-generated-repository'
+        run: |
+          set -euo pipefail
+          node tooling/bootstrap-generated-distribution-repository.mjs \
+            --output "$RUNNER_TEMP/generated-distribution-repository" \
+            --record "$RUNNER_TEMP/generated-distribution-repository.json"
+          test "$(git -C "$RUNNER_TEMP/generated-distribution-repository" rev-list --count HEAD)" = "1"
+          test -z "$(git -C "$RUNNER_TEMP/generated-distribution-repository" status --porcelain)"
+
       - name: Run distribution specifications
         run: |
           node --test tooling/specs/distribution-fixture.spec.mjs
           node --test tooling/specs/distribution-rollout.spec.mjs
+          node --test tooling/specs/generated-distribution-repository.spec.mjs
 
       - name: Confirm publication remains absent
         run: |

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
@@ -1295,3 +1295,52 @@ Actual bot writes, protected environments, package staging/publication, approved
 public targets, fleet canaries, rollback against consuming repositories, legacy
 retirement, and freeze lifting remain blocked on external repository/credential,
 source, target, and reviewer authority.
+
+## 35. Local generated distribution repository — 2026-08-22
+
+Fixture canary/rollback mechanics merged with green CI in Cratis/AI#141; the
+post-merge formatter output was preserved separately in green Cratis/AI#142.
+Hosted read-only simulation
+`https://github.com/Cratis/AI/actions/runs/32572002783` passed on merge commit
+`1bc237935c5cb202caf6c794e159160225e789b3`. AI#126 and Workflows#68 were
+updated, and both merged branches/worktrees were removed normally. This branch
+starts from formatter merge `0d4c0c860bab9795bd91deddbff9e7573247696d`.
+
+The next independent distribution work creates a real local Git repository
+projection without crossing the missing remote-authority boundary:
+
+- `distribution/generated-repository-contract.json` defines public repository
+  identity, bot-only writes, deterministic local simulation identity, protected
+  checks/environments, forbidden authoring content, and closed production gates;
+- `tooling/bootstrap-generated-distribution-repository.mjs` generates the
+  fixture tree into an empty directory, validates it before Git initialization,
+  creates one deterministic bot-simulation root commit on `main`, and verifies
+  exact tracked inventory, clean status, author identity, digests, and absence
+  of authoring/evaluation/tooling paths;
+- the same tool emits the current production materialization plan, which remains
+  `BLOCKED_NO_APPROVED_TARGETS` with zero approved targets and the planned public
+  artifact still materialization/runtime disabled;
+- focused specs prove deterministic commit/tree identity, tamper rejection,
+  human-follow-up-commit rejection, exact generated files, and fail-closed
+  existing destinations;
+- the read-only distribution workflow gains a generated-repository simulation
+  operation.
+
+Local evidence is recorded in
+`distribution/evidence/local-generated-repository-2026-08-22.json`: one
+bot-simulation root commit, 51 generated files, deterministic commit
+`4c0c11a68f8d75a72d86495f9ae3d253821fe36f`, and tree
+`6a189e044968cce21039eed6e767073ffa4020ab`.
+
+Fresh evidence is 7/7 focused generated-repository specs and 188/188 full
+repository specs. Workflow YAML, bootstrap/plan CLIs, catalog, stable inventory,
+syntax, strict JSON, LSP, structural, focused Markdown, and diff gates pass with
+only unchanged legacy advisories.
+
+Merge and run the generated-repository simulation on hosted CI. Then all
+deterministic local work available without real product-source and
+target approvals or remote bot/repository credentials is substantially
+complete. The next required action is external: create/protect
+`Cratis/AI.Distribution`, designate the bot identity, and configure protected
+canary/npm-stage environments. Publication, production promotion, fleet rollout,
+legacy retirement, and freeze lifting remain blocked.

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
@@ -553,4 +553,7 @@ Evidence and exact next actions are in
   gates for the fixture-only distribution.
 - [x] Add fixture-only candidate staging, canary evidence, stable-pin simulation,
   rollback, emergency disable, audit history, and a read-only manual workflow.
+- [x] Bootstrap deterministic local bot-authored generated Git repositories and
+  reject authoring content, tampering, human commits, and unapproved production
+  plans; remote repository creation remains externally blocked.
 - [ ] Keep publication and retirement disabled until explicit approvals pass.

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "e3836157dc3ac6b239b07f7cd9153dcf72065b6bf4dc4772c15bfe5b193dc1cf",
+  "indexDigest": "9b334539135d622c4b9b7ebe6bd03c20a65af02ba5a3d7496bb01592bc64dc74",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -271,7 +271,15 @@
       "status": "added"
     },
     {
+      "path": "distribution/evidence/local-generated-repository-2026-08-22.json",
+      "status": "added"
+    },
+    {
       "path": "distribution/generated-repository-authority-request.md",
+      "status": "added"
+    },
+    {
+      "path": "distribution/generated-repository-contract.json",
       "status": "added"
     },
     {
@@ -1223,6 +1231,10 @@
       "status": "added"
     },
     {
+      "path": "tooling/bootstrap-generated-distribution-repository.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/catalog-ordering.mjs",
       "status": "added"
     },
@@ -1376,6 +1388,10 @@
     },
     {
       "path": "tooling/specs/domain-expert-event-modeling-pilot.spec.mjs",
+      "status": "added"
+    },
+    {
+      "path": "tooling/specs/generated-distribution-repository.spec.mjs",
       "status": "added"
     },
     {
@@ -2618,8 +2634,8 @@
       "evidenceIds": [
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 6,
-      "expectedPathsDigest": "fadcc1dd51593bf2e9557c4ab06719adee4876441b0ce43d7038db68ca95d685"
+      "expectedPathCount": 8,
+      "expectedPathsDigest": "63829ad1ccb62e6e2c691ac5bc34adebc2a3870b568a0c22212725faa8bbf531"
     },
     {
       "excludePathPatterns": [],
@@ -2641,8 +2657,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 20,
-      "expectedPathsDigest": "67beb4ea95016f01915c3818e904e877592606b61819946673627d667d87a117"
+      "expectedPathCount": 21,
+      "expectedPathsDigest": "44bb0ac2c5fc21f5e51e1d1cd302686ec826d78e8826597e85943257250aacd8"
     },
     {
       "excludePathPatterns": [],
@@ -2665,8 +2681,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 13,
-      "expectedPathsDigest": "49857b600828a3be4340bf44b96e180feb5e13a23572efc384ed6aaeb1316b24"
+      "expectedPathCount": 14,
+      "expectedPathsDigest": "2048a1afb804cd99dd7cff263210fbe2e8c3599e0440159bc4671a45a3a04b50"
     },
     {
       "excludePathPatterns": [],

--- a/distribution/evidence/local-generated-repository-2026-08-22.json
+++ b/distribution/evidence/local-generated-repository-2026-08-22.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "observedAt": "2026-08-22",
+  "sourceCommit": null,
+  "sourceWorktreeBase": "0d4c0c860bab9795bd91deddbff9e7573247696d",
+  "state": "LOCAL_GENERATED_REPOSITORY_FIXTURE",
+  "repositoryName": "Cratis/AI.Distribution",
+  "remoteRepositoryStatus": "BLOCKED_ON_REMOTE_REPOSITORY_AND_BOT_CREDENTIAL",
+  "generatedCommit": "4c0c11a68f8d75a72d86495f9ae3d253821fe36f",
+  "generatedTree": "6a189e044968cce21039eed6e767073ffa4020ab",
+  "generatedFiles": 51,
+  "generatedBranch": "main",
+  "commitCount": 1,
+  "author": {
+    "name": "cratis-distribution-fixture-bot",
+    "email": "fixture-bot@invalid.example"
+  },
+  "checks": [
+    "deterministic commit and tree across independent repositories",
+    "one root commit",
+    "bot simulation author identity",
+    "clean worktree",
+    "manifest-only tracked inventory",
+    "no authoring tooling or evaluation content",
+    "tamper rejection",
+    "human follow-up commit rejection",
+    "production plan blocked with zero approved targets"
+  ],
+  "status": "PASS",
+  "limitations": [
+    "This is a local Git repository simulation, not the remote Cratis/AI.Distribution repository.",
+    "The fixture bot identity is deterministic test metadata, not a credential or organization account.",
+    "No branch protection, protected environment, GitHub App, npm trusted publisher, approved target, publication, production canary, fleet rollout, or legacy retirement is included."
+  ],
+  "publicationEligible": false,
+  "promotionEligible": false,
+  "legacyRetirementEligible": false
+}

--- a/distribution/generated-repository-contract.json
+++ b/distribution/generated-repository-contract.json
@@ -1,0 +1,54 @@
+{
+  "schemaVersion": "1.0.0",
+  "repository": {
+    "name": "Cratis/AI.Distribution",
+    "visibility": "PUBLIC",
+    "defaultBranch": "main",
+    "status": "BLOCKED_ON_REMOTE_REPOSITORY_AND_BOT_CREDENTIAL",
+    "manualAuthoringAllowed": false,
+    "botOnlyWrites": true
+  },
+  "localSimulation": {
+    "enabled": true,
+    "identity": {
+      "name": "cratis-distribution-fixture-bot",
+      "email": "fixture-bot@invalid.example"
+    },
+    "fixedCommitDate": "2000-01-01T00:00:00Z",
+    "commitMessage": "Generate fixture distribution"
+  },
+  "requiredChecks": [
+    "generated-inventory",
+    "canonical-byte-parity",
+    "native-manifests",
+    "checksums",
+    "fixture-provenance",
+    "pack-install-smoke-uninstall",
+    "canary-rollback-simulation"
+  ],
+  "protectedEnvironments": [
+    "distribution-canary",
+    "npm-stage"
+  ],
+  "forbiddenRepositoryContent": [
+    "authoring catalogs",
+    "evaluation cases",
+    "engineering rules",
+    "agents",
+    "hooks",
+    "prompts",
+    "tooling",
+    "credentials",
+    "private product sources"
+  ],
+  "productionMaterialization": {
+    "enabled": false,
+    "requiresApprovedTargets": true,
+    "requiresExactSourceCommit": true,
+    "requiresBotCredential": true,
+    "requiresProtectedRepository": true
+  },
+  "publicationEligible": false,
+  "promotionEligible": false,
+  "legacyRetirementEligible": false
+}

--- a/tooling/bootstrap-generated-distribution-repository.mjs
+++ b/tooling/bootstrap-generated-distribution-repository.mjs
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+    existsSync,
+    readFileSync,
+    writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+    generateDistributionFixture,
+    validateDistributionFixture,
+} from "./generate-distribution-fixture.mjs";
+
+const defaultRepositoryRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+
+function sha256(content) {
+    return createHash("sha256").update(content).digest("hex");
+}
+
+function readJson(path) {
+    try {
+        return JSON.parse(readFileSync(path, "utf8"));
+    } catch (error) {
+        throw new Error(`Unable to parse generated-repository input: ${path}`, {
+            cause: error,
+        });
+    }
+}
+
+function runGit(repositoryRoot, arguments_, options = {}) {
+    try {
+        return execFileSync("git", arguments_, {
+            cwd: repositoryRoot,
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "pipe"],
+            ...options,
+        }).trim();
+    } catch (error) {
+        throw new Error(`Generated repository git command failed: git ${arguments_.join(" ")}`, {
+            cause: error,
+        });
+    }
+}
+
+function trackedFiles(repositoryRoot) {
+    const output = execFileSync("git", ["ls-files", "-z"], {
+        cwd: repositoryRoot,
+    });
+    return output
+        .toString("utf8")
+        .split("\0")
+        .filter(Boolean)
+        .sort();
+}
+
+export function buildApprovedDistributionPlan(
+    repositoryRoot = defaultRepositoryRoot,
+) {
+    const targets = readJson(join(repositoryRoot, "catalog/v2/targets.json"));
+    const artifacts = readJson(join(repositoryRoot, "catalog/v2/artifacts.json"));
+    const approvedTargets = targets.targets
+        .filter(
+            target =>
+                target.includeInRuntime === true &&
+                target.approval?.state === "approved",
+        )
+        .map(target => target.id)
+        .sort();
+    const publicArtifact = artifacts.artifacts.find(
+        artifact => artifact.id === "planned-passive-public-release",
+    );
+    const ready =
+        approvedTargets.length > 0 &&
+        publicArtifact?.materializationAllowed === true &&
+        publicArtifact?.runtimeEligible === true;
+    return {
+        schemaVersion: "1.0.0",
+        state: ready
+            ? "READY_FOR_BOT_MATERIALIZATION"
+            : "BLOCKED_NO_APPROVED_TARGETS",
+        sourceCommit: runGit(repositoryRoot, ["rev-parse", "HEAD"]),
+        artifactId: publicArtifact?.id ?? null,
+        approvedTargets,
+        materializationAllowed:
+            publicArtifact?.materializationAllowed === true,
+        runtimeEligible: publicArtifact?.runtimeEligible === true,
+        publicationEligible: false,
+        promotionEligible: false,
+    };
+}
+
+export function verifyGeneratedDistributionRepository(
+    generatedRepositoryRoot,
+    contractPath = join(
+        defaultRepositoryRoot,
+        "distribution/generated-repository-contract.json",
+    ),
+) {
+    const root = resolve(generatedRepositoryRoot);
+    const contract = readJson(contractPath);
+    const branch = runGit(root, ["branch", "--show-current"]);
+    if (branch !== contract.repository.defaultBranch)
+        throw new Error(`Generated repository branch changed: ${branch}`);
+    if (runGit(root, ["status", "--porcelain"]) !== "")
+        throw new Error("Generated repository worktree is not clean");
+    if (runGit(root, ["rev-list", "--count", "HEAD"]) !== "1")
+        throw new Error("Generated fixture repository must have one root commit");
+    const identity = runGit(root, [
+        "show",
+        "-s",
+        "--format=%an%x00%ae%x00%aI%x00%cI%x00%s",
+        "HEAD",
+    ]).split("\0");
+    const expectedIdentity = contract.localSimulation.identity;
+    if (
+        identity[0] !== expectedIdentity.name ||
+        identity[1] !== expectedIdentity.email ||
+        identity[2] !== contract.localSimulation.fixedCommitDate ||
+        identity[3] !== contract.localSimulation.fixedCommitDate ||
+        identity[4] !== contract.localSimulation.commitMessage
+    ) {
+        throw new Error("Generated repository commit identity changed");
+    }
+    const manifest = readJson(join(root, "distribution-manifest.json"));
+    const expectedFiles = [
+        ...manifest.files.map(file => file.path),
+        "distribution-manifest.json",
+    ].sort();
+    if (JSON.stringify(trackedFiles(root)) !== JSON.stringify(expectedFiles))
+        throw new Error("Generated repository tracked inventory changed");
+    for (const file of manifest.files) {
+        const content = readFileSync(join(root, file.path));
+        if (content.length !== file.size || sha256(content) !== file.sha256)
+            throw new Error(`Generated repository digest mismatch: ${file.path}`);
+    }
+    const forbiddenSegments = new Set([
+        "agents",
+        "evals",
+        "hooks",
+        "prompts",
+        "tooling",
+    ]);
+    if (
+        expectedFiles.some(path =>
+            path
+                .split("/")
+                .some(segment => forbiddenSegments.has(segment)),
+        )
+    ) {
+        throw new Error("Generated repository contains authoring content");
+    }
+    return {
+        commit: runGit(root, ["rev-parse", "HEAD"]),
+        tree: runGit(root, ["rev-parse", "HEAD^{tree}"]),
+        files: expectedFiles,
+        author: expectedIdentity,
+        fixtureOnly: true,
+        publicationEligible: false,
+        promotionEligible: false,
+    };
+}
+
+export function bootstrapGeneratedDistributionRepository({
+    repositoryRoot = defaultRepositoryRoot,
+    generatedRepositoryRoot,
+    recordPath,
+    version = "0.0.0-fixture",
+} = {}) {
+    if (!generatedRepositoryRoot || !recordPath)
+        throw new Error("generatedRepositoryRoot and recordPath are required");
+    if (existsSync(generatedRepositoryRoot))
+        throw new Error(
+            `Generated repository destination must not exist: ${generatedRepositoryRoot}`,
+        );
+    if (existsSync(recordPath))
+        throw new Error(`Generated repository record must not exist: ${recordPath}`);
+    const contractPath = join(
+        repositoryRoot,
+        "distribution/generated-repository-contract.json",
+    );
+    const contract = readJson(contractPath);
+    if (
+        contract.repository.status !==
+            "BLOCKED_ON_REMOTE_REPOSITORY_AND_BOT_CREDENTIAL" ||
+        contract.repository.manualAuthoringAllowed !== false ||
+        contract.productionMaterialization.enabled !== false
+    ) {
+        throw new Error("Generated repository authority gate changed");
+    }
+    generateDistributionFixture({
+        repositoryRoot,
+        outputRoot: generatedRepositoryRoot,
+        version,
+    });
+    validateDistributionFixture(generatedRepositoryRoot);
+    runGit(generatedRepositoryRoot, [
+        "init",
+        "--initial-branch",
+        contract.repository.defaultBranch,
+    ]);
+    runGit(generatedRepositoryRoot, [
+        "config",
+        "user.name",
+        contract.localSimulation.identity.name,
+    ]);
+    runGit(generatedRepositoryRoot, [
+        "config",
+        "user.email",
+        contract.localSimulation.identity.email,
+    ]);
+    const manifest = readJson(
+        join(generatedRepositoryRoot, "distribution-manifest.json"),
+    );
+    const files = [
+        ...manifest.files.map(file => file.path),
+        "distribution-manifest.json",
+    ];
+    runGit(generatedRepositoryRoot, ["add", "--", ...files]);
+    const environment = {
+        ...process.env,
+        GIT_AUTHOR_DATE: contract.localSimulation.fixedCommitDate,
+        GIT_COMMITTER_DATE: contract.localSimulation.fixedCommitDate,
+    };
+    runGit(
+        generatedRepositoryRoot,
+        ["commit", "--message", contract.localSimulation.commitMessage],
+        { env: environment },
+    );
+    const verification = verifyGeneratedDistributionRepository(
+        generatedRepositoryRoot,
+        contractPath,
+    );
+    const record = {
+        schemaVersion: "1.0.0",
+        state: "LOCAL_GENERATED_REPOSITORY_FIXTURE",
+        repositoryName: contract.repository.name,
+        remoteRepositoryStatus: contract.repository.status,
+        sourceCommit: runGit(repositoryRoot, ["rev-parse", "HEAD"]),
+        generatedCommit: verification.commit,
+        generatedTree: verification.tree,
+        generatedFiles: verification.files.length,
+        author: verification.author,
+        fixtureOnly: true,
+        publicationEligible: false,
+        promotionEligible: false,
+    };
+    writeFileSync(recordPath, `${JSON.stringify(record, null, 2)}\n`, {
+        flag: "wx",
+    });
+    return record;
+}
+
+function parseArguments(arguments_) {
+    const values = new Map();
+    for (let index = 0; index < arguments_.length; index += 2) {
+        const name = arguments_[index];
+        const value = arguments_[index + 1];
+        if (!name?.startsWith("--") || value === undefined)
+            throw new Error("Arguments must be --name value pairs");
+        values.set(name.slice(2), value);
+    }
+    return values;
+}
+
+function main() {
+    try {
+        const arguments_ = parseArguments(process.argv.slice(2));
+        if (arguments_.has("plan")) {
+            process.stdout.write(
+                `${JSON.stringify(buildApprovedDistributionPlan(), null, 2)}\n`,
+            );
+            return;
+        }
+        const record = bootstrapGeneratedDistributionRepository({
+            generatedRepositoryRoot: arguments_.get("output"),
+            recordPath: arguments_.get("record"),
+            version: arguments_.get("version") ?? "0.0.0-fixture",
+        });
+        process.stdout.write(`${JSON.stringify(record, null, 2)}\n`);
+    } catch (error) {
+        process.stderr.write(
+            `${error instanceof Error ? error.message : "Generated repository bootstrap failed"}\n`,
+        );
+        process.exitCode = 1;
+    }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/tooling/specs/generated-distribution-repository.spec.mjs
+++ b/tooling/specs/generated-distribution-repository.spec.mjs
@@ -1,0 +1,186 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+    mkdtempSync,
+    mkdirSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+    bootstrapGeneratedDistributionRepository,
+    buildApprovedDistributionPlan,
+    verifyGeneratedDistributionRepository,
+} from "../bootstrap-generated-distribution-repository.mjs";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const contractPath = join(
+    repositoryRoot,
+    "distribution/generated-repository-contract.json",
+);
+
+function withTemporaryDirectory(callback) {
+    const root = mkdtempSync(join(tmpdir(), "cratis-generated-repository-"));
+    try {
+        return callback(root);
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+}
+
+function bootstrap(root, name = "generated") {
+    return bootstrapGeneratedDistributionRepository({
+        repositoryRoot,
+        generatedRepositoryRoot: join(root, name),
+        recordPath: join(root, `${name}.json`),
+    });
+}
+
+test("generated repository contract keeps remote authority and production blocked", () => {
+    const contract = JSON.parse(readFileSync(contractPath, "utf8"));
+    assert.equal(contract.repository.name, "Cratis/AI.Distribution");
+    assert.equal(
+        contract.repository.status,
+        "BLOCKED_ON_REMOTE_REPOSITORY_AND_BOT_CREDENTIAL",
+    );
+    assert.equal(contract.repository.manualAuthoringAllowed, false);
+    assert.equal(contract.repository.botOnlyWrites, true);
+    assert.equal(contract.productionMaterialization.enabled, false);
+    assert.equal(contract.publicationEligible, false);
+    assert.equal(contract.promotionEligible, false);
+    assert.equal(contract.legacyRetirementEligible, false);
+});
+
+test("production distribution plan remains blocked without approved targets", () => {
+    const plan = buildApprovedDistributionPlan(repositoryRoot);
+    assert.equal(plan.state, "BLOCKED_NO_APPROVED_TARGETS");
+    assert.deepEqual(plan.approvedTargets, []);
+    assert.equal(plan.materializationAllowed, false);
+    assert.equal(plan.runtimeEligible, false);
+    assert.equal(plan.publicationEligible, false);
+    assert.equal(plan.promotionEligible, false);
+});
+
+test("local generated repository is deterministic and bot-authored", () => {
+    withTemporaryDirectory(root => {
+        const first = bootstrap(root, "first");
+        const second = bootstrap(root, "second");
+        assert.equal(first.generatedCommit, second.generatedCommit);
+        assert.equal(first.generatedTree, second.generatedTree);
+        assert.equal(first.generatedFiles, second.generatedFiles);
+        assert.deepEqual(first.author, {
+            name: "cratis-distribution-fixture-bot",
+            email: "fixture-bot@invalid.example",
+        });
+        assert.equal(first.fixtureOnly, true);
+        assert.equal(first.publicationEligible, false);
+        assert.equal(first.promotionEligible, false);
+    });
+});
+
+test("generated repository contains only manifested distribution files", () => {
+    withTemporaryDirectory(root => {
+        bootstrap(root);
+        const generatedRoot = join(root, "generated");
+        const verification = verifyGeneratedDistributionRepository(
+            generatedRoot,
+            contractPath,
+        );
+        assert(verification.files.includes("distribution-manifest.json"));
+        assert(verification.files.includes("SHA256SUMS"));
+        assert(verification.files.includes("provenance.json"));
+        assert(
+            verification.files.every(
+                path =>
+                    !path.startsWith("tooling/") &&
+                    !path.startsWith("evals/") &&
+                    !path.startsWith("agents/") &&
+                    !path.startsWith("hooks/") &&
+                    !path.startsWith("prompts/"),
+            ),
+        );
+    });
+});
+
+test("generated repository verification rejects worktree tampering", () => {
+    withTemporaryDirectory(root => {
+        bootstrap(root);
+        const generatedRoot = join(root, "generated");
+        writeFileSync(
+            join(generatedRoot, "canonical/skills/cratis-example/SKILL.md"),
+            "tampered\n",
+        );
+        assert.throws(
+            () =>
+                verifyGeneratedDistributionRepository(
+                    generatedRoot,
+                    contractPath,
+                ),
+            /worktree is not clean/,
+        );
+    });
+});
+
+test("generated repository verification rejects human follow-up commits", () => {
+    withTemporaryDirectory(root => {
+        bootstrap(root);
+        const generatedRoot = join(root, "generated");
+        const path = join(generatedRoot, "canonical/skills/cratis-example/LICENSE");
+        writeFileSync(path, `${readFileSync(path, "utf8")}human edit\n`);
+        execFileSync("git", ["add", "--", "canonical/skills/cratis-example/LICENSE"], {
+            cwd: generatedRoot,
+        });
+        execFileSync(
+            "git",
+            [
+                "-c",
+                "user.name=human-author",
+                "-c",
+                "user.email=human@example.invalid",
+                "commit",
+                "--message",
+                "Manual edit",
+            ],
+            {
+                cwd: generatedRoot,
+                env: {
+                    ...process.env,
+                    GIT_AUTHOR_DATE: "2000-01-02T00:00:00+00:00",
+                    GIT_COMMITTER_DATE: "2000-01-02T00:00:00+00:00",
+                },
+                stdio: "pipe",
+            },
+        );
+        assert.throws(
+            () =>
+                verifyGeneratedDistributionRepository(
+                    generatedRoot,
+                    contractPath,
+                ),
+            /one root commit|commit identity changed/,
+        );
+    });
+});
+
+test("generated repository bootstrap refuses existing destinations and records", () => {
+    withTemporaryDirectory(root => {
+        const generatedRoot = join(root, "generated");
+        mkdirSync(generatedRoot);
+        assert.throws(
+            () =>
+                bootstrapGeneratedDistributionRepository({
+                    repositoryRoot,
+                    generatedRepositoryRoot: generatedRoot,
+                    recordPath: join(root, "record.json"),
+                }),
+            /destination must not exist/,
+        );
+    });
+});


### PR DESCRIPTION
# Summary

Completes deterministic local work for the bot-owned distribution boundary by creating and verifying generated-only Git repositories while production materialization remains fail-closed.

## Added

- Add the generated repository contract for bot-only writes, protected checks/environments, and forbidden authoring content (Cratis/Workflows#68)
- Add deterministic local generated-repository bootstrap with one bot-simulation root commit and exact inventory verification (#126)
- Add production planning that remains blocked with zero approved targets and a disabled public artifact (#126)
- Add tamper, human-commit, inventory, reproducibility, and existing-destination gates plus hosted simulation wiring (Cratis/Workflows#68)
