### PR TITLE
Prepare generated update and npm workflows

### DIFF
--- a/.github/workflows/distribution-generated-update.yml
+++ b/.github/workflows/distribution-generated-update.yml
@@ -1,0 +1,127 @@
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+name: Prepare Generated Distribution Update
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: Credential-gated fixture operation
+        required: true
+        default: verify-fixture-update
+        type: choice
+        options:
+          - verify-fixture-update
+          - create-fixture-pr
+      version:
+        description: Fixture prerelease version (0.0.N-fixture)
+        required: true
+        default: 0.0.1-fixture
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: distribution-update-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify-fixture-update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out the canonical authoring repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      - name: Validate the fixture version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          [[ "$VERSION" =~ ^0\.0\.[0-9]+-fixture$ ]]
+
+      - name: Generate and verify the candidate
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          node tooling/generate-distribution-fixture.mjs \
+            "$RUNNER_TEMP/generated-distribution" "$VERSION"
+          test "$(node -p "require('$RUNNER_TEMP/generated-distribution/distribution-manifest.json').publicationEligible")" = "false"
+          node --test tooling/specs/distribution-fixture.spec.mjs
+          node --test tooling/specs/generated-distribution-repository.spec.mjs
+
+  create-fixture-pr:
+    if: inputs.operation == 'create-fixture-pr'
+    needs: verify-fixture-update
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: distribution-canary
+    steps:
+      - name: Check out the canonical authoring repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      - name: Create a repository-scoped GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AI_DISTRIBUTION_APP_ID }}
+          private-key: ${{ secrets.AI_DISTRIBUTION_APP_PRIVATE_KEY }}
+          owner: Cratis
+          repositories: AI.Distribution
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Generate the fixture update
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          [[ "$VERSION" =~ ^0\.0\.[0-9]+-fixture$ ]]
+          node tooling/generate-distribution-fixture.mjs \
+            "$RUNNER_TEMP/generated-distribution" "$VERSION"
+
+      - name: Create the generated update pull request
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          gh auth setup-git
+          gh repo clone Cratis/AI.Distribution "$RUNNER_TEMP/AI.Distribution"
+          version_slug="${VERSION//./-}"
+          branch="generated/${version_slug}-${GITHUB_SHA:0:12}"
+          git -C "$RUNNER_TEMP/AI.Distribution" checkout -b "$branch"
+          rsync -a --delete --exclude=.git \
+            "$RUNNER_TEMP/generated-distribution/" \
+            "$RUNNER_TEMP/AI.Distribution/"
+          git -C "$RUNNER_TEMP/AI.Distribution" config \
+            user.name "cratis-distribution-fixture-bot"
+          git -C "$RUNNER_TEMP/AI.Distribution" config \
+            user.email "fixture-bot@invalid.example"
+          git -C "$RUNNER_TEMP/AI.Distribution" add -A
+          git -C "$RUNNER_TEMP/AI.Distribution" commit \
+            --message "Generate fixture distribution $VERSION"
+          git -C "$RUNNER_TEMP/AI.Distribution" push origin "$branch"
+          gh pr create \
+            --repo Cratis/AI.Distribution \
+            --base main \
+            --head "$branch" \
+            --title "Generate fixture distribution $VERSION" \
+            --body "Generated from Cratis/AI@$GITHUB_SHA. Fixture-only; publication and promotion remain disabled."

--- a/.github/workflows/distribution-npm-stage.yml
+++ b/.github/workflows/distribution-npm-stage.yml
@@ -1,0 +1,61 @@
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+name: Verify Passive AI npm Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Fixture prerelease version (0.0.N-fixture)
+        required: true
+        default: 0.0.1-fixture
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: distribution-npm-fixture-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-private-fixture:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out the canonical authoring repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Generate the private fixture package
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          [[ "$VERSION" =~ ^0\.0\.[0-9]+-fixture$ ]]
+          node tooling/generate-distribution-fixture.mjs \
+            "$RUNNER_TEMP/generated-distribution" "$VERSION"
+
+      - name: Verify package boundaries and lifecycle
+        run: |
+          set -euo pipefail
+          package="$RUNNER_TEMP/generated-distribution/pi/package/package.json"
+          test "$(node -p "require('$package').name")" = "@cratis/ai"
+          test "$(node -p "require('$package').private")" = "true"
+          test "$(node -p "require('$package').scripts === undefined")" = "true"
+          test "$(node -p "require('$package').dependencies === undefined")" = "true"
+          node --test tooling/specs/distribution-fixture.spec.mjs
+
+      - name: Confirm npm publication remains absent
+        run: |
+          set -euo pipefail
+          test "$(node -p "require('./distribution/npm-stage-contract.json').workflow.stagePublishEnabled")" = "false"
+          test "$(node -p "require('./distribution/npm-stage-contract.json').workflow.publicPublishEnabled")" = "false"

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
@@ -1494,3 +1494,41 @@ Every remaining manual/external gate has a focused issue:
 No broad propagation is needed or allowed. Publication, real package installation,
 production promotion, fleet rollout, legacy retirement, and freeze lifting remain
 blocked until the focused issues above pass.
