### PR TITLE
Format generated repository tooling

### DIFF
--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "9b334539135d622c4b9b7ebe6bd03c20a65af02ba5a3d7496bb01592bc64dc74",
+  "indexDigest": "6fbf651b0c5b1750a58ae716bcff05789ef3fcf9bfdaa1b4896d4a0e5e7827cc",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/tooling/bootstrap-generated-distribution-repository.mjs
+++ b/tooling/bootstrap-generated-distribution-repository.mjs
@@ -4,11 +4,7 @@
 
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import {
-    existsSync,
-    readFileSync,
-    writeFileSync,
-} from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -16,7 +12,9 @@ import {
     validateDistributionFixture,
 } from "./generate-distribution-fixture.mjs";
 
-const defaultRepositoryRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const defaultRepositoryRoot = resolve(
+    fileURLToPath(new URL("..", import.meta.url)),
+);
 
 function sha256(content) {
     return createHash("sha256").update(content).digest("hex");
@@ -41,9 +39,12 @@ function runGit(repositoryRoot, arguments_, options = {}) {
             ...options,
         }).trim();
     } catch (error) {
-        throw new Error(`Generated repository git command failed: git ${arguments_.join(" ")}`, {
-            cause: error,
-        });
+        throw new Error(
+            `Generated repository git command failed: git ${arguments_.join(" ")}`,
+            {
+                cause: error,
+            },
+        );
     }
 }
 
