### PR TITLE
Define internal Cratis AI adoption

### DIFF
--- a/.ai/rules/general.md
+++ b/.ai/rules/general.md
@@ -77,6 +77,30 @@ link the resulting issue or decision back to the new repository and its owning
 implementation issue. Repository creation is not complete until the Strategy
 issue URL is recorded.
 
+## Shared AI Distribution
+
+Do not copy or synchronize shared `.ai`, `.agents`, `.claude`, `.github`, or
+`.pi` trees from one Cratis repository to another. A consuming repository must
+never become an accidental source that republishes its local AI corpus.
+
+Shared Cratis capabilities are authored and approved in `Cratis/AI`, generated
+into `Cratis/AI.Distribution`, and installed only from an immutable reviewed
+version after its release gates pass. Keep existing repository-local AI files in
+place while the replacement distribution remains under canary; do not restart
+legacy all-to-all propagation and do not delete legacy adapters before reviewed
+retirement evidence exists.
+
+The consuming repository owns its project facts and minimal host bootstraps.
+Use `.cratis/PROJECT.md` as canonical project context when that migration is
+active, with `.agents/PROJECT.md` only as the documented legacy fallback. Never
+merge, overwrite, or remove project context as a side effect of installing,
+updating, rolling back, or uninstalling shared AI capabilities.
+
+Update shared AI by changing a version pin through the approved organization or
+host mechanism. Canary the new version, observe its behavior and gates, and roll
+back by version when needed. Never patch generated distribution bytes or
+marketplace wrappers by hand.
+
 ## Verification Discipline
 
 A claim is only as good as the signal behind it — a build result, a test run, a lint pass, observed app behavior — not the model's own confidence. Internal reasoning *plans* the work; external signals *confirm* it.

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
@@ -1432,3 +1432,65 @@ release authority, tags/releases; approve real product-source contracts and
 public targets; establish `@cratis/ai` package ownership/trusted publishing; and
 run production consumer canary/rollback. Publication, promotion, fleet rollout,
 legacy retirement, and freeze lifting remain blocked.
+
+## 38. Internal adoption story, public docs, and manual gates — 2026-08-22
+
+The maintainer requested the complete internal development story, an explicit
+answer on propagation, public cratis.io documentation for every ecosystem, a
+brand surface on cratis.no, and durable issues for every remaining manual gate.
+
+The internal answer is now explicit in the universal **Shared AI Distribution**
+rule:
+
+- Cratis maintainers use the repository-local rules/skills already present while
+  migration is under canary;
+- shared `.ai`, `.agents`, `.claude`, `.github`, and `.pi` trees are never copied
+  or synchronized between repositories;
+- canonical shared capability comes from `Cratis/AI` and immutable generated
+  versions from `Cratis/AI.Distribution` after release approval;
+- project facts and minimal host bootstraps remain project-owned;
+- installation/update/uninstall never merges, overwrites, or deletes project
+  context;
+- updates are pinned, canaried, observed, and rolled back by version;
+- generated distribution bytes and marketplace wrappers are never hand-edited.
+
+Public documentation work in Cratis/Documentation#60 adds:
+
+- `/ai/getting-started/` for currently available CLI/MCP setup and honest coding-
+  skills status;
+- `/ai/cratis-maintainers/` for profiles, context, skills, gates, shipping, and
+  the no-propagation internal workflow;
+- `/ai/ecosystems/` for Agent Skills, Claude, Codex, Copilot, Cursor, Kiro,
+  Junie, Gemini, Pi, and npm formats/evidence/status;
+- `/ai/trust-and-distribution/` for generated packages, project context, source /
+  target approval, canary, rollback, publication, and retirement gates;
+- refreshed `/ai/` and `/plugins/` pages and AI navigation that remove obsolete
+  folder-copy instructions.
+
+Visual QA passes on the AI landing, ecosystem matrix, maintainer workflow, trust
+page, and plugins page; dark/light themes, tables, diagrams, code blocks, cards,
+and navigation render correctly. The Astro build renders 1,059 pages and docs
+lint reports zero errors. Unrelated main-gate repairs were delivered in
+Cratis/Components#167 and Cratis/Chronicle#3804; the reviewed Kotlin Spring Boot
+client-doc exception is included in Documentation#60. Remaining unrelated docs
+baseline/link repairs are tracked in Documentation#59.
+
+The AI-native brand page and approved messaging merged in Cratis/cratis.no#4.
+It presents one canonical skill behavior across hosts, project-local facts,
+compiler/spec/CI/human gates, no propagation, reversible generated distribution,
+and honest fixture-only availability. Release-time doc and brand updates are
+tracked in Documentation#58 and cratis.no#5.
+
+Every remaining manual/external gate has a focused issue:
+
+- Workflows#72 — repository-scoped GitHub App / PR-release bot;
+- Workflows#70 — `@cratis/ai` ownership and stage-only npm trusted publishing;
+- Workflows#71 — first real consuming-repository install/update/rollback canary;
+- AI#148 — first approved product-source contract and public target;
+- AI#147 — reviewed vendor marketplace submissions;
+- Strategy#126 — generated repository portfolio metadata, ownership, and AI setup;
+- Documentation#58 and cratis.no#5 — first-release public copy updates.
+
+No broad propagation is needed or allowed. Publication, real package installation,
+production promotion, fleet rollout, legacy retirement, and freeze lifting remain
+blocked until the focused issues above pass.

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
@@ -561,6 +561,12 @@ Evidence and exact next actions are in
   secret scanning/push protection, and reviewed canary/npm-stage environments.
 - [x] Initialize remote `main` from reviewed hosted generated fixture bytes,
   protect the branch, then remove the one-time deploy key and Actions secret.