+
+## 39. Credential-ready update and npm verification workflows — 2026-08-22
+
+Internal adoption policy merged with green CI in Cratis/AI#149. Independent work
+that does not require the missing credentials is now complete for the two next
+manual gates:
+
+- `.github/workflows/distribution-generated-update.yml` verifies a selected
+  fixture version without credentials and, only after `distribution-canary`
+  approval plus Workflows#72 App secrets, creates a generated branch and pull
+  request in `Cratis/AI.Distribution`;
+- the GitHub App installation token is scoped to `AI.Distribution`, down-scoped
+  to contents and pull-request write, masked, one-hour limited, and automatically
+  revoked after the job;
+- the workflow validates `0.0.N-fixture`, generates that exact version, never
+  pushes `main`, and contains no force-push, self-approval, tag, release, npm, or
+  marketplace operation;
+- `distribution/update-bot-contract.json` records exact secret names,
+  installation scope, permissions, environment, forbidden operations, and the
+  Workflows#72 blocker;
+- `.github/workflows/distribution-npm-stage.yml` provides the exact future npm
+  workflow identity and verifies the private `@cratis/ai` fixture package,
+  script/dependency absence, and pack/install/uninstall lifecycle;
+- `distribution/npm-stage-contract.json` keeps ownership, trusted publisher,
+  OIDC, stage publish, public publish, publication, and promotion disabled until
+  Workflows#70 passes;
+- focused workflow specs and the full repository suite pass at 195/195.
+
+The public docs work merged in Documentation#60. Components#167 and
+Chronicle#3804 restored build/client-snippet gates; AuthProxy#107,
+Chronicle#3805, and Cratis/.github#26 repair the remaining rendered-link sources.
+Documentation#59 tracks the recovery run and any residual unrelated site debt.
+The AI-native brand page is live at `https://cratis.no/ai/`.
+
+The prepared workflows deliberately cannot be used for generated PRs or npm
+staging until the focused manual issues provision their credentials/ownership.
+No secret, App, package, release, publication, promotion, or retirement authority
+is inferred from workflow readiness.

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
@@ -1525,8 +1525,10 @@ manual gates:
 The public docs work merged in Documentation#60. Components#167 and
 Chronicle#3804 restored build/client-snippet gates; AuthProxy#107,
 Chronicle#3805, and Cratis/.github#26 repair the remaining rendered-link sources.
-Documentation#59 tracks the recovery run and any residual unrelated site debt.
-The AI-native brand page is live at `https://cratis.no/ai/`.
+Documentation recovery completed: full main build and deploy passed at
+`https://github.com/Cratis/Documentation/actions/runs/32577668021`, all new AI
+pages are live on cratis.io, and Documentation#59 is closed. The AI-native brand
+page is live at `https://cratis.no/ai/`.
 
 The prepared workflows deliberately cannot be used for generated PRs or npm
 staging until the focused manual issues provision their credentials/ownership.

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
@@ -567,6 +567,8 @@ Evidence and exact next actions are in
   setup, ecosystem, maintainer, trust, and distribution documentation.
 - [x] Record every remaining manual gate as linked AI, Workflows, Documentation,
   cratis.no, and Strategy issues.
