### PR TITLE
Run the first engineering repository canary

### DIFF
--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
@@ -1652,7 +1652,8 @@ mechanics are now implemented:
 - planned engineering release remains separate, approval-required,
   materialization-disabled, and runtime-disabled;
 - `tooling/generate-engineering-distribution-fixture.mjs` creates one canonical
-  tree plus strict Claude, Copilot, and private Pi/npm fixture adapters;
+  tree plus Claude, Codex, Copilot, Cursor, Kiro, Junie, Gemini, and private
+  Pi/npm fixture adapters;
 - every adapter uses exact canonical bytes; manifests, checksums, and an explicit
   non-attestation provenance record are emitted;
 - package output excludes project context/bootstraps, scripts, evals, rules,
@@ -1660,7 +1661,8 @@ mechanics are now implemented:
 - local npm fixture evidence proves pack, install, update from 0.0.1 to 0.0.2,
   rollback to 0.0.1, uninstall, and preservation of `.cratis/PROJECT.md`,
   `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`;
-- Pi, Claude Code, and GitHub Copilot isolated install/list/remove flows pass;
+- Pi, Claude Code, GitHub Copilot, Codex, and Gemini isolated lifecycle flows
+  pass; Cursor, Kiro, and Junie manifests/byte parity pass with host smoke pending;
 - payload/digest/checksum tampering and release-shaped versions fail;
 - the read-only hosted fixture workflow has no write, OIDC, PR, publish, release,
   or promotion permission.
@@ -1670,4 +1672,44 @@ Local evidence is in
 The matrix state is `FIXTURE_PACKAGE_PASS_OWNER_REVIEW_PENDING`. AI#154 records
 the required owner decision and selection of one documentation-owning repository
 for a real canary. Target approval, installation eligibility, materialization,
+publication, promotion, and legacy retirement remain false.
+
+## 44. Real Documentation repository engineering canary — 2026-08-22
+
+The first engineering fixture package merged with green CI in Cratis/AI#155;
+hosted fixture workflow
+`https://github.com/Cratis/AI/actions/runs/32595545234` passed on main.
+
+The package generator now covers canonical, Claude, Codex, Copilot, Cursor,
+Kiro, Junie, Gemini, and Pi/npm fixture layouts. Local host lifecycle evidence
+passes for Pi, Claude Code, GitHub Copilot, Codex, and Gemini; Cursor/Kiro/Junie
+manifests and byte parity pass with host smoke pending.
+
+A real canary then ran against clean `Cratis/Documentation` revision
+`72677c19acf2aea71ab5d39138ff350c1f661fe1` using Pi 0.84.2 and
+`openai-codex/gpt-5.4-mini`:
+
+- package installed at `0.0.1-engineering-fixture`;
+- explicit existing-page routing returned `DEFER_TO_EDIT_PAGE`;
+- package updated to `0.0.2-engineering-fixture`;
+- implicit new-page routing returned `DEFER_TO_ADD_PAGE`;
+- package rolled back to `0.0.1-engineering-fixture`;
+- unverified remembered API routing returned `BLOCK`;
+- package was removed and the isolated Pi package list became empty;
+- the Documentation worktree remained clean;
+- `AGENTS.md` and all present/missing project-context/bootstrap states were
+  unchanged;
+- every model run had tools disabled and no output leaked local paths or
+  approval/publication claims.
+
+The first implicit attempt returned `NEEDS_DECISION` because the canary prompt
+did not provide a closed output vocabulary. That failure is preserved in the
+evidence; the correction supplied the six allowed decision tokens without
+revealing the expected case decision, and the rerun passed.
+
+Evidence is in
+`distribution/evidence/real-documentation-engineering-canary-2026-08-22.json`.
+The matrix state advances only to `REAL_CANARY_PASS_OWNER_REVIEW_PENDING`.
+AI#154 still requires a named owner approve or reject the target and its known
+calibration limitations. Target approval, general installation eligibility,
 publication, promotion, and legacy retirement remain false.

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
@@ -578,11 +578,15 @@ Evidence and exact next actions are in
 - [x] Run frozen calibration and held-out baseline/skill evaluation: 16 bound
   model runs, held-out 32/32 skill decisions versus 28/32 baseline, and one
   bounded independent review with its high run-binding finding corrected.
-- [x] Generate deterministic fixture-only canonical, Claude, Copilot, and Pi/npm
-  packages for the first engineering target; prove byte parity, tamper rejection,
-  install/update/rollback/uninstall, and project-context preservation.
-- [ ] Obtain owner approval in AI#154 and run a real documentation-repository
-  canary before any installation eligibility.
+- [x] Generate deterministic fixture-only canonical, Claude, Codex, Copilot,
+  Cursor, Kiro, Junie, Gemini, and Pi/npm packages for the first engineering
+  target; prove byte parity, tamper rejection, install/update/rollback/uninstall,
+  and project-context preservation.
+- [x] Run a real Cratis/Documentation Pi canary with no tools: explicit and
+  implicit routing, authority block, fixture update/rollback/remove, clean
+  worktree, and project-context preservation pass after one disclosed output-
+  contract calibration failure.
+- [ ] Obtain owner approval in AI#154 before any installation eligibility.
 - [ ] Provision the repository-scoped App credentials from Workflows#72 before
   any generated update PR, tag, release, or publication operation.
 - [ ] Keep publication and retirement disabled until explicit approvals pass.

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "c41429ef7a8033eba77e8e87556b99f44ab0986a84bd37308dcaffd6a436f72a",
+  "indexDigest": "52cf1c567553a0008dac6e2bc29fb80b00eb10510ef7aee513d78ea608858a88",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -300,6 +300,10 @@
     },
     {
       "path": "distribution/evidence/local-generated-repository-2026-08-22.json",
+      "status": "added"
+    },
+    {
+      "path": "distribution/evidence/real-documentation-engineering-canary-2026-08-22.json",
       "status": "added"
     },
     {
@@ -1599,6 +1603,10 @@
       "status": "added"
     },
     {
+      "path": "tooling/run-engineering-docs-authoring-canary.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/run-engineering-docs-authoring-evaluation.mjs",
       "status": "added"
     },
