### PR TITLE
Classify the first engineering package target

### DIFF
--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
@@ -1534,3 +1534,38 @@ The prepared workflows deliberately cannot be used for generated PRs or npm
 staging until the focused manual issues provision their credentials/ownership.
 No secret, App, package, release, publication, promotion, or retirement authority
 is inferred from workflow readiness.
+
+## 40. Engineering distribution classification — 2026-08-22
+
+The next internal-distribution unit classifies before packaging. Repository
+evidence identifies eight Cratis-engineering skill targets, but none was approved
+or installable and no engineering artifact existed.
+
+This branch adds:
+
+- `distribution/engineering-artifact-matrix.json`, which separates low-trust
+  passive skills, effectful passive skills, and executable tooling;
+- exact profile intent for application, framework, client, corpus, and
+  documentation repositories;
+- explicit exclusion of project-owned context/bootstrap files and all evals,
+  scripts, rules, agents, prompts, hooks, workflows, tooling, Pi state, and Git
+  state from the first passive package;
+- a distinct `planned-passive-engineering-release` artifact whose audience is
+  `cratis-engineering`, whose eight targets are audience-isolated from public
+  targets, and whose materialization/runtime remain disabled;
+- reviewed classification for only the lowest-risk first target,
+  `cratis-engineering-docs-authoring`: journey, user/model invoked,
+  product-neutral, contributor/maintainer, direct-skill/IDE, applicable to
+  application/client/corpus/framework repositories, passive but effect-assessed,
+  with explicit create/modify confirmation and reversible effects;
+- hard dependencies on documentation structure/writing rules, soft degraded
+  dependencies on add/edit page targets, and the clean-room authoring contract;
+- closed schema/semantic/inventory tests proving all other engineering targets
+  remain unclassified candidates and no artifact is installable.
+
+The raw `.ai/skills/write-documentation` source is explicitly not packageable.
+The next PR must reconcile it into self-contained canonical engineering source,
+remove repository-relative and sibling-skill assumptions from the runtime
+payload, add behavior/trigger/collision/portability evidence, and only then
+generate a fixture package. Effectful shipping/QA/tracing and executable skill
+creation remain separate later packages and security reviews.

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
@@ -569,6 +569,11 @@ Evidence and exact next actions are in
   cratis.no, and Strategy issues.
 - [x] Prepare a least-privilege, environment-gated generated-update PR workflow
   using a one-repository GitHub App token; keep it fixture-only and non-publishing.
+- [x] Define separate low-trust passive, effectful passive, and executable
+  engineering package boundaries; classify the first low-risk docs-authoring
+  target and add a distinct runtime-disabled engineering artifact.
+- [ ] Reconcile the docs-authoring target into self-contained canonical
+  engineering source before generating its first installable fixture package.
 - [ ] Provision the repository-scoped App credentials from Workflows#72 before
   any generated update PR, tag, release, or publication operation.
 - [ ] Keep publication and retirement disabled until explicit approvals pass.

--- a/catalog/generated/human-catalog/catalog.json
+++ b/catalog/generated/human-catalog/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractVersion": 1,
   "disclaimer": "Catalog inclusion, evaluation evidence, bundle generation, or publication does not grant runtime permission or approval.",