-- [ ] Provision a repository-scoped PR/release-capable bot identity before any
-  generated update, tag, release, or publication operation.
+- [x] Prepare a least-privilege, environment-gated generated-update PR workflow
+  using a one-repository GitHub App token; keep it fixture-only and non-publishing.
+- [ ] Provision the repository-scoped App credentials from Workflows#72 before
+  any generated update PR, tag, release, or publication operation.
 - [ ] Keep publication and retirement disabled until explicit approvals pass.

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "e5481f18a5196add8ad5ac0afe13fc63c8b0181fd1103c5aa8f083253542ac9c",
+  "indexDigest": "b7bfb88bcbfb0fc6d7a3f041865ebc0c19953dee7ea71ac82c008091c96e42e3",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "c9ddf3822c2ca97a3d744204519d5940d61551d6d1cd412d8f3d187abac76d0d",
+  "indexDigest": "e5481f18a5196add8ad5ac0afe13fc63c8b0181fd1103c5aa8f083253542ac9c",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -12,6 +12,14 @@
     },
     {
       "path": ".github/workflows/distribution-canary-rollback.yml",
+      "status": "added"
+    },
+    {
+      "path": ".github/workflows/distribution-generated-update.yml",
+      "status": "added"
+    },
+    {
+      "path": ".github/workflows/distribution-npm-stage.yml",
       "status": "added"
     },
     {
@@ -295,11 +303,19 @@
       "status": "added"
     },
     {
+      "path": "distribution/npm-stage-contract.json",
+      "status": "added"
+    },
+    {
       "path": "distribution/remote-repository-state.json",
       "status": "added"
     },
     {
       "path": "distribution/rollout-policy.json",
+      "status": "added"
+    },
+    {
+      "path": "distribution/update-bot-contract.json",
       "status": "added"
     },
     {
@@ -1395,7 +1411,15 @@
       "status": "added"
     },
     {
+      "path": "tooling/specs/distribution-npm-stage.spec.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/specs/distribution-rollout.spec.mjs",
+      "status": "added"
+    },
+    {
+      "path": "tooling/specs/distribution-update-workflow.spec.mjs",
       "status": "added"
     },
     {
@@ -1963,6 +1987,8 @@
       "id": "repository-validation-workflow",
       "sourcePathPatterns": [
         ".github/workflows/distribution-canary-rollback.yml",
+        ".github/workflows/distribution-generated-update.yml",
+        ".github/workflows/distribution-npm-stage.yml",
         ".github/workflows/verify-ai-corpus.yml"
       ],
       "artifactType": "workflow",
@@ -1981,8 +2007,8 @@
         "repo-main-b795d53",
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 2,
-      "expectedPathsDigest": "fd74711f49c8c23ac1ea288bbf7c16a039bcc6d2608f5f3f794a4c2b608ef738"
+      "expectedPathCount": 4,
+      "expectedPathsDigest": "e1954180491c3afafb5bc8225878c01927f90a4b81abdd76442fbe3e5796f50f"
     },
     {
       "excludePathPatterns": [],
@@ -2646,8 +2672,8 @@
       "evidenceIds": [
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 10,
-      "expectedPathsDigest": "bc7ff918cc405140867b95bc5ccf498d1451ca5caa6f1632c2c3934d9e3742bd"
+      "expectedPathCount": 12,
+      "expectedPathsDigest": "fe60acdc096ee26ee4092e1fd3e1b3875eea548b9eba7eb61554e1bc37354800"
     },
     {
       "excludePathPatterns": [],
@@ -2693,8 +2719,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 14,
-      "expectedPathsDigest": "2048a1afb804cd99dd7cff263210fbe2e8c3599e0440159bc4671a45a3a04b50"
+      "expectedPathCount": 16,
+      "expectedPathsDigest": "c1a7af0eea7bc5a01092cb5192c69a592337b46f13a7e2d29031451001ce16c1"
     },
     {
       "excludePathPatterns": [],

--- a/distribution/generated-repository-authority-request.md
+++ b/distribution/generated-repository-authority-request.md
@@ -37,6 +37,14 @@ Future generated updates need a repository-scoped GitHub App or equivalent bot
 that can create pull requests and, only after separate approval, tags and
 releases. Human or deploy-key direct pushes are not an accepted update path.
 
+`Cratis/AI` contains a reviewed `distribution-generated-update.yml` workflow
+contract for this path. It generates and verifies fixture bytes without
+credentials, and creates a protected generated PR only when the scoped App ID and
+private key from Workflows#72 are configured. Its installation token is narrowed
+to contents and pull-request write access for `AI.Distribution` and is revoked at
+job completion. The workflow cannot push to `main`, tag, release, publish npm, or
+submit a marketplace package.
+
 ## Gates that remain closed
 
 - Zero public targets or product-source contracts are approved.

--- a/distribution/npm-stage-contract.json
+++ b/distribution/npm-stage-contract.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "state": "PACK_VERIFY_READY_OWNER_AND_TRUST_MISSING",
+  "trackingIssue": "https://github.com/Cratis/Workflows/issues/70",
+  "package": {
+    "name": "@cratis/ai",
+    "fixturePrivate": true,
+    "lifecycleScriptsAllowed": false,
+    "dependenciesAllowed": false,
+    "publicOwnershipConfirmed": false
+  },
+  "workflow": {
+    "path": ".github/workflows/distribution-npm-stage.yml",
+    "currentOperation": "VERIFY_PRIVATE_FIXTURE",
+    "environment": "npm-stage",
+    "trustedPublisherConfigured": false,
+    "oidcEnabled": false,
+    "stagePublishEnabled": false,
+    "publicPublishEnabled": false
+  },
+  "futureStageRequirements": [
+    "approved public target and source contract",
+    "public package ownership",
+    "exact npm trusted-publisher workflow registration",
+    "Node 22.14 or newer",
+    "npm 11.5.1 or newer",
+    "npm-stage environment approval",
+    "id-token write only in the stage job",
+    "unpacked allowlist and zero lifecycle scripts",
+    "provenance and checksum verification",
+    "reject and rollback evidence"
+  ],
+  "publicationEligible": false,
+  "promotionEligible": false
+}

--- a/distribution/update-bot-contract.json
+++ b/distribution/update-bot-contract.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "1.0.0",
+  "state": "WORKFLOW_READY_CREDENTIALS_MISSING",
+  "trackingIssue": "https://github.com/Cratis/Workflows/issues/72",
+  "githubApp": {
+    "installationScope": [
+      "Cratis/AI",
+      "Cratis/AI.Distribution"
+    ],
+    "requiredPermissions": {
+      "metadata": "read",
+      "contents": "write",
+      "pullRequests": "write"
+    },
+    "appIdSecret": "AI_DISTRIBUTION_APP_ID",
+    "privateKeySecret": "AI_DISTRIBUTION_APP_PRIVATE_KEY",
+    "configured": false
+  },
+  "workflow": {
+    "path": ".github/workflows/distribution-generated-update.yml",
+    "environment": "distribution-canary",
+    "sourceBranch": "main",
+    "targetRepository": "Cratis/AI.Distribution",
+    "targetBaseBranch": "main",
+    "directPushToBaseAllowed": false,
+    "fixturePullRequestEnabledAfterCredentialSetup": true,
+    "productionPullRequestEnabled": false
+  },
+  "forbiddenOperations": [
+    "force push",
+    "direct push to main",
+    "self approval",
+    "tag creation",
+    "release creation",
+    "npm publication",
+    "marketplace submission"
+  ],
+  "publicationEligible": false,
+  "promotionEligible": false,
+  "legacyRetirementEligible": false
+}