+- [x] Define the internal maintainer workflow: no shared-folder propagation,
+  versioned generated distribution, project-owned context, canary, and rollback.
+- [x] Publish the honest AI-native brand story and prepare comprehensive cratis.io
+  setup, ecosystem, maintainer, trust, and distribution documentation.
+- [x] Record every remaining manual gate as linked AI, Workflows, Documentation,
+  cratis.no, and Strategy issues.
 - [ ] Provision a repository-scoped PR/release-capable bot identity before any
   generated update, tag, release, or publication operation.
 - [ ] Keep publication and retirement disabled until explicit approvals pass.

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "a97f57eac7ff9c8c63ef32b7541d17cfcf93260303486c2ff60f8616588f890b",
+  "indexDigest": "c9ddf3822c2ca97a3d744204519d5940d61551d6d1cd412d8f3d187abac76d0d",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/tooling/specs/generated-distribution-repository.spec.mjs
+++ b/tooling/specs/generated-distribution-repository.spec.mjs
@@ -68,10 +68,7 @@ test("generated repository contract keeps remote authority and production blocke
         ),
     );
     assert.equal(contract.repository.name, "Cratis/AI.Distribution");
-    assert.equal(
-        contract.repository.status,
-        "INITIALIZED_PROTECTED_FIXTURE",
-    );
+    assert.equal(contract.repository.status, "INITIALIZED_PROTECTED_FIXTURE");
     assert.equal(contract.repository.manualAuthoringAllowed, false);
     assert.equal(contract.repository.botOnlyWrites, true);
     assert.equal(
@@ -89,6 +86,9 @@ test("generated repository contract keeps remote authority and production blocke
     assert.equal(contract.legacyRetirementEligible, false);
     assert.match(generalRules, /## New Repository Registration/);
     assert.match(generalRules, /Cratis\/Strategy/);
+    assert.match(generalRules, /## Shared AI Distribution/);
+    assert.match(generalRules, /Do not copy or synchronize shared/);
+    assert.match(generalRules, /Never patch generated distribution bytes/);
     for (const requiredDetail of [
         "repository name, URL, visibility, and creation state",
         "accountable owner",
@@ -96,10 +96,7 @@ test("generated repository contract keeps remote authority and production blocke
         "repository metadata, topics, ownership records",
     ])
         assert(generalRules.includes(requiredDetail));
-    assert.equal(
-        remoteState.repository.state,
-        "INITIALIZED_PROTECTED_FIXTURE",
-    );
+    assert.equal(remoteState.repository.state, "INITIALIZED_PROTECTED_FIXTURE");
     assert.equal(remoteState.repository.secretScanningEnabled, true);
     assert.equal(remoteState.repository.pushProtectionEnabled, true);
     assert.equal(


### PR DESCRIPTION
# Summary

Defines how Cratis maintainers use shared AI capabilities without repository-to-repository propagation and records the public documentation, brand story, and ownership of every remaining manual gate.

## Added

- Add the universal versioned-distribution, project-context, canary, rollback, and no-propagation rule (#126)
- Add regression coverage for the internal distribution invariant (#126)

## Changed

- Record the maintainer workflow, Documentation#60, cratis.no#4, Strategy intake, and focused manual follow-up issues (#126)