-  "inputDigest": "e42bfa066a6c58d75a51d607dcb9660ea2145af6d643958eb94c200ef3d66ee6",
+  "inputDigest": "011c011348a80c36e3fe68ff1f85f35e2e9e164c68dd4a20e0a4ba1ecd242a46",
   "capabilities": [
     {
       "id": "cratis-application-react-specifications",

--- a/catalog/generated/human-catalog/manifest.json
+++ b/catalog/generated/human-catalog/manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "contractVersion": 1,
-  "inputDigest": "e42bfa066a6c58d75a51d607dcb9660ea2145af6d643958eb94c200ef3d66ee6",
+  "inputDigest": "011c011348a80c36e3fe68ff1f85f35e2e9e164c68dd4a20e0a4ba1ecd242a46",
   "files": [
     {
       "path": "CATALOG.md",
@@ -11,7 +11,7 @@
     {
       "path": "catalog.json",
       "size": 64765,
-      "sha256": "c47df1d2daf7fe424c9084dea5d1b4e178d182b1b2169b143c14efe5197e11c6"
+      "sha256": "acf51ff4c74638428f03ecb1e5909d5117750f25f977eeb467958f85d94cac6c"
     }
   ]
 }

--- a/catalog/schemas/v2/catalog-v2.schema.json
+++ b/catalog/schemas/v2/catalog-v2.schema.json
@@ -965,7 +965,7 @@
       ],
       "properties": {
         "id": { "$ref": "#/$defs/id" },
-        "audience": { "enum": ["public", "test-fixture"] },
+        "audience": { "enum": ["public", "cratis-engineering", "test-fixture"] },
         "fixtureOnly": { "type": "boolean" },
         "materializationAllowed": { "type": "boolean" },
         "runtimeEligible": { "type": "boolean" },

--- a/catalog/v2/artifacts.json
+++ b/catalog/v2/artifacts.json
@@ -93,6 +93,59 @@
       ]
     },
     {
+      "id": "planned-passive-engineering-release",
+      "audience": "cratis-engineering",
+      "fixtureOnly": false,
+      "materializationAllowed": false,
+      "runtimeEligible": false,
+      "componentInventory": {
+        "skills": [
+          "cratis-engineering-chronicle-kernel-tracing",
+          "cratis-engineering-csharp-conventions",
+          "cratis-engineering-docs-add-page",
+          "cratis-engineering-docs-authoring",
+          "cratis-engineering-docs-edit-page",
+          "cratis-engineering-docs-visual-qa",
+          "cratis-engineering-ship-changes",
+          "skill-creator"
+        ],
+        "mcp": []
+      },
+      "exactSourcePaths": [],
+      "allowedPathPatterns": [
+        "engineering/skills/<approved-target>/SKILL.md",
+        "engineering/skills/<approved-target>/references/**",
+        "engineering/skills/<approved-target>/assets/**",
+        "engineering/skills/<approved-target>/LICENSE*"
+      ],
+      "forbiddenPathPatterns": [
+        "skills/**",
+        "**/scripts/**",
+        "**/evals/**",
+        "rules/**",
+        "agents/**",
+        "prompts/**",
+        "commands/**",
+        "hooks/**",
+        "lsp/**",
+        "tooling/**",
+        "workflows/**",
+        ".pi/**",
+        ".git/**",
+        ".cratis/PROJECT.md",
+        ".agents/PROJECT.md",
+        "AGENTS.md",
+        "CLAUDE.md",
+        "GEMINI.md"
+      ],
+      "requiresApprovedTargets": true,
+      "evidenceIds": [
+        "workflows-68",
+        "option-a-plus-authority",
+        "organization-option-a-plus-authority"
+      ]
+    },
+    {
       "id": "sanitized-public-materializer-fixture",
       "audience": "test-fixture",
       "fixtureOnly": true,

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "b7bfb88bcbfb0fc6d7a3f041865ebc0c19953dee7ea71ac82c008091c96e42e3",
+  "indexDigest": "10db39fec06c6c22d817f952b3eccc42cd815e8471f6e506c9beec355bb8044b",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -272,6 +272,10 @@
     },
     {
       "path": "distribution/artifact-matrix.json",
+      "status": "added"
+    },
+    {
+      "path": "distribution/engineering-artifact-matrix.json",
       "status": "added"
     },
     {
@@ -1424,6 +1428,10 @@
     },
     {
       "path": "tooling/specs/domain-expert-event-modeling-pilot.spec.mjs",
+      "status": "added"
+    },
+    {
+      "path": "tooling/specs/engineering-distribution.spec.mjs",
       "status": "added"
     },
     {
@@ -2672,8 +2680,8 @@
       "evidenceIds": [
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 12,
-      "expectedPathsDigest": "fe60acdc096ee26ee4092e1fd3e1b3875eea548b9eba7eb61554e1bc37354800"
+      "expectedPathCount": 13,
+      "expectedPathsDigest": "44be17dfc60356a52c190f85b2dc30ab829a0091d6f8c79d346adc819f9eda38"
     },
     {
       "excludePathPatterns": [],
@@ -2719,8 +2727,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 16,
-      "expectedPathsDigest": "c1a7af0eea7bc5a01092cb5192c69a592337b46f13a7e2d29031451001ce16c1"
+      "expectedPathCount": 17,
+      "expectedPathsDigest": "0f7fa74db962f9bcdc50b2a99c8cb92cee8a934fef62af4b4cc477573fd691e4"
     },
     {
       "excludePathPatterns": [],

--- a/catalog/v2/targets.json
+++ b/catalog/v2/targets.json
@@ -3976,41 +3976,154 @@
       "languages": [
         "language-agnostic"
       ],
-      "capabilityKind": "unclassified",
-      "invocation": "unclassified",
+      "capabilityKind": "journey",
+      "invocation": "both",
       "lifecycle": "candidate",
       "architectures": {
-        "state": "unclassified",
-        "ids": [],
-        "reason": "Architecture requires reviewed target classification."
+        "state": "applicable",
+        "ids": [
+          "product-neutral"
+        ],
+        "reason": "Documentation authoring applies across Cratis products without assuming an application architecture."
       },
       "personas": {
-        "state": "unclassified",
-        "ids": [],
-        "reason": "Persona requires reviewed target classification."
+        "state": "applicable",
+        "ids": [
+          "contributor",
+          "maintainer"
+        ],
+        "reason": "Contributors and maintainers author reviewed Cratis documentation."
       },
       "surfaces": {
-        "state": "unclassified",
-        "ids": [],
-        "reason": "Surface requires reviewed target classification."
+        "state": "applicable",
+        "ids": [
+          "direct-agent-skills",
+          "ide"
+        ],
+        "reason": "The workflow is an instruction-only skill used from an agent or IDE session."
       },
       "repositoryProfiles": {
-        "state": "unclassified",
-        "ids": [],
-        "reason": "Repository profile requires reviewed target classification."
+        "state": "applicable",
+        "ids": [
+          "application",
+          "client",
+          "corpus",
+          "framework"
+        ],
+        "reason": "Documentation can be owned by application, client, framework, or corpus repositories."
       },
       "trust": {
         "class": "passive",
-        "assessmentState": "unclassified",
-        "effects": []
+        "assessmentState": "assessed",
+        "effects": [
+          {
+            "id": "create-repository-documentation",
+            "operation": "create",
+            "resourceBoundary": "current repository worktree",
+            "scope": "Documentation source and navigation files selected by the owning repository",
+            "dataClassifications": [
+              "internal",
+              "public"
+            ],
+            "reversible": true,
+            "rollbackOrCompensation": "Delete the uncommitted page or revert the dedicated documentation commit.",
+            "confirmation": {
+              "required": true,
+              "timing": "before-effect",
+              "reason": "The repository maintainer confirms the proposed documentation paths before files are created."
+            },
+            "authorization": {
+              "required": true,
+              "authority": "Repository maintainer or task owner",
+              "evidenceIds": [
+                "ai-126"
+              ]
+            },
+            "evidenceIds": [
+              "repo-main-b795d53",
+              "reevaluation-authority"
+            ]
+          },
+          {
+            "id": "modify-repository-documentation",
+            "operation": "modify",
+            "resourceBoundary": "current repository worktree",
+            "scope": "Documentation source and navigation files selected by the owning repository",
+            "dataClassifications": [
+              "internal",
+              "public"
+            ],
+            "reversible": true,
+            "rollbackOrCompensation": "Restore the prior bytes or revert the dedicated documentation commit.",
+            "confirmation": {
+              "required": true,
+              "timing": "before-effect",
+              "reason": "The repository maintainer confirms the proposed documentation paths before existing files are changed."
+            },
+            "authorization": {
+              "required": true,
+              "authority": "Repository maintainer or task owner",
+              "evidenceIds": [
+                "ai-126"
+              ]
+            },
+            "evidenceIds": [
+              "repo-main-b795d53",
+              "reevaluation-authority"
+            ]
+          }
+        ]
       },
-      "dependencyClassificationState": "unclassified",
-      "dependencyEdges": [],
+      "dependencyClassificationState": "classified",
+      "dependencyEdges": [
+        {
+          "dependencyId": ".ai/rules/documentation-structure-and-formatting.md",
+          "category": "internal-artifact",
+          "strength": "hard",
+          "reason": "The rule defines the site-compatible document structure.",
+          "missingBehavior": {
+            "action": "block",
+            "description": "Stop rather than inventing documentation structure."
+          }
+        },
+        {
+          "dependencyId": ".ai/rules/writing-cratis-docs.md",
+          "category": "internal-artifact",
+          "strength": "hard",
+          "reason": "The rule defines the Cratis documentation voice and quality bar.",
+          "missingBehavior": {
+            "action": "block",
+            "description": "Stop rather than drafting without the Cratis writing contract."
+          }
+        },
+        {
+          "dependencyId": "cratis-engineering-docs-add-page",
+          "category": "target",
+          "strength": "soft",
+          "reason": "New pages need repository placement and navigation wiring.",
+          "missingBehavior": {
+            "action": "degrade",
+            "description": "Draft content only and disclose that placement and navigation remain unresolved."
+          }
+        },
+        {
+          "dependencyId": "cratis-engineering-docs-edit-page",
+          "category": "target",
+          "strength": "soft",
+          "reason": "Existing pages need source-of-truth discovery and sync guidance.",
+          "missingBehavior": {
+            "action": "degrade",
+            "description": "Draft content only and disclose that source discovery and integration remain unresolved."
+          }
+        }
+      ],
       "sourceContractState": "unclassified",
       "sourceContractIds": [],
       "sourceAuthoritySubjects": [],
-      "authoringContractState": "unclassified",
-      "authoringContractIds": [],
+      "authoringContractState": "classified",
+      "authoringContractIds": [
+        "cratis-skill-clean-room-v1"
+      ],
       "capability": "Cratis documentation authoring",
       "positiveTriggerIntent": "Use by Cratis maintainers to apply Diátaxis and documentation writing guidance.",
       "nearMissExclusions": [
@@ -4021,12 +4134,23 @@
         "cratis-engineering-docs-edit-page"
       ],
       "dependencies": {
-        "targets": [],
-        "internalArtifacts": [],
+        "targets": [
+          "cratis-engineering-docs-add-page",
+          "cratis-engineering-docs-edit-page"
+        ],
+        "internalArtifacts": [
+          ".ai/rules/documentation-structure-and-formatting.md",
+          ".ai/rules/writing-cratis-docs.md"
+        ],
         "externalTools": []
       },
       "runtimePayloadPolicy": {
-        "allowed": [],
+        "allowed": [
+          "SKILL.md",
+          "references/**",
+          "assets/**",
+          "LICENSE*"
+        ],
         "forbidden": [
           "scripts/**",
           "evals/**",

--- a/distribution/engineering-artifact-matrix.json
+++ b/distribution/engineering-artifact-matrix.json
@@ -1,0 +1,99 @@
+{
+  "schemaVersion": "1.0.0",
+  "state": "CLASSIFICATION_IN_PROGRESS_RUNTIME_DISABLED",
+  "audience": "cratis-engineering",
+  "firstPassiveTarget": {
+    "targetId": "cratis-engineering-docs-authoring",
+    "state": "CLASSIFIED_NOT_APPROVED",
+    "reason": "It is the lowest-risk engineering target and has no scripts, hooks, remote operations, live-store access, or executable package implementation.",
+    "rawSourcePackagingAllowed": false
+  },
+  "packageBoundaries": [
+    {
+      "id": "engineering-passive-low-trust",
+      "trust": "PASSIVE",
+      "state": "PLANNED_DISABLED",
+      "targetIds": [
+        "cratis-engineering-docs-authoring",
+        "cratis-engineering-docs-add-page",
+        "cratis-engineering-docs-edit-page",
+        "cratis-engineering-csharp-conventions"
+      ],
+      "allowedPaths": [
+        "engineering/skills/<approved-target>/SKILL.md",
+        "engineering/skills/<approved-target>/references/**",
+        "engineering/skills/<approved-target>/assets/**",
+        "engineering/skills/<approved-target>/LICENSE*"
+      ]
+    },
+    {
+      "id": "engineering-passive-effectful",
+      "trust": "PASSIVE_EFFECTFUL",
+      "state": "PLANNED_DISABLED_SEPARATE_REVIEW",
+      "targetIds": [
+        "cratis-engineering-chronicle-kernel-tracing",
+        "cratis-engineering-docs-visual-qa",
+        "cratis-engineering-ship-changes"
+      ],
+      "allowedPaths": []
+    },
+    {
+      "id": "engineering-executable-tooling",
+      "trust": "EXECUTABLE",
+      "state": "PLANNED_DISABLED_SEPARATE_PACKAGE",
+      "targetIds": [
+        "skill-creator"
+      ],
+      "allowedPaths": []
+    }
+  ],
+  "profileIntent": {
+    "application": [
+      "cratis-engineering-csharp-conventions",
+      "cratis-engineering-ship-changes"
+    ],
+    "framework": [
+      "cratis-engineering-csharp-conventions",
+      "cratis-engineering-chronicle-kernel-tracing",
+      "cratis-engineering-ship-changes"
+    ],
+    "client": [
+      "cratis-engineering-csharp-conventions",
+      "cratis-engineering-ship-changes"
+    ],
+    "corpus": [
+      "cratis-engineering-ship-changes",
+      "skill-creator"
+    ],
+    "documentation": [
+      "cratis-engineering-docs-authoring",
+      "cratis-engineering-docs-add-page",
+      "cratis-engineering-docs-edit-page",
+      "cratis-engineering-docs-visual-qa",
+      "cratis-engineering-ship-changes"
+    ]
+  },
+  "projectOwnedForbiddenPaths": [
+    ".cratis/PROJECT.md",
+    ".agents/PROJECT.md",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "GEMINI.md"
+  ],
+  "alwaysForbiddenPaths": [
+    "**/evals/**",
+    "**/scripts/**",
+    "rules/**",
+    "agents/**",
+    "prompts/**",
+    "hooks/**",
+    "workflows/**",
+    "tooling/**",
+    ".pi/**",
+    ".git/**",
+    "local-configuration/**"
+  ],
+  "installationEligible": false,
+  "publicationEligible": false,
+  "promotionEligible": false
+}

--- a/tooling/catalog-v2-validation.mjs
+++ b/tooling/catalog-v2-validation.mjs
@@ -1482,6 +1482,12 @@ export function validateArtifacts(catalogs) {
     const targetIds = new Set(
         catalogs.targets.targets.map((target) => target.id),
     );
+    const targetAudiences = new Map(
+        catalogs.targets.targets.map((target) => [
+            target.id,
+            target.audience,
+        ]),
+    );
     const approvedTargets = new Set(
         catalogs.targets.targets
             .filter(
@@ -1541,6 +1547,13 @@ export function validateArtifacts(catalogs) {
         for (const targetId of artifact.componentInventory.skills) {
             if (!targetIds.has(targetId) && !artifact.fixtureOnly) {
                 errors.push(`${artifact.id}: unknown target ${targetId}`);
+            } else if (
+                !artifact.fixtureOnly &&
+                targetAudiences.get(targetId) !== artifact.audience
+            ) {
+                errors.push(
+                    `${artifact.id}: ${artifact.audience} artifact cannot select ${targetAudiences.get(targetId)} target ${targetId}`,
+                );
             } else if (
                 !artifact.fixtureOnly &&
                 liveEnabled &&

--- a/tooling/generate-catalog-v2.mjs
+++ b/tooling/generate-catalog-v2.mjs
@@ -41,6 +41,134 @@ const internalTargets = new Map([
     ["write-documentation", "cratis-engineering-docs-authoring"],
 ]);
 
+const engineeringClassifications = new Map([
+    [
+        "cratis-engineering-docs-authoring",
+        {
+            capabilityKind: "journey",
+            invocation: "both",
+            architectures: {
+                state: "applicable",
+                ids: ["product-neutral"],
+                reason: "Documentation authoring applies across Cratis products without assuming an application architecture.",
+            },
+            personas: {
+                state: "applicable",
+                ids: ["contributor", "maintainer"],
+                reason: "Contributors and maintainers author reviewed Cratis documentation.",
+            },
+            surfaces: {
+                state: "applicable",
+                ids: ["direct-agent-skills", "ide"],
+                reason: "The workflow is an instruction-only skill used from an agent or IDE session.",
+            },
+            repositoryProfiles: {
+                state: "applicable",
+                ids: ["application", "client", "corpus", "framework"],
+                reason: "Documentation can be owned by application, client, framework, or corpus repositories.",
+            },
+            trust: {
+                class: "passive",
+                assessmentState: "assessed",
+                effects: [
+                    {
+                        id: "create-repository-documentation",
+                        operation: "create",
+                        resourceBoundary: "current repository worktree",
+                        scope: "Documentation source and navigation files selected by the owning repository",
+                        dataClassifications: ["internal", "public"],
+                        reversible: true,
+                        rollbackOrCompensation: "Delete the uncommitted page or revert the dedicated documentation commit.",
+                        confirmation: {
+                            required: true,
+                            timing: "before-effect",
+                            reason: "The repository maintainer confirms the proposed documentation paths before files are created.",
+                        },
+                        authorization: {
+                            required: true,
+                            authority: "Repository maintainer or task owner",
+                            evidenceIds: ["ai-126"],
+                        },
+                        evidenceIds: ["repo-main-b795d53", "reevaluation-authority"],
+                    },
+                    {
+                        id: "modify-repository-documentation",
+                        operation: "modify",
+                        resourceBoundary: "current repository worktree",
+                        scope: "Documentation source and navigation files selected by the owning repository",
+                        dataClassifications: ["internal", "public"],
+                        reversible: true,
+                        rollbackOrCompensation: "Restore the prior bytes or revert the dedicated documentation commit.",
+                        confirmation: {
+                            required: true,
+                            timing: "before-effect",
+                            reason: "The repository maintainer confirms the proposed documentation paths before existing files are changed.",
+                        },
+                        authorization: {
+                            required: true,
+                            authority: "Repository maintainer or task owner",
+                            evidenceIds: ["ai-126"],
+                        },
+                        evidenceIds: ["repo-main-b795d53", "reevaluation-authority"],
+                    },
+                ],
+            },
+            dependencyEdges: [
+                {
+                    dependencyId: ".ai/rules/documentation-structure-and-formatting.md",
+                    category: "internal-artifact",
+                    strength: "hard",
+                    reason: "The rule defines the site-compatible document structure.",
+                    missingBehavior: {
+                        action: "block",
+                        description: "Stop rather than inventing documentation structure.",
+                    },
+                },
+                {
+                    dependencyId: ".ai/rules/writing-cratis-docs.md",
+                    category: "internal-artifact",
+                    strength: "hard",
+                    reason: "The rule defines the Cratis documentation voice and quality bar.",
+                    missingBehavior: {
+                        action: "block",
+                        description: "Stop rather than drafting without the Cratis writing contract.",
+                    },
+                },
+                {
+                    dependencyId: "cratis-engineering-docs-add-page",
+                    category: "target",
+                    strength: "soft",
+                    reason: "New pages need repository placement and navigation wiring.",
+                    missingBehavior: {
+                        action: "degrade",
+                        description: "Draft content only and disclose that placement and navigation remain unresolved.",
+                    },
+                },
+                {
+                    dependencyId: "cratis-engineering-docs-edit-page",
+                    category: "target",
+                    strength: "soft",
+                    reason: "Existing pages need source-of-truth discovery and sync guidance.",
+                    missingBehavior: {
+                        action: "degrade",
+                        description: "Draft content only and disclose that source discovery and integration remain unresolved.",
+                    },
+                },
+            ],
+            targetDependencies: [
+                "cratis-engineering-docs-add-page",
+                "cratis-engineering-docs-edit-page",
+            ],
+            internalArtifacts: [
+                ".ai/rules/documentation-structure-and-formatting.md",
+                ".ai/rules/writing-cratis-docs.md",
+            ],
+            authoringContractIds: ["cratis-skill-clean-room-v1"],
+            runtimeAllowed: ["SKILL.md", "references/**", "assets/**", "LICENSE*"],
+        },
+    ],
+]);
+
 const profiles = {
     "cratis-arc-command-validation": [
         "Arc command validation",
@@ -695,6 +823,7 @@ const targets = allTargetIds.map((targetId) => {
     const hasLegacyBehaviorEvals = sourceSkillIds.some((source) =>
         existsSync(join(repositoryRoot, `.ai/skills/${source}/evals`)),
     );
+    const engineeringClassification = engineeringClassifications.get(targetId);
     return {
         id: targetId,
         semanticName: targetId,
@@ -703,38 +832,58 @@ const targets = allTargetIds.map((targetId) => {
         audience: publicTarget ? "public" : "cratis-engineering",
         products: publicTarget ? products : ["cratis-engineering"],
         languages: publicTarget ? languages : ["language-agnostic"],
-        capabilityKind: "unclassified",
-        invocation: "unclassified",
+        capabilityKind:
+            engineeringClassification?.capabilityKind ?? "unclassified",
+        invocation: engineeringClassification?.invocation ?? "unclassified",
         lifecycle: "candidate",
-        architectures: unclassifiedApplicability("Architecture"),
-        personas: unclassifiedApplicability("Persona"),
-        surfaces: unclassifiedApplicability("Surface"),
-        repositoryProfiles: unclassifiedApplicability("Repository profile"),
-        trust: {
+        architectures:
+            engineeringClassification?.architectures ??
+            unclassifiedApplicability("Architecture"),
+        personas:
+            engineeringClassification?.personas ??
+            unclassifiedApplicability("Persona"),
+        surfaces:
+            engineeringClassification?.surfaces ??
+            unclassifiedApplicability("Surface"),
+        repositoryProfiles:
+            engineeringClassification?.repositoryProfiles ??
+            unclassifiedApplicability("Repository profile"),
+        trust: engineeringClassification?.trust ?? {
             class: "passive",
             assessmentState: "unclassified",
             effects: [],
         },
-        dependencyClassificationState: "unclassified",
-        dependencyEdges: [],
+        dependencyClassificationState: engineeringClassification
+            ? "classified"
+            : "unclassified",
+        dependencyEdges: engineeringClassification?.dependencyEdges ?? [],
         sourceContractState: "unclassified",
         sourceContractIds: [],
         sourceAuthoritySubjects: [],
-        authoringContractState: "unclassified",
-        authoringContractIds: [],
+        authoringContractState: engineeringClassification
+            ? "classified"
+            : "unclassified",
+        authoringContractIds:
+            engineeringClassification?.authoringContractIds ?? [],
         capability: profile[0],
         positiveTriggerIntent: profile[1],
         nearMissExclusions: profile[2],
         collisionSet: profile[3],
         dependencies: {
-            targets: targetDependencies,
-            internalArtifacts,
+            targets:
+                engineeringClassification?.targetDependencies ??
+                targetDependencies,
+            internalArtifacts:
+                engineeringClassification?.internalArtifacts ??
+                internalArtifacts,
             externalTools,
         },
         runtimePayloadPolicy: {
-            allowed: publicTarget
-                ? ["SKILL.md", "references/**", "assets/**", "LICENSE*"]
-                : [],
+            allowed:
+                engineeringClassification?.runtimeAllowed ??
+                (publicTarget
+                    ? ["SKILL.md", "references/**", "assets/**", "LICENSE*"]
+                    : []),
             forbidden: [
                 "scripts/**",
                 "evals/**",
@@ -836,6 +985,9 @@ writeJson("migrations.json", {
 const publicTargetIds = targets
     .filter((target) => target.audience === "public")
     .map((target) => target.id);
+const engineeringTargetIds = targets
+    .filter((target) => target.audience === "cratis-engineering")
+    .map((target) => target.id);
 writeJson("artifacts.json", {
     schemaVersion: 2,
     defaultPolicy: "deny",
@@ -883,6 +1035,47 @@ writeJson("artifacts.json", {
                 "workflows/**",
                 ".pi/**",
                 ".git/**",
+            ],
+            requiresApprovedTargets: true,
+            evidenceIds: [
+                "workflows-68",
+                "option-a-plus-authority",
+                "organization-option-a-plus-authority",
+            ],
+        },
+        {
+            id: "planned-passive-engineering-release",
+            audience: "cratis-engineering",
+            fixtureOnly: false,
+            materializationAllowed: false,
+            runtimeEligible: false,
+            componentInventory: { skills: engineeringTargetIds, mcp: [] },
+            exactSourcePaths: [],
+            allowedPathPatterns: [
+                "engineering/skills/<approved-target>/SKILL.md",
+                "engineering/skills/<approved-target>/references/**",
+                "engineering/skills/<approved-target>/assets/**",
+                "engineering/skills/<approved-target>/LICENSE*",
+            ],
+            forbiddenPathPatterns: [
+                "skills/**",
+                "**/scripts/**",
+                "**/evals/**",
+                "rules/**",
+                "agents/**",
+                "prompts/**",
+                "commands/**",
+                "hooks/**",
+                "lsp/**",
+                "tooling/**",
+                "workflows/**",
+                ".pi/**",
+                ".git/**",
+                ".cratis/PROJECT.md",
+                ".agents/PROJECT.md",
+                "AGENTS.md",
+                "CLAUDE.md",
+                "GEMINI.md",
             ],
             requiresApprovedTargets: true,
             evidenceIds: [

--- a/tooling/specs/catalog-v2-validation.spec.mjs
+++ b/tooling/specs/catalog-v2-validation.spec.mjs
@@ -93,9 +93,10 @@ test("catalog v2 exposes closed shared taxonomies without broadening targets", (
     }
 });
 
-test("legacy targets remain explicitly unclassified and runtime ineligible", () => {
+test("unreviewed targets remain explicitly unclassified and runtime ineligible", () => {
     const catalogs = loadCatalogs();
     for (const target of catalogs.targets.targets) {
+        if (target.id === "cratis-engineering-docs-authoring") continue;
         assert.equal(target.capabilityKind, "unclassified");
         assert.equal(target.invocation, "unclassified");
         assert.equal(target.lifecycle, "candidate");
@@ -120,6 +121,54 @@ test("legacy targets remain explicitly unclassified and runtime ineligible", () 
         assert.equal(target.approval.state, "candidate");
         assert.equal(target.includeInRuntime, false);
     }
+});
+
+test("documentation authoring is classified but remains unapproved", () => {
+    const catalogs = loadCatalogs();
+    const target = catalogs.targets.targets.find(
+        (candidate) => candidate.id === "cratis-engineering-docs-authoring",
+    );
+    assert.equal(target.audience, "cratis-engineering");
+    assert.equal(target.capabilityKind, "journey");
+    assert.equal(target.invocation, "both");
+    assert.deepEqual(target.architectures.ids, ["product-neutral"]);
+    assert.deepEqual(target.personas.ids, ["contributor", "maintainer"]);
+    assert.deepEqual(target.surfaces.ids, ["direct-agent-skills", "ide"]);
+    assert.deepEqual(target.repositoryProfiles.ids, [
+        "application",
+        "client",
+        "corpus",
+        "framework",
+    ]);
+    assert.equal(target.trust.class, "passive");
+    assert.equal(target.trust.assessmentState, "assessed");
+    assert.deepEqual(
+        target.trust.effects.map((effect) => effect.operation),
+        ["create", "modify"],
+    );
+    assert.equal(target.dependencyClassificationState, "classified");
+    assert.equal(target.dependencyEdges.length, 4);
+    assert.deepEqual(target.dependencies.targets, [
+        "cratis-engineering-docs-add-page",
+        "cratis-engineering-docs-edit-page",
+    ]);
+    assert.deepEqual(target.dependencies.internalArtifacts, [
+        ".ai/rules/documentation-structure-and-formatting.md",
+        ".ai/rules/writing-cratis-docs.md",
+    ]);
+    assert.equal(target.sourceContractState, "unclassified");
+    assert.equal(target.authoringContractState, "classified");
+    assert.deepEqual(target.authoringContractIds, [
+        "cratis-skill-clean-room-v1",
+    ]);
+    assert.deepEqual(target.runtimePayloadPolicy.allowed, [
+        "SKILL.md",
+        "references/**",
+        "assets/**",
+        "LICENSE*",
+    ]);
+    assert.equal(target.approval.state, "candidate");
+    assert.equal(target.includeInRuntime, false);
 });
 
 test("source digests remain bound to the current source bytes", () => {
@@ -619,7 +668,10 @@ test("the accepted Option A+ decision still blocks unapproved live targets", () 
     const catalogs = loadCatalogs();
     const decision = catalogs.artifacts.distributionDecision;
     const planned = catalogs.artifacts.artifacts.find(
-        (artifact) => !artifact.fixtureOnly,
+        (artifact) => artifact.id === "planned-passive-public-release",
+    );
+    const engineering = catalogs.artifacts.artifacts.find(
+        (artifact) => artifact.id === "planned-passive-engineering-release",
     );
     const fixture = catalogs.artifacts.artifacts.find(
         (artifact) => artifact.fixtureOnly,
@@ -631,6 +683,34 @@ test("the accepted Option A+ decision still blocks unapproved live targets", () 
     );
     assert(decision.authorityEvidenceIds.includes("option-a-plus-authority"));
     assert.equal(fixture.materializationAllowed, true);
+    assert.equal(engineering.audience, "cratis-engineering");
+    assert.equal(engineering.materializationAllowed, false);
+    assert.equal(engineering.runtimeEligible, false);
+    assert.equal(engineering.requiresApprovedTargets, true);
+    assert.equal(engineering.exactSourcePaths.length, 0);
+    assert(
+        engineering.componentInventory.skills.every((targetId) =>
+            catalogs.targets.targets.some(
+                (target) =>
+                    target.id === targetId &&
+                    target.audience === "cratis-engineering",
+            ),
+        ),
+    );
+    assert(engineering.forbiddenPathPatterns.includes("skills/**"));
+    assert(engineering.forbiddenPathPatterns.includes(".cratis/PROJECT.md"));
+    const publicTarget = catalogs.targets.targets.find(
+        (target) => target.audience === "public",
+    );
+    engineering.componentInventory.skills.push(publicTarget.id);
+    assert(
+        validateArtifacts(catalogs).some((error) =>
+            error.includes(
+                "cratis-engineering artifact cannot select public target",
+            ),
+        ),
+    );
+    engineering.componentInventory.skills.pop();
     planned.requiresApprovedTargets = false;
     planned.materializationAllowed = true;
     assert(

--- a/tooling/specs/engineering-distribution.spec.mjs
+++ b/tooling/specs/engineering-distribution.spec.mjs
@@ -1,0 +1,115 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readJson(path) {
+    return JSON.parse(readFileSync(join(repositoryRoot, path), "utf8"));
+}
+
+test("engineering package matrix accounts for every engineering target once", () => {
+    const matrix = readJson("distribution/engineering-artifact-matrix.json");
+    const targets = readJson("catalog/v2/targets.json").targets.filter(
+        (target) => target.audience === "cratis-engineering",
+    );
+    const matrixIds = matrix.packageBoundaries
+        .flatMap((boundary) => boundary.targetIds)
+        .sort();
+    assert.deepEqual(
+        matrixIds,
+        targets.map((target) => target.id).sort(),
+    );
+    assert.equal(new Set(matrixIds).size, matrixIds.length);
+    assert.equal(matrix.installationEligible, false);
+    assert.equal(matrix.publicationEligible, false);
+    assert.equal(matrix.promotionEligible, false);
+});
+
+test("first engineering target is classified but cannot package raw source", () => {
+    const matrix = readJson("distribution/engineering-artifact-matrix.json");
+    const targets = readJson("catalog/v2/targets.json").targets;
+    const first = targets.find(
+        (target) => target.id === matrix.firstPassiveTarget.targetId,
+    );
+    assert.equal(matrix.firstPassiveTarget.state, "CLASSIFIED_NOT_APPROVED");
+    assert.equal(matrix.firstPassiveTarget.rawSourcePackagingAllowed, false);
+    assert.equal(first.trust.class, "passive");
+    assert.equal(first.trust.assessmentState, "assessed");
+    assert.equal(first.security.risk, "low");
+    assert.equal(first.approval.state, "candidate");
+    assert.equal(first.includeInRuntime, false);
+});
+
+test("effectful and executable engineering capabilities stay separate", () => {
+    const matrix = readJson("distribution/engineering-artifact-matrix.json");
+    const lowTrust = matrix.packageBoundaries.find(
+        (boundary) => boundary.id === "engineering-passive-low-trust",
+    );
+    const effectful = matrix.packageBoundaries.find(
+        (boundary) => boundary.id === "engineering-passive-effectful",
+    );
+    const executable = matrix.packageBoundaries.find(
+        (boundary) => boundary.id === "engineering-executable-tooling",
+    );
+    assert(lowTrust.targetIds.includes("cratis-engineering-docs-authoring"));
+    assert(effectful.targetIds.includes("cratis-engineering-ship-changes"));
+    assert.deepEqual(executable.targetIds, ["skill-creator"]);
+    assert.equal(effectful.allowedPaths.length, 0);
+    assert.equal(executable.allowedPaths.length, 0);
+});
+
+test("engineering distribution cannot own project context or executable payloads", () => {
+    const matrix = readJson("distribution/engineering-artifact-matrix.json");
+    assert.deepEqual(matrix.projectOwnedForbiddenPaths, [
+        ".cratis/PROJECT.md",
+        ".agents/PROJECT.md",
+        "AGENTS.md",
+        "CLAUDE.md",
+        "GEMINI.md",
+    ]);
+    for (const forbidden of [
+        "**/evals/**",
+        "**/scripts/**",
+        "rules/**",
+        "agents/**",
+        "prompts/**",
+        "hooks/**",
+        "workflows/**",
+        "tooling/**",
+        ".pi/**",
+        ".git/**",
+    ])
+        assert(matrix.alwaysForbiddenPaths.includes(forbidden), forbidden);
+});
+
+test("engineering artifact remains distinct from the public release", () => {
+    const artifacts = readJson("catalog/v2/artifacts.json").artifacts;
+    const engineering = artifacts.find(
+        (artifact) => artifact.id === "planned-passive-engineering-release",
+    );
+    const publicArtifact = artifacts.find(
+        (artifact) => artifact.id === "planned-passive-public-release",
+    );
+    assert.equal(engineering.audience, "cratis-engineering");
+    assert.equal(publicArtifact.audience, "public");
+    assert.equal(engineering.materializationAllowed, false);
+    assert.equal(engineering.runtimeEligible, false);
+    assert.equal(publicArtifact.materializationAllowed, false);
+    assert.equal(publicArtifact.runtimeEligible, false);
+    assert.deepEqual(
+        new Set(engineering.componentInventory.skills),
+        new Set(
+            readJson("catalog/v2/targets.json")
+                .targets.filter(
+                    (target) => target.audience === "cratis-engineering",
+                )
+                .map((target) => target.id),
+        ),
+    );
+});


### PR DESCRIPTION
# Summary

Starts the internal engineering distribution by classifying before packaging. It separates low-trust passive skills from effectful and executable behavior and keeps every target runtime-disabled.

## Added

- Add the engineering package/profile matrix and project-context exclusions (#126)
- Add a distinct runtime-disabled engineering artifact isolated from public distribution (#126)
- Classify the first low-risk documentation-authoring target, its reversible effects, profiles, dependencies and authoring contract (#126)
- Add audience-isolation and engineering package-boundary regression specs (#126)

## Changed

- Extend artifact schema and semantic validation for the `cratis-engineering` audience (#126)