--- a/tooling/generate-distribution-fixture.mjs
+++ b/tooling/generate-distribution-fixture.mjs
@@ -675,14 +675,20 @@ export function smokeGeminiDistributionFixture(
 
 function main() {
     const outputRoot = process.argv[2];
+    const version = process.argv[3] ?? "0.0.0-fixture";
     if (!outputRoot) {
         process.stderr.write(
-            "Usage: node tooling/generate-distribution-fixture.mjs <empty-output-path>\n",
+            "Usage: node tooling/generate-distribution-fixture.mjs <empty-output-path> [version]\n",
         );
         process.exitCode = 1;
         return;
     }
-    const manifest = generateDistributionFixture({ outputRoot });
+    if (!/^0\.0\.[0-9]+-fixture$/.test(version)) {
+        process.stderr.write("Fixture version must match 0.0.N-fixture\n");
+        process.exitCode = 1;
+        return;
+    }
+    const manifest = generateDistributionFixture({ outputRoot, version });
     process.stdout.write(
         `Generated fixture-only distribution: ${manifest.files.length} files across ${manifest.generatedTargets.length} targets.\n`,
     );

--- a/tooling/generate-repository-inventory.mjs
+++ b/tooling/generate-repository-inventory.mjs
@@ -97,6 +97,8 @@ const unexpectedUntracked = admittedUntracked.filter(
     (path) =>
         !(
             path === ".github/workflows/distribution-canary-rollback.yml" ||
+            path === ".github/workflows/distribution-generated-update.yml" ||
+            path === ".github/workflows/distribution-npm-stage.yml" ||
             /^AI-REPOSITORY-REDESIGN-[A-Z0-9-]+\.md$/.test(path) ||
             /^Documentation\/(?:capability-catalog-v2|phase-0-verification|public-product-architecture|skill-authoring-contract|skill-classification-audit|project-context-bootstrap|redesign-foundation-validation|source-evidence-contract)\.md$/.test(
                 path,
@@ -435,6 +437,8 @@ const definitions = [
         id: "repository-validation-workflow",
         sourcePathPatterns: [
             ".github/workflows/distribution-canary-rollback.yml",
+            ".github/workflows/distribution-generated-update.yml",
+            ".github/workflows/distribution-npm-stage.yml",
             ".github/workflows/verify-ai-corpus.yml",
         ],
         artifactType: "workflow",

--- a/tooling/specs/distribution-fixture.spec.mjs
+++ b/tooling/specs/distribution-fixture.spec.mjs
@@ -320,6 +320,40 @@ test("Gemini fixture links and removes in an isolated home", {
     });
 });
 
+test("distribution generator CLI binds the requested fixture version", () => {
+    withTemporaryDirectory((root) => {
+        const stage = join(root, "stage");
+        execFileSync(
+            process.execPath,
+            [
+                join(repositoryRoot, "tooling/generate-distribution-fixture.mjs"),
+                stage,
+                "0.0.5-fixture",
+            ],
+            { cwd: repositoryRoot, stdio: "pipe" },
+        );
+        assert.equal(
+            readJson(join(stage, "distribution-manifest.json")).version,
+            "0.0.5-fixture",
+        );
+        assert.throws(
+            () =>
+                execFileSync(
+                    process.execPath,
+                    [
+                        join(
+                            repositoryRoot,
+                            "tooling/generate-distribution-fixture.mjs",
+                        ),
+                        join(root, "invalid"),
+                        "latest",
+                    ],
+                    { cwd: repositoryRoot, stdio: "pipe" },
+                ),
+        );
+    });
+});
+
 test("distribution generator refuses an existing destination", () => {
     withTemporaryDirectory((root) => {
         const stage = join(root, "stage");

--- a/tooling/specs/distribution-npm-stage.spec.mjs
+++ b/tooling/specs/distribution-npm-stage.spec.mjs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const contract = JSON.parse(
+    readFileSync(join(repositoryRoot, "distribution/npm-stage-contract.json"), "utf8"),
+);
+const workflow = readFileSync(
+    join(repositoryRoot, ".github/workflows/distribution-npm-stage.yml"),
+    "utf8",
+);
+
+test("npm stage contract keeps ownership OIDC and publication blocked", () => {
+    assert.equal(contract.state, "PACK_VERIFY_READY_OWNER_AND_TRUST_MISSING");
+    assert.equal(contract.package.name, "@cratis/ai");
+    assert.equal(contract.package.fixturePrivate, true);
+    assert.equal(contract.package.publicOwnershipConfirmed, false);
+    assert.equal(contract.workflow.trustedPublisherConfigured, false);
+    assert.equal(contract.workflow.oidcEnabled, false);
+    assert.equal(contract.workflow.stagePublishEnabled, false);
+    assert.equal(contract.workflow.publicPublishEnabled, false);
+    assert.equal(contract.publicationEligible, false);
+    assert.equal(contract.promotionEligible, false);
+});
+
+test("npm fixture workflow verifies a private scriptless package", () => {
+    assert.match(workflow, /workflow_dispatch:/);
+    assert.match(workflow, /package-manager-cache: false/);
+    assert.match(workflow, /require\('\$package'\)\.private/);
+    assert.match(workflow, /scripts === undefined/);
+    assert.match(workflow, /dependencies === undefined/);
+    assert.match(workflow, /distribution-fixture\.spec\.mjs/);
+    assert.match(workflow, /"\$RUNNER_TEMP\/generated-distribution" "\$VERSION"/);
+});
+
+test("npm fixture workflow cannot mint OIDC or publish", () => {
+    for (const forbidden of [
+        "id-token: write",
+        "npm publish",
+        "npm stage publish",
+        "NODE_AUTH_TOKEN",
+        "NPM_TOKEN",
+        "pull_request:",
+        "release:",
+    ])
+        assert.equal(workflow.includes(forbidden), false, forbidden);
+});

--- a/tooling/specs/distribution-update-workflow.spec.mjs
+++ b/tooling/specs/distribution-update-workflow.spec.mjs
@@ -1,0 +1,85 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const workflowPath = join(
+    repositoryRoot,
+    ".github/workflows/distribution-generated-update.yml",
+);
+const contractPath = join(
+    repositoryRoot,
+    "distribution/update-bot-contract.json",
+);
+
+function workflowText() {
+    return readFileSync(workflowPath, "utf8");
+}
+
+test("generated update bot contract remains credential and release gated", () => {
+    const contract = JSON.parse(readFileSync(contractPath, "utf8"));
+    assert.equal(contract.state, "WORKFLOW_READY_CREDENTIALS_MISSING");
+    assert.equal(contract.githubApp.configured, false);
+    assert.deepEqual(contract.githubApp.installationScope, [
+        "Cratis/AI",
+        "Cratis/AI.Distribution",
+    ]);
+    assert.deepEqual(contract.githubApp.requiredPermissions, {
+        metadata: "read",
+        contents: "write",
+        pullRequests: "write",
+    });
+    assert.equal(contract.workflow.directPushToBaseAllowed, false);
+    assert.equal(contract.workflow.productionPullRequestEnabled, false);
+    assert.equal(contract.publicationEligible, false);
+    assert.equal(contract.promotionEligible, false);
+    assert.equal(contract.legacyRetirementEligible, false);
+});
+
+test("generated update workflow scopes the GitHub App token to one repository", () => {
+    const workflow = workflowText();
+    assert.match(
+        workflow,
+        /actions\/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1/,
+    );
+    assert.match(workflow, /repositories: AI\.Distribution/);
+    assert.match(workflow, /permission-contents: write/);
+    assert.match(workflow, /permission-pull-requests: write/);
+    assert.match(workflow, /AI_DISTRIBUTION_APP_ID/);
+    assert.match(workflow, /AI_DISTRIBUTION_APP_PRIVATE_KEY/);
+    assert.match(workflow, /environment: distribution-canary/);
+    assert.match(workflow, /version_slug="\$\{VERSION\/\/\.\/-\}"/);
+    assert.match(workflow, /gh pr create/);
+    assert.match(workflow, /--repo Cratis\/AI\.Distribution/);
+    assert.match(workflow, /--base main/);
+});
+
+test("generated update workflow cannot publish or bypass protected main", () => {
+    const workflow = workflowText();
+    assert.match(workflow, /workflow_dispatch:/);
+    assert.match(workflow, /create-fixture-pr/);
+    assert(
+        workflow.includes('[[ "$VERSION" =~ ^0\\.0\\.[0-9]+-fixture$ ]]'),
+    );
+    assert.equal(
+        workflow.match(/"\$RUNNER_TEMP\/generated-distribution" "\$VERSION"/g)
+            ?.length,
+        2,
+    );
+    for (const forbidden of [
+        "push origin main",
+        "push --force",
+        "push -f",
+        "gh release create",
+        "npm publish",
+        "npm stage publish",
+        "git tag",
+        "pull_request:",
+    ])
+        assert.equal(workflow.includes(forbidden), false, forbidden);
+});


### PR DESCRIPTION
# Summary

Prepares the least-privilege generated-update and npm verification workflows so the remaining manual credential and package-ownership issues can be completed without redesigning automation.

## Added

- Add a fixture-only generated PR workflow using a one-repository, contents/pull-request scoped GitHub App token (Cratis/Workflows#72)
- Add the exact verify-only npm workflow identity and private scriptless package lifecycle gate (Cratis/Workflows#70)
- Add closed contracts and regression specs that forbid direct main pushes, tags, releases, OIDC, npm staging, publication, and promotion (#126)