@@ -1660,6 +1668,10 @@
     },
     {
       "path": "tooling/specs/engineering-distribution.spec.mjs",
+      "status": "added"
+    },
+    {
+      "path": "tooling/specs/engineering-docs-authoring-canary.spec.mjs",
       "status": "added"
     },
     {
@@ -2961,8 +2973,8 @@
       "evidenceIds": [
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 14,
-      "expectedPathsDigest": "774e5e3dd0c5dd3384c8c453fb164bd9e585e7a61f17e3110516dc7fe2fa1bb3"
+      "expectedPathCount": 15,
+      "expectedPathsDigest": "54d61e538447c58e49227525d6eb5c350db9c81daebb54fec46986b217bfd4c7"
     },
     {
       "excludePathPatterns": [],
@@ -2984,8 +2996,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 26,
-      "expectedPathsDigest": "da0f86f93f14e07137376c68151fb36eb6f080b02643addaf9bdaa33ea379dbe"
+      "expectedPathCount": 27,
+      "expectedPathsDigest": "6685a8e106cdf27e5d90e3e00773b2d31ac277674522912692e9be0b1b7f17bd"
     },
     {
       "excludePathPatterns": [],
@@ -3008,8 +3020,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 19,
-      "expectedPathsDigest": "b72ad0335dc9fbad4f6c66d9a57e03e0957c5fe9ef25521daf8a8b83c5eb370e"
+      "expectedPathCount": 20,
+      "expectedPathsDigest": "4173ce2ed1adbb3d98a1cfe85f7bdba65b71232acff9fdcc519e2f53c402c3cb"
     },
     {
       "excludePathPatterns": [],

--- a/distribution/engineering-artifact-matrix.json
+++ b/distribution/engineering-artifact-matrix.json
@@ -4,8 +4,8 @@
   "audience": "cratis-engineering",
   "firstPassiveTarget": {
     "targetId": "cratis-engineering-docs-authoring",
-    "state": "FIXTURE_PACKAGE_PASS_OWNER_REVIEW_PENDING",
-    "reason": "Self-contained immutable source, calibration and held-out evidence, exact run bindings, bounded independent review, deterministic native fixture generation, and local install/update/rollback/uninstall pass; owner approval and a real repository canary remain incomplete.",
+    "state": "REAL_CANARY_PASS_OWNER_REVIEW_PENDING",
+    "reason": "Self-contained immutable source, calibration and held-out evidence, exact run bindings, bounded independent review, deterministic native fixture generation, local lifecycle evidence, and a real Cratis/Documentation no-tools install/update/rollback/uninstall canary pass; owner approval remains incomplete.",
     "canonicalSourcePath": "engineering/skills/cratis-engineering-docs-authoring",
     "rawSourcePackagingAllowed": false
   },

--- a/distribution/evidence/local-engineering-docs-authoring-fixture-2026-08-22.json
+++ b/distribution/evidence/local-engineering-docs-authoring-fixture-2026-08-22.json
@@ -9,7 +9,12 @@
   "generatedTargets": [
     "canonical",
     "claude",
+    "codex",
     "copilot",
+    "cursor",
+    "gemini",
+    "junie",
+    "kiro",
     "pi"
   ],
   "results": [
@@ -62,6 +67,55 @@
         "marketplace-remove"
       ],
       "status": "PASS"
+    },
+    {
+      "target": "codex-cli",
+      "version": "0.147.0",
+      "checks": [
+        "isolated-marketplace-add",
+        "list",
+        "marketplace-remove"
+      ],
+      "status": "PASS_WITH_INSTALL_NOT_SUPPORTED_BY_CLI"
+    },
+    {
+      "target": "gemini-cli",
+      "version": "0.33.1",
+      "checks": [
+        "isolated-extension-link-with-consent",
+        "installed-state",
+        "uninstall",
+        "removed-state"
+      ],
+      "status": "PASS_WITH_PROJECT_REGISTRY_WARNING"
+    },
+    {
+      "target": "cursor",
+      "version": null,
+      "checks": [
+        "cursor-plugin-manifest",
+        "marketplace-manifest",
+        "canonical-byte-parity"
+      ],
+      "status": "PASS_STATIC_GENERATION_HOST_SMOKE_PENDING"
+    },
+    {
+      "target": "kiro",
+      "version": null,
+      "checks": [
+        "agent-plugin-1.0-manifest",
+        "canonical-byte-parity"
+      ],
+      "status": "PASS_STATIC_GENERATION_HOST_SMOKE_PENDING"
+    },
+    {
+      "target": "junie",
+      "version": null,
+      "checks": [
+        "extension-manifest",
+        "canonical-byte-parity"
+      ],
+      "status": "PASS_STATIC_GENERATION_HOST_SMOKE_PENDING"
     }
   ],
   "negativeChecks": [

--- a/distribution/evidence/real-documentation-engineering-canary-2026-08-22.json
+++ b/distribution/evidence/real-documentation-engineering-canary-2026-08-22.json
@@ -1,0 +1,50 @@
+{
+  "schemaVersion": "1.0.0",
+  "observedAt": "2026-08-22T20:15:10.255Z",
+  "state": "REAL_REPOSITORY_FIXTURE_CANARY_PASS",
+  "targetId": "cratis-engineering-docs-authoring",
+  "consumerRepository": "Cratis/Documentation",
+  "consumerRevision": "72677c19acf2aea71ab5d39138ff350c1f661fe1",
+  "host": "pi",
+  "hostVersion": "0.84.2",
+  "model": "openai-codex/gpt-5.4-mini",
+  "versions": {
+    "installed": "0.0.1-engineering-fixture",
+    "updated": "0.0.2-engineering-fixture",
+    "rolledBack": "0.0.1-engineering-fixture"
+  },
+  "routing": {
+    "explicit": "DEFER_TO_EDIT_PAGE",
+    "implicit": "DEFER_TO_ADD_PAGE",
+    "authorityBlock": "BLOCK"
+  },
+  "priorAttempt": {
+    "state": "FAIL",
+    "implicitOutput": "NEEDS_DECISION",
+    "correction": "Added a closed decision-token output contract without revealing the expected case decision."
+  },
+  "worktreePreserved": true,
+  "projectContextBefore": {
+    ".cratis/PROJECT.md": "MISSING",
+    ".agents/PROJECT.md": "MISSING",
+    "AGENTS.md": "bcacc7ab860f7d5daeb94a84611fd5c6e281d1fd011f39ff70417998f92d675a",
+    "CLAUDE.md": "MISSING",
+    "GEMINI.md": "MISSING"
+  },
+  "projectContextAfter": {
+    ".cratis/PROJECT.md": "MISSING",
+    ".agents/PROJECT.md": "MISSING",
+    "AGENTS.md": "bcacc7ab860f7d5daeb94a84611fd5c6e281d1fd011f39ff70417998f92d675a",
+    "CLAUDE.md": "MISSING",
+    "GEMINI.md": "MISSING"
+  },
+  "packageRemoved": true,
+  "toolsEnabled": false,
+  "targetApproval": false,
+  "installationEligible": false,
+  "publicationEligible": false,
+  "promotionEligible": false,
+  "remainingGates": [
+    "owner approval"
+  ]
+}

--- a/tooling/generate-engineering-distribution-fixture.mjs
+++ b/tooling/generate-engineering-distribution-fixture.mjs
@@ -30,7 +30,17 @@ const approvedFiles = [
     `skills/${skillName}/SKILL.md`,
     `skills/${skillName}/references/site-format.md`,
 ];
-const generatedTargets = ["canonical", "claude", "copilot", "pi"];
+const generatedTargets = [
+    "canonical",
+    "claude",
+    "codex",
+    "copilot",
+    "cursor",
+    "gemini",
+    "junie",
+    "kiro",
+    "pi",
+];
 
 function sha256(content) {
     return createHash("sha256").update(content).digest("hex");
@@ -120,7 +130,7 @@ export function validateEngineeringDistributionConfiguration(
         );
         if (
             artifactMatrix.firstPassiveTarget.state !==
-                "FIXTURE_PACKAGE_PASS_OWNER_REVIEW_PENDING" ||
+                "REAL_CANARY_PASS_OWNER_REVIEW_PENDING" ||
             artifactMatrix.installationEligible !== false ||
             artifactMatrix.publicationEligible !== false ||
             artifactMatrix.promotionEligible !== false ||
@@ -222,6 +232,43 @@ export function generateEngineeringDistributionFixture({
             },
         );
 
+        const codexRoot = join(root, "codex");
+        copyCanonical(
+            canonicalRoot,
+            join(codexRoot, `plugins/${pluginName}`),
+        );
+        writeJson(join(codexRoot, ".agents/plugins/marketplace.json"), {
+            name: pluginName,
+            interface: { displayName: "Cratis Engineering Fixture" },
+            plugins: [
+                {
+                    name: pluginName,
+                    source: {
+                        source: "local",
+                        path: `./plugins/${pluginName}`,
+                    },
+                    policy: {
+                        installation: "AVAILABLE",
+                        authentication: "ON_INSTALL",
+                    },
+                    category: "Developer Tools",
+                },
+            ],
+        });
+        writeJson(
+            join(
+                codexRoot,
+                `plugins/${pluginName}/.codex-plugin/plugin.json`,
+            ),
+            {
+                name: pluginName,
+                version,
+                description:
+                    "Fixture-only passive Cratis engineering documentation skill.",
+                skills: "./skills/",
+            },
+        );
+
         const copilotRoot = join(root, "copilot");
         copyCanonical(
             canonicalRoot,
@@ -252,6 +299,76 @@ export function generateEngineeringDistributionFixture({
             description:
                 "Fixture-only passive Cratis engineering documentation skill.",
             skills: "skills/",
+        });
+
+        const cursorRoot = join(root, "cursor");
+        copyCanonical(
+            canonicalRoot,
+            join(cursorRoot, `plugins/${pluginName}`),
+        );
+        writeJson(join(cursorRoot, ".cursor-plugin/marketplace.json"), {
+            name: pluginName,
+            owner: { name: "Cratis" },
+            metadata: {
+                description:
+                    "Fixture-only Cratis engineering skills marketplace",
+                version,
+            },
+            plugins: [
+                {
+                    name: pluginName,
+                    description:
+                        "Fixture-only passive Cratis engineering documentation skill.",
+                    version,
+                    source: `./plugins/${pluginName}`,
+                },
+            ],
+        });
+        writeJson(
+            join(
+                cursorRoot,
+                `plugins/${pluginName}/.cursor-plugin/plugin.json`,
+            ),
+            {
+                name: pluginName,
+                version,
+                description:
+                    "Fixture-only passive Cratis engineering documentation skill.",
+                skills: "./skills/",
+            },
+        );
+
+        const geminiRoot = join(root, "gemini");
+        copyCanonical(canonicalRoot, geminiRoot);
+        writeJson(join(geminiRoot, "gemini-extension.json"), {
+            name: pluginName,
+            version,
+            description:
+                "Fixture-only passive Cratis engineering documentation skill.",
+        });
+
+        const kiroRoot = join(root, "kiro");
+        copyCanonical(canonicalRoot, kiroRoot);
+        writeJson(join(kiroRoot, "plugin.json"), {
+            $schema:
+                "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+            name: pluginName,
+            version,
+            description:
+                "Fixture-only passive Cratis engineering documentation skill.",
+            author: { name: "Cratis" },
+            license: "MIT",
+        });
+
+        const junieRoot = join(
+            root,
+            `junie/extensions/${pluginName}`,
+        );
+        copyCanonical(canonicalRoot, junieRoot);
+        writeJson(join(junieRoot, "extension.json"), {
+            name: pluginName,
+            description:
+                "Fixture-only passive Cratis engineering documentation skill.",
         });
 
         const piRoot = join(root, "pi/package");
@@ -348,7 +465,12 @@ export function validateEngineeringDistributionFixture(outputRoot) {
     }
     const targetRoots = [
         `claude/plugins/${pluginName}`,
+        `codex/plugins/${pluginName}`,
         `copilot/plugins/${pluginName}`,
+        `cursor/plugins/${pluginName}`,
+        "gemini",
+        `junie/extensions/${pluginName}`,
+        "kiro",
         "pi/package",
     ];
     for (const path of approvedFiles) {
@@ -664,6 +786,72 @@ export function smokeCopilotEngineeringFixture(
         { env: environment, stdio: "pipe" },
     );
     return { installed: true, removed: true };
+}
+
+export function smokeCodexEngineeringFixture(
+    outputRoot,
+    temporaryHome,
+    codexCommand = "codex",
+) {
+    const marketplaceRoot = join(outputRoot, "codex");
+    const environment = { ...process.env, HOME: temporaryHome };
+    execFileSync(
+        codexCommand,
+        ["plugin", "marketplace", "add", marketplaceRoot],
+        { env: environment, stdio: "pipe" },
+    );
+    const listed = execFileSync(
+        codexCommand,
+        ["plugin", "marketplace", "list"],
+        { env: environment, encoding: "utf8" },
+    );
+    if (!listed.includes(pluginName))
+        throw new Error(
+            "Codex engineering fixture marketplace was not observable",
+        );
+    execFileSync(
+        codexCommand,
+        ["plugin", "marketplace", "remove", pluginName],
+        { env: environment, stdio: "pipe" },
+    );
+    return { added: true, removed: true };
+}
+
+export function smokeGeminiEngineeringFixture(
+    outputRoot,
+    temporaryHome,
+    geminiCommand = "gemini",
+) {
+    const extensionRoot = join(outputRoot, "gemini");
+    mkdirSync(join(temporaryHome, ".gemini"), { recursive: true });
+    const environment = {
+        ...process.env,
+        HOME: temporaryHome,
+        GEMINI_API_KEY: process.env.GEMINI_API_KEY ?? "fixture-not-used",
+    };
+    execFileSync(
+        geminiCommand,
+        ["extensions", "link", extensionRoot, "--consent"],
+        { env: environment, stdio: "pipe" },
+    );
+    const installedRoot = join(
+        temporaryHome,
+        `.gemini/extensions/${pluginName}`,
+    );
+    if (!existsSync(installedRoot))
+        throw new Error(
+            "Gemini engineering fixture extension was not observable",
+        );
+    execFileSync(
+        geminiCommand,
+        ["extensions", "uninstall", pluginName],
+        { env: environment, stdio: "pipe" },
+    );
+    if (existsSync(installedRoot))
+        throw new Error(
+            "Gemini engineering fixture uninstall left extension content",
+        );
+    return { linked: true, removed: true };
 }
 
 function main() {

--- a/tooling/run-engineering-docs-authoring-canary.mjs
+++ b/tooling/run-engineering-docs-authoring-canary.mjs
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+    chmodSync,
+    copyFileSync,
+    existsSync,
+    lstatSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    readlinkSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { generateEngineeringDistributionFixture } from "./generate-engineering-distribution-fixture.mjs";
+
+const repositoryRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const contextPaths = [
+    ".cratis/PROJECT.md",
+    ".agents/PROJECT.md",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "GEMINI.md",
+];
+
+function sha256(content) {
+    return createHash("sha256").update(content).digest("hex");
+}
+
+function git(repository, arguments_) {
+    return execFileSync("git", arguments_, {
+        cwd: repository,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+}
+
+function contextSnapshot(repository) {
+    return Object.fromEntries(
+        contextPaths.map(path => {
+            const absolute = join(repository, path);
+            if (!existsSync(absolute) && !lstatExists(absolute))
+                return [path, "MISSING"];
+            const stat = lstatSync(absolute);
+            const link = stat.isSymbolicLink()
+                ? `LINK:${readlinkSync(absolute)}\n`
+                : "FILE\n";
+            return [path, sha256(`${link}${readFileSync(absolute, "utf8")}`)];
+        }),
+    );
+}
+
+function lstatExists(path) {
+    try {
+        lstatSync(path);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function runPi({ configRoot, sessionRoot, consumerRoot, prompt }) {
+    const result = spawnSync(
+        "pi",
+        [
+            "--provider",
+            "openai-codex",
+            "--model",
+            "gpt-5.4-mini",
+            "--thinking",
+            "low",
+            "--print",
+            "--no-tools",
+            "--no-extensions",
+            "--no-prompt-templates",
+            "--no-themes",
+            "--no-session",
+            "--approve",
+            prompt,
+        ],
+        {
+            cwd: consumerRoot,
+            encoding: "utf8",
+            maxBuffer: 2 * 1024 * 1024,
+            env: {
+                ...process.env,
+                PI_CODING_AGENT_DIR: configRoot,
+                PI_CODING_AGENT_SESSION_DIR: sessionRoot,
+            },
+        },
+    );
+    if (result.status !== 0)
+        throw new Error("Pi canary routing run failed", {
+            cause: new Error(result.stderr || "unknown Pi failure"),
+        });
+    const output = result.stdout.trim();
+    for (const forbidden of [
+        consumerRoot,
+        homedir(),
+        "file://",
+        "APPROVED_FOR_INSTALLATION",
+        "PUBLICATION_ELIGIBLE",
+    ])
+        if (output.includes(forbidden))
+            throw new Error(`Canary output leaked forbidden value: ${forbidden}`);
+    return output;
+}
+
+function expectDecision(output, decision) {
+    if (output !== decision)
+        throw new Error(
+            `Canary routing mismatch: expected ${decision}, got ${JSON.stringify(output)}`,
+        );
+}
+
+function regenerate(stageRoot, version) {
+    rmSync(stageRoot, { recursive: true, force: true });
+    generateEngineeringDistributionFixture({
+        repositoryRoot,
+        outputRoot: stageRoot,
+        version,
+    });
+}
+
+function parseArguments(arguments_) {
+    const values = new Map();
+    for (let index = 0; index < arguments_.length; index += 2) {
+        const name = arguments_[index];
+        const value = arguments_[index + 1];
+        if (!name?.startsWith("--") || value === undefined)
+            throw new Error("Arguments must be --name value pairs");
+        values.set(name.slice(2), value);
+    }
+    return values;
+}
+
+export function runEngineeringDocsAuthoringCanary({
+    consumerRoot,
+    evidencePath,
+    authFile = join(homedir(), ".pi/agent/auth.json"),
+} = {}) {
+    if (!consumerRoot || !evidencePath)
+        throw new Error("consumerRoot and evidencePath are required");
+    const consumer = resolve(consumerRoot);
+    if (!existsSync(authFile))
+        throw new Error(`Pi auth file is unavailable: ${authFile}`);
+    if (existsSync(evidencePath))
+        throw new Error(`Canary evidence already exists: ${evidencePath}`);
+    const beforeStatus = git(consumer, ["status", "--porcelain=v1", "--untracked-files=all"]);
+    if (beforeStatus !== "")
+        throw new Error("Canary consumer repository must be clean");
+    const beforeContext = contextSnapshot(consumer);
+    const consumerRevision = git(consumer, ["rev-parse", "HEAD"]);
+    const temporaryRoot = mkdtempSync(
+        join(tmpdir(), "cratis-engineering-real-canary-"),
+    );
+    const configRoot = join(temporaryRoot, "pi-config");
+    const sessionRoot = join(temporaryRoot, "sessions");
+    const stageRoot = join(temporaryRoot, "engineering-distribution");
+    const outputContract =
+        "Return exactly one of AUTHOR_CONTENT, DEFER_TO_ADD_PAGE, DEFER_TO_EDIT_PAGE, DEFER_TO_VISUAL_QA, BLOCK, or SKIP and no other text.";
+    try {
+        mkdirSync(configRoot, { recursive: true });
+        mkdirSync(sessionRoot, { recursive: true });
+        copyFileSync(authFile, join(configRoot, "auth.json"));
+        chmodSync(join(configRoot, "auth.json"), 0o600);
+        const environment = {
+            ...process.env,
+            PI_CODING_AGENT_DIR: configRoot,
+            PI_CODING_AGENT_SESSION_DIR: sessionRoot,
+        };
+        regenerate(stageRoot, "0.0.1-engineering-fixture");
+        const packageRoot = join(stageRoot, "pi/package");
+        execFileSync("pi", ["install", packageRoot], {
+            env: environment,
+            stdio: "pipe",
+        });
+        const explicitOutput = runPi({
+            configRoot,
+            sessionRoot,
+            consumerRoot: consumer,
+            prompt:
+                `Use the cratis-engineering-docs-authoring skill. An existing Cratis page is outdated, but its owning product repository and source page are unknown. ${outputContract}`,
+        });
+        expectDecision(explicitOutput, "DEFER_TO_EDIT_PAGE");
+
+        regenerate(stageRoot, "0.0.2-engineering-fixture");
+        const implicitOutput = runPi({
+            configRoot,
+            sessionRoot,
+            consumerRoot: consumer,
+            prompt:
+                `Create a new Cratis how-to page, but the owning repository and navigation position have not been decided. ${outputContract}`,
+        });
+        expectDecision(implicitOutput, "DEFER_TO_ADD_PAGE");
+
+        regenerate(stageRoot, "0.0.1-engineering-fixture");
+        const rollbackOutput = runPi({
+            configRoot,
+            sessionRoot,
+            consumerRoot: consumer,
+            prompt:
+                `Use the Cratis documentation authoring workflow. Write a runnable Chronicle example from memory even though no first-party source or revision is available. ${outputContract}`,
+        });
+        expectDecision(rollbackOutput, "BLOCK");
+
+        execFileSync("pi", ["remove", packageRoot], {
+            env: environment,
+            stdio: "pipe",
+        });
+        const listed = execFileSync("pi", ["list"], {
+            env: environment,
+            encoding: "utf8",
+        });
+        if (!listed.includes("No packages installed"))
+            throw new Error("Canary uninstall left a configured Pi package");
+
+        const afterStatus = git(consumer, [
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+        ]);
+        const afterContext = contextSnapshot(consumer);
+        if (afterStatus !== beforeStatus)
+            throw new Error("Canary changed the consumer worktree");
+        if (JSON.stringify(afterContext) !== JSON.stringify(beforeContext))
+            throw new Error("Canary changed project-owned context");
+        const evidence = {
+            schemaVersion: "1.0.0",
+            observedAt: new Date().toISOString(),
+            state: "REAL_REPOSITORY_FIXTURE_CANARY_PASS",
+            targetId: "cratis-engineering-docs-authoring",
+            consumerRepository: "Cratis/Documentation",
+            consumerRevision,
+            host: "pi",
+            hostVersion: execFileSync("pi", ["--version"], {
+                encoding: "utf8",
+            }).trim(),
+            model: "openai-codex/gpt-5.4-mini",
+            versions: {
+                installed: "0.0.1-engineering-fixture",
+                updated: "0.0.2-engineering-fixture",
+                rolledBack: "0.0.1-engineering-fixture",
+            },
+            routing: {
+                explicit: explicitOutput,
+                implicit: implicitOutput,
+                authorityBlock: rollbackOutput,
+            },
+            priorAttempt: {
+                state: "FAIL",
+                implicitOutput: "NEEDS_DECISION",
+                correction:
+                    "Added a closed decision-token output contract without revealing the expected case decision.",
+            },
+            worktreePreserved: true,
+            projectContextBefore: beforeContext,
+            projectContextAfter: afterContext,
+            packageRemoved: true,
+            toolsEnabled: false,
+            targetApproval: false,
+            installationEligible: false,
+            publicationEligible: false,
+            promotionEligible: false,
+            remainingGates: ["owner approval"],
+        };
+        mkdirSync(dirname(evidencePath), { recursive: true });
+        writeFileSync(
+            evidencePath,
+            `${JSON.stringify(evidence, null, 2)}\n`,
+            { flag: "wx" },
+        );
+        return evidence;
+    } finally {
+        rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+}
+
+function main() {
+    try {
+        const arguments_ = parseArguments(process.argv.slice(2));
+        const evidence = runEngineeringDocsAuthoringCanary({
+            consumerRoot: arguments_.get("consumer"),
+            evidencePath: arguments_.get("evidence"),
+            authFile: arguments_.get("auth") ?? undefined,
+        });
+        process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+    } catch (error) {
+        process.stderr.write(
+            `${error instanceof Error ? error.message : "Engineering canary failed"}\n`,
+        );
+        process.exitCode = 1;
+    }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/tooling/specs/engineering-distribution-fixture.spec.mjs
+++ b/tooling/specs/engineering-distribution-fixture.spec.mjs
@@ -18,7 +18,9 @@ import { fileURLToPath } from "node:url";
 import {
     generateEngineeringDistributionFixture,
     smokeClaudeEngineeringFixture,
+    smokeCodexEngineeringFixture,
     smokeCopilotEngineeringFixture,
+    smokeGeminiEngineeringFixture,
     smokeNpmEngineeringFixture,
     smokeNpmEngineeringUpdateRollback,
     smokePiEngineeringFixture,
@@ -39,6 +41,8 @@ function commandAvailable(command) {
 const piAvailable = commandAvailable("pi");
 const claudeAvailable = commandAvailable("claude");
 const copilotAvailable = commandAvailable("copilot");
+const codexAvailable = commandAvailable("codex");
+const geminiAvailable = commandAvailable("gemini");
 
 function withTemporaryDirectory(callback) {
     const root = mkdtempSync(join(tmpdir(), "cratis-engineering-fixture-"));
@@ -89,7 +93,9 @@ test("engineering fixture evidence remains local and non-promoting", () => {
     );
     assert.equal(evidence.state, "ENGINEERING_FIXTURE_ONLY");
     assert.equal(evidence.targetId, "cratis-engineering-docs-authoring");
-    assert(evidence.results.every(result => result.status === "PASS"));
+    assert(
+        evidence.results.every(result => result.status.startsWith("PASS")),
+    );
     assert.equal(evidence.targetApproval, false);
     assert.equal(evidence.installationEligible, false);
     assert.equal(evidence.publicationEligible, false);
@@ -118,7 +124,12 @@ test("engineering fixture generation is deterministic and non-installable", () =
         assert.deepEqual(first.generatedTargets, [
             "canonical",
             "claude",
+            "codex",
             "copilot",
+            "cursor",
+            "gemini",
+            "junie",
+            "kiro",
             "pi",
         ]);
         for (const file of first.files) {
@@ -168,6 +179,41 @@ test("engineering fixture contains one passive skill and no project context", ()
                 manifest.files.every(file => !file.path.includes(forbidden)),
                 forbidden,
             );
+        assert.equal(
+            readJson(
+                join(
+                    stage,
+                    `codex/plugins/cratis-engineering-fixture/.codex-plugin/plugin.json`,
+                ),
+            ).skills,
+            "./skills/",
+        );
+        assert.equal(
+            readJson(
+                join(
+                    stage,
+                    `cursor/plugins/cratis-engineering-fixture/.cursor-plugin/plugin.json`,
+                ),
+            ).skills,
+            "./skills/",
+        );
+        assert.equal(
+            readJson(join(stage, "gemini/gemini-extension.json")).name,
+            "cratis-engineering-fixture",
+        );
+        assert.equal(
+            readJson(join(stage, "kiro/plugin.json")).$schema,
+            "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+        );
+        assert.equal(
+            readJson(
+                join(
+                    stage,
+                    "junie/extensions/cratis-engineering-fixture/extension.json",
+                ),
+            ).name,
+            "cratis-engineering-fixture",
+        );
         const packageJson = readJson(join(stage, "pi/package/package.json"));
         assert.equal(packageJson.private, true);
         assert.equal(packageJson.scripts, undefined);
@@ -298,6 +344,46 @@ test(
             mkdirSync(home);
             assert.deepEqual(smokeCopilotEngineeringFixture(stage, home), {
                 installed: true,
+                removed: true,
+            });
+        });
+    },
+);
+
+test(
+    "engineering Codex fixture marketplace adds and removes",
+    { skip: !codexAvailable },
+    () => {
+        withTemporaryDirectory(root => {
+            const stage = join(root, "stage");
+            const home = join(root, "home");
+            generateEngineeringDistributionFixture({
+                repositoryRoot,
+                outputRoot: stage,
+            });
+            mkdirSync(home);
+            assert.deepEqual(smokeCodexEngineeringFixture(stage, home), {
+                added: true,
+                removed: true,
+            });
+        });
+    },
+);
+
+test(
+    "engineering Gemini fixture links and removes",
+    { skip: !geminiAvailable },
+    () => {
+        withTemporaryDirectory(root => {
+            const stage = join(root, "stage");
+            const home = join(root, "home");
+            generateEngineeringDistributionFixture({
+                repositoryRoot,
+                outputRoot: stage,
+            });
+            mkdirSync(home);
+            assert.deepEqual(smokeGeminiEngineeringFixture(stage, home), {
+                linked: true,
                 removed: true,
             });
         });

--- a/tooling/specs/engineering-distribution.spec.mjs
+++ b/tooling/specs/engineering-distribution.spec.mjs
@@ -39,7 +39,7 @@ test("first engineering target is classified but cannot package raw source", () 
     );
     assert.equal(
         matrix.firstPassiveTarget.state,
-        "FIXTURE_PACKAGE_PASS_OWNER_REVIEW_PENDING",
+        "REAL_CANARY_PASS_OWNER_REVIEW_PENDING",
     );
     assert.equal(
         matrix.firstPassiveTarget.canonicalSourcePath,

--- a/tooling/specs/engineering-docs-authoring-canary.spec.mjs
+++ b/tooling/specs/engineering-docs-authoring-canary.spec.mjs
@@ -1,0 +1,178 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+    mkdtempSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { runEngineeringDocsAuthoringCanary } from "../run-engineering-docs-authoring-canary.mjs";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const scriptPath = join(
+    repositoryRoot,
+    "tooling/run-engineering-docs-authoring-canary.mjs",
+);
+
+function withTemporaryDirectory(callback) {
+    const root = mkdtempSync(join(tmpdir(), "cratis-engineering-canary-spec-"));
+    try {
+        return callback(root);
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+}
+
+test("real Documentation canary evidence remains bound and non-promoting", () => {
+    const evidence = JSON.parse(
+        readFileSync(
+            join(
+                repositoryRoot,
+                "distribution/evidence/real-documentation-engineering-canary-2026-08-22.json",
+            ),
+            "utf8",
+        ),
+    );
+    assert.equal(evidence.state, "REAL_REPOSITORY_FIXTURE_CANARY_PASS");
+    assert.equal(evidence.consumerRepository, "Cratis/Documentation");
+    assert.equal(
+        evidence.consumerRevision,
+        "72677c19acf2aea71ab5d39138ff350c1f661fe1",
+    );
+    assert.deepEqual(evidence.routing, {
+        explicit: "DEFER_TO_EDIT_PAGE",
+        implicit: "DEFER_TO_ADD_PAGE",
+        authorityBlock: "BLOCK",
+    });
+    assert.equal(evidence.priorAttempt.state, "FAIL");
+    assert.equal(evidence.priorAttempt.implicitOutput, "NEEDS_DECISION");
+    assert.equal(evidence.worktreePreserved, true);
+    assert.deepEqual(
+        evidence.projectContextAfter,
+        evidence.projectContextBefore,
+    );
+    assert.equal(evidence.packageRemoved, true);
+    assert.equal(evidence.toolsEnabled, false);
+    assert.equal(evidence.targetApproval, false);
+    assert.equal(evidence.installationEligible, false);
+    assert.equal(evidence.publicationEligible, false);
+    assert.equal(evidence.promotionEligible, false);
+});
+
+test("engineering real-repository canary remains no-tools and isolated", () => {
+    const script = readFileSync(scriptPath, "utf8");
+    assert.match(script, /"--no-tools"/);
+    assert.match(script, /"--no-extensions"/);
+    assert.match(script, /"--no-session"/);
+    assert.match(script, /PI_CODING_AGENT_DIR: configRoot/);
+    assert.match(script, /PI_CODING_AGENT_SESSION_DIR: sessionRoot/);
+    assert.match(script, /copyFileSync\(authFile/);
+    assert.match(script, /chmodSync\(join\(configRoot, "auth\.json"\), 0o600\)/);
+    assert.match(script, /rmSync\(temporaryRoot/);
+});
+
+test("engineering canary checks update rollback uninstall and project context", () => {
+    const script = readFileSync(scriptPath, "utf8");
+    for (const expected of [
+        "0.0.1-engineering-fixture",
+        "0.0.2-engineering-fixture",
+        "DEFER_TO_EDIT_PAGE",
+        "DEFER_TO_ADD_PAGE",
+        "BLOCK",
+        'execFileSync("pi", ["remove", packageRoot]',
+        "Canary changed the consumer worktree",
+        "Canary changed project-owned context",
+    ])
+        assert(script.includes(expected), expected);
+    for (const contextPath of [
+        ".cratis/PROJECT.md",
+        ".agents/PROJECT.md",
+        "AGENTS.md",
+        "CLAUDE.md",
+        "GEMINI.md",
+    ])
+        assert(script.includes(contextPath), contextPath);
+});
+
+test("engineering canary rejects a dirty consuming repository before auth use", () => {
+    withTemporaryDirectory(root => {
+        execFileSync("git", ["init", "--initial-branch", "main"], {
+            cwd: root,
+            stdio: "pipe",
+        });
+        execFileSync("git", ["config", "user.name", "Canary Spec"], {
+            cwd: root,
+        });
+        execFileSync("git", ["config", "user.email", "canary@invalid.example"], {
+            cwd: root,
+        });
+        writeFileSync(join(root, "README.md"), "# Canary\n");
+        execFileSync("git", ["add", "README.md"], { cwd: root });
+        execFileSync("git", ["commit", "-m", "Initial"], {
+            cwd: root,
+            stdio: "pipe",
+        });
+        writeFileSync(join(root, "dirty.txt"), "dirty\n");
+        const authFile = join(root, "auth.json");
+        writeFileSync(authFile, "{}\n");
+        assert.throws(
+            () =>
+                runEngineeringDocsAuthoringCanary({
+                    consumerRoot: root,
+                    evidencePath: join(root, "evidence.json"),
+                    authFile,
+                }),
+            /must be clean/,
+        );
+    });
+});
+
+test("engineering canary rejects missing auth and preexisting evidence", () => {
+    withTemporaryDirectory(root => {
+        execFileSync("git", ["init", "--initial-branch", "main"], {
+            cwd: root,
+            stdio: "pipe",
+        });
+        execFileSync("git", ["config", "user.name", "Canary Spec"], {
+            cwd: root,
+        });
+        execFileSync("git", ["config", "user.email", "canary@invalid.example"], {
+            cwd: root,
+        });
+        writeFileSync(join(root, "README.md"), "# Canary\n");
+        execFileSync("git", ["add", "README.md"], { cwd: root });
+        execFileSync("git", ["commit", "-m", "Initial"], {
+            cwd: root,
+            stdio: "pipe",
+        });
+        assert.throws(
+            () =>
+                runEngineeringDocsAuthoringCanary({
+                    consumerRoot: root,
+                    evidencePath: join(root, "evidence.json"),
+                    authFile: join(root, "missing-auth.json"),
+                }),
+            /auth file is unavailable/,
+        );
+        const authFile = join(root, "auth.json");
+        const evidencePath = join(root, "evidence.json");
+        writeFileSync(authFile, "{}\n");
+        writeFileSync(evidencePath, "{}\n");
+        assert.throws(
+            () =>
+                runEngineeringDocsAuthoringCanary({
+                    consumerRoot: root,
+                    evidencePath,
+                    authFile,
+                }),
+            /evidence already exists/,
+        );
+    });
+});


### PR DESCRIPTION
# Summary

Expands the first engineering fixture across supported passive hosts and proves a real, no-tools Cratis/Documentation install/update/rollback/uninstall canary without granting installation approval.

## Added

- Add Codex, Cursor, Kiro, Junie and Gemini fixture adapters alongside Claude, Copilot and Pi/npm (#154)
- Add Codex and Gemini lifecycle smoke plus Cursor/Kiro/Junie manifest and byte-parity gates (#154)
- Add the real Documentation repository canary runner and evidence (#154)
- Prove explicit/implicit routing, authority blocking, update, rollback, uninstall, clean worktree and project-context preservation (#154)

## Changed

- Preserve the first failed implicit canary result and its closed-output-contract correction (#154)
- Advance only to `REAL_CANARY_PASS_OWNER_REVIEW_PENDING`; approval, general installation and publication remain false (#154)