@@ -51,28 +52,26 @@ function trackedFiles(repositoryRoot) {
     const output = execFileSync("git", ["ls-files", "-z"], {
         cwd: repositoryRoot,
     });
-    return output
-        .toString("utf8")
-        .split("\0")
-        .filter(Boolean)
-        .sort();
+    return output.toString("utf8").split("\0").filter(Boolean).sort();
 }
 
 export function buildApprovedDistributionPlan(
     repositoryRoot = defaultRepositoryRoot,
 ) {
     const targets = readJson(join(repositoryRoot, "catalog/v2/targets.json"));
-    const artifacts = readJson(join(repositoryRoot, "catalog/v2/artifacts.json"));
+    const artifacts = readJson(
+        join(repositoryRoot, "catalog/v2/artifacts.json"),
+    );
     const approvedTargets = targets.targets
         .filter(
-            target =>
+            (target) =>
                 target.includeInRuntime === true &&
                 target.approval?.state === "approved",
         )
-        .map(target => target.id)
+        .map((target) => target.id)
         .sort();
     const publicArtifact = artifacts.artifacts.find(
-        artifact => artifact.id === "planned-passive-public-release",
+        (artifact) => artifact.id === "planned-passive-public-release",
     );
     const ready =
         approvedTargets.length > 0 &&
@@ -86,8 +85,7 @@ export function buildApprovedDistributionPlan(
         sourceCommit: runGit(repositoryRoot, ["rev-parse", "HEAD"]),
         artifactId: publicArtifact?.id ?? null,
         approvedTargets,
-        materializationAllowed:
-            publicArtifact?.materializationAllowed === true,
+        materializationAllowed: publicArtifact?.materializationAllowed === true,
         runtimeEligible: publicArtifact?.runtimeEligible === true,
         publicationEligible: false,
         promotionEligible: false,
@@ -109,7 +107,9 @@ export function verifyGeneratedDistributionRepository(
     if (runGit(root, ["status", "--porcelain"]) !== "")
         throw new Error("Generated repository worktree is not clean");
     if (runGit(root, ["rev-list", "--count", "HEAD"]) !== "1")
-        throw new Error("Generated fixture repository must have one root commit");
+        throw new Error(
+            "Generated fixture repository must have one root commit",
+        );
     const identity = runGit(root, [
         "show",
         "-s",
@@ -128,7 +128,7 @@ export function verifyGeneratedDistributionRepository(
     }
     const manifest = readJson(join(root, "distribution-manifest.json"));
     const expectedFiles = [
-        ...manifest.files.map(file => file.path),
+        ...manifest.files.map((file) => file.path),
         "distribution-manifest.json",
     ].sort();
     if (JSON.stringify(trackedFiles(root)) !== JSON.stringify(expectedFiles))
@@ -136,7 +136,9 @@ export function verifyGeneratedDistributionRepository(
     for (const file of manifest.files) {
         const content = readFileSync(join(root, file.path));
         if (content.length !== file.size || sha256(content) !== file.sha256)
-            throw new Error(`Generated repository digest mismatch: ${file.path}`);
+            throw new Error(
+                `Generated repository digest mismatch: ${file.path}`,
+            );
     }
     const forbiddenSegments = new Set([
         "agents",
@@ -146,10 +148,8 @@ export function verifyGeneratedDistributionRepository(
         "tooling",
     ]);
     if (
-        expectedFiles.some(path =>
-            path
-                .split("/")
-                .some(segment => forbiddenSegments.has(segment)),
+        expectedFiles.some((path) =>
+            path.split("/").some((segment) => forbiddenSegments.has(segment)),
         )
     ) {
         throw new Error("Generated repository contains authoring content");
@@ -178,7 +178,9 @@ export function bootstrapGeneratedDistributionRepository({
             `Generated repository destination must not exist: ${generatedRepositoryRoot}`,
         );
     if (existsSync(recordPath))
-        throw new Error(`Generated repository record must not exist: ${recordPath}`);
+        throw new Error(
+            `Generated repository record must not exist: ${recordPath}`,
+        );
     const contractPath = join(
         repositoryRoot,
         "distribution/generated-repository-contract.json",
@@ -217,7 +219,7 @@ export function bootstrapGeneratedDistributionRepository({
         join(generatedRepositoryRoot, "distribution-manifest.json"),
     );
     const files = [
-        ...manifest.files.map(file => file.path),
+        ...manifest.files.map((file) => file.path),
         "distribution-manifest.json",
     ];
     runGit(generatedRepositoryRoot, ["add", "--", ...files]);

--- a/tooling/specs/generated-distribution-repository.spec.mjs
+++ b/tooling/specs/generated-distribution-repository.spec.mjs
@@ -20,7 +20,10 @@ import {
     verifyGeneratedDistributionRepository,
 } from "../bootstrap-generated-distribution-repository.mjs";
 
-const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const repositoryRoot = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    "../..",
+);
 const contractPath = join(
     repositoryRoot,
     "distribution/generated-repository-contract.json",
@@ -69,7 +72,7 @@ test("production distribution plan remains blocked without approved targets", ()
 });
 
 test("local generated repository is deterministic and bot-authored", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const first = bootstrap(root, "first");
         const second = bootstrap(root, "second");
         assert.equal(first.generatedCommit, second.generatedCommit);
@@ -86,7 +89,7 @@ test("local generated repository is deterministic and bot-authored", () => {
 });
 
 test("generated repository contains only manifested distribution files", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         bootstrap(root);
         const generatedRoot = join(root, "generated");
         const verification = verifyGeneratedDistributionRepository(
@@ -98,7 +101,7 @@ test("generated repository contains only manifested distribution files", () => {
         assert(verification.files.includes("provenance.json"));
         assert(
             verification.files.every(
-                path =>
+                (path) =>
                     !path.startsWith("tooling/") &&
                     !path.startsWith("evals/") &&
                     !path.startsWith("agents/") &&
@@ -110,7 +113,7 @@ test("generated repository contains only manifested distribution files", () => {
 });
 
 test("generated repository verification rejects worktree tampering", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         bootstrap(root);
         const generatedRoot = join(root, "generated");
         writeFileSync(
@@ -129,14 +132,21 @@ test("generated repository verification rejects worktree tampering", () => {
 });
 
 test("generated repository verification rejects human follow-up commits", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         bootstrap(root);
         const generatedRoot = join(root, "generated");
-        const path = join(generatedRoot, "canonical/skills/cratis-example/LICENSE");
+        const path = join(
+            generatedRoot,
+            "canonical/skills/cratis-example/LICENSE",
+        );
         writeFileSync(path, `${readFileSync(path, "utf8")}human edit\n`);
-        execFileSync("git", ["add", "--", "canonical/skills/cratis-example/LICENSE"], {
-            cwd: generatedRoot,
-        });
+        execFileSync(
+            "git",
+            ["add", "--", "canonical/skills/cratis-example/LICENSE"],
+            {
+                cwd: generatedRoot,
+            },
+        );
         execFileSync(
             "git",
             [
@@ -170,7 +180,7 @@ test("generated repository verification rejects human follow-up commits", () => 
 });
 
 test("generated repository bootstrap refuses existing destinations and records", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const generatedRoot = join(root, "generated");
         mkdirSync(generatedRoot);
         assert.throws(


### PR DESCRIPTION
# Summary

Preserves formatter output produced after the generated-repository merge and refreshes the generated inventory digest. Behavior is unchanged.

## Changed

- Apply repository formatting to generated-repository bootstrap tooling and specs (#126)
