### PR TITLE
Classify documentation companion targets

### DIFF
--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
@@ -1742,3 +1742,34 @@ still point at legacy source until immutable commits are available, and their
 target classifications/evaluations remain incomplete. Next: merge, bind each
 source to its immutable canonical revision, classify effects/profiles/dependencies,
 then freeze and run companion evaluations before fixture packaging.
+
+## 46. Documentation companion classification — 2026-08-22
+
+Canonical companion sources merged with green CI in Cratis/AI#157. Their
+existing catalog source identities now point to the canonical engineering paths
+at immutable revision `684d03755bacd40af95463b81b4a0c8b9f088ec1`, with one
+repository-snapshot evidence record per source. Legacy `.ai` copies remain
+inventory-only.
+
+Both companion targets are now classified as passive, user/model-invoked,
+product-neutral journeys for contributor/maintainer personas on direct-skill and
+IDE surfaces across application/client/corpus/framework repositories:
+
+- add-page has confirmed reversible create-page and modify-navigation effects;
+- edit-page has one confirmed reversible source/navigation modify effect;
+- both require repository/task-owner authorization and before-effect path
+  confirmation;
+- both soft-depend on docs-authoring and optionally depend on visual QA, with
+  explicit degrade/omit behavior when absent;
+- both use `cratis-ai-composition` / `capability-composition` source authority
+  and the clean-room authoring contract;
+- both allow only `SKILL.md`, references, assets, and licenses while scripts,
+  evals, rules, agents, prompts, hooks, tooling, workflows, and local
+  configuration remain forbidden;
+- behavior, trigger, negative-trigger, and collision evidence remain missing;
+- approval remains candidate and `includeInRuntime` remains false.
+
+The matrix records both as `SOURCE_RECONCILED_NOT_EVALUATED`; raw source
+packaging remains forbidden. Next: freeze calibration and held-out routing
+corpora for both targets, run repeated evidence, independently review it, then
+consider fixture packaging.

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
@@ -590,8 +590,11 @@ Evidence and exact next actions are in
 - [x] Reconcile the new-page placement and existing-page source-discovery
   companion targets into self-contained canonical passive sources with exact
   routing cases and zero model runs.
-- [ ] Bind and classify those companions at immutable revisions, then evaluate
-  them before adding them to an engineering fixture package.
+- [x] Bind and classify both companion sources at immutable revision `684d037`,
+  including profiles, confirmed reversible effects, soft authoring and optional
+  visual-QA dependencies, source/authoring contracts, and runtime exclusions.
+- [ ] Freeze and run companion calibration/held-out evaluations before adding
+  either target to an engineering fixture package.
 - [ ] Provision the repository-scoped App credentials from Workflows#72 before
   any generated update PR, tag, release, or publication operation.
 - [ ] Keep publication and retirement disabled until explicit approvals pass.

--- a/catalog/generated/human-catalog/catalog.json
+++ b/catalog/generated/human-catalog/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractVersion": 1,
   "disclaimer": "Catalog inclusion, evaluation evidence, bundle generation, or publication does not grant runtime permission or approval.",
-  "inputDigest": "b0cc5abb0c2f000405b0762883e765b7ec52945c1706100744400ccc25c91318",
+  "inputDigest": "f1fb529f7503aaca898097161fd408ab62f662a8441c767f86fc82b2f5803f30",
   "capabilities": [
     {
       "id": "cratis-application-react-specifications",

--- a/catalog/generated/human-catalog/manifest.json
+++ b/catalog/generated/human-catalog/manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "contractVersion": 1,
-  "inputDigest": "b0cc5abb0c2f000405b0762883e765b7ec52945c1706100744400ccc25c91318",
+  "inputDigest": "f1fb529f7503aaca898097161fd408ab62f662a8441c767f86fc82b2f5803f30",
   "files": [
     {
       "path": "CATALOG.md",
@@ -11,7 +11,7 @@
     {
       "path": "catalog.json",
       "size": 64765,
-      "sha256": "2b90e96be77d6465a07f1ebdfb3b7f55e71c196c625cc3d61fb73ceb905d5b5d"
+      "sha256": "108b442c6e358d2415b18f53c9614d11e9edb51807528228faa568e99289de0a"
     }
   ]
 }

--- a/catalog/v2/evidence.json
+++ b/catalog/v2/evidence.json
@@ -50,6 +50,26 @@
       "immutableRevision": "b795d5307e20f7f7458a67708b4f26975e223796"
     },
     {
+      "id": "engineering-docs-add-page-source-684d037",
+      "officialUrl": "https://github.com/Cratis/AI/tree/684d03755bacd40af95463b81b4a0c8b9f088ec1/engineering/skills/cratis-engineering-docs-add-page",
+      "sourceKind": "repository-snapshot",
+      "verifiedOn": "2026-08-22",
+      "expiresOn": "2027-08-22",
+      "applicableVersion": "684d03755bacd40af95463b81b4a0c8b9f088ec1",
+      "confidence": "high",
+      "immutableRevision": "684d03755bacd40af95463b81b4a0c8b9f088ec1"
+    },
+    {
+      "id": "engineering-docs-edit-page-source-684d037",
+      "officialUrl": "https://github.com/Cratis/AI/tree/684d03755bacd40af95463b81b4a0c8b9f088ec1/engineering/skills/cratis-engineering-docs-edit-page",
+      "sourceKind": "repository-snapshot",
+      "verifiedOn": "2026-08-22",
+      "expiresOn": "2027-08-22",
+      "applicableVersion": "684d03755bacd40af95463b81b4a0c8b9f088ec1",
+      "confidence": "high",
+      "immutableRevision": "684d03755bacd40af95463b81b4a0c8b9f088ec1"
+    },
+    {
       "id": "engineering-docs-authoring-source-f58bcf7",
       "officialUrl": "https://github.com/Cratis/AI/tree/f58bcf7f5cc9fc0e11305ada3b5ecb6fa20953e9/engineering/skills/cratis-engineering-docs-authoring",
       "sourceKind": "repository-snapshot",

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "cd5976214c0ecc403db700c3142b1c535ad841eee815935b1aa9b877f695bd95",
+  "indexDigest": "d47670aaf9440306f8e212d0c152af8b14f56d706c025636e9ddbc6ff2ad3ead",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/catalog/v2/sources.json
+++ b/catalog/v2/sources.json
@@ -42,20 +42,23 @@
     },
     {
       "id": "add-cratis-docs-page",
-      "sourcePath": ".ai/skills/add-cratis-docs-page",
+      "sourcePath": "engineering/skills/cratis-engineering-docs-add-page",
       "artifactType": "agent-skill-source",
       "currentOwner": "reusable Cratis engineering behavior",
       "targetOwner": "reusable Cratis engineering behavior",
       "audience": "cratis-engineering",
       "bundledPaths": [
-        ".ai/skills/add-cratis-docs-page/SKILL.md"
+        "engineering/skills/cratis-engineering-docs-add-page/LICENSE",
+        "engineering/skills/cratis-engineering-docs-add-page/SKILL.md",
+        "engineering/skills/cratis-engineering-docs-add-page/references/ownership-and-navigation.md"
       ],
-      "sourceRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-      "contentDigest": "af8a22b279a7075c110fd6bf4197275006678699e46b154f6215784fb52b057d",
+      "sourceRevision": "684d03755bacd40af95463b81b4a0c8b9f088ec1",
+      "contentDigest": "60bb6acfc3af73b3c8d0e300f2620d74999ad8f0bc47dbaf207783225ae1f085",
       "publicationApproval": false,
       "evidenceIds": [
         "repo-main-b795d53",
-        "reevaluation-authority"
+        "reevaluation-authority",
+        "engineering-docs-add-page-source-684d037"
       ]
     },
     {
@@ -420,20 +423,23 @@
     },
     {
       "id": "edit-cratis-docs",
-      "sourcePath": ".ai/skills/edit-cratis-docs",
+      "sourcePath": "engineering/skills/cratis-engineering-docs-edit-page",
       "artifactType": "agent-skill-source",
       "currentOwner": "reusable Cratis engineering behavior",
       "targetOwner": "reusable Cratis engineering behavior",
       "audience": "cratis-engineering",
       "bundledPaths": [
-        ".ai/skills/edit-cratis-docs/SKILL.md"
+        "engineering/skills/cratis-engineering-docs-edit-page/LICENSE",
+        "engineering/skills/cratis-engineering-docs-edit-page/SKILL.md",
+        "engineering/skills/cratis-engineering-docs-edit-page/references/source-discovery.md"
       ],
-      "sourceRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-      "contentDigest": "d07be3bed6a4cc4cc3d72548baafd211826160b168fa7a4b7e39d5c950063b07",
+      "sourceRevision": "684d03755bacd40af95463b81b4a0c8b9f088ec1",
+      "contentDigest": "c6b98ea12de1607871036d3f421ad3fc5e05149fcb21e7bbf83d3a613153357e",
       "publicationApproval": false,
       "evidenceIds": [
         "repo-main-b795d53",
-        "reevaluation-authority"
+        "reevaluation-authority",
+        "engineering-docs-edit-page-source-684d037"
       ]
     },
     {

--- a/catalog/v2/targets.json
+++ b/catalog/v2/targets.json
@@ -3862,41 +3862,138 @@
       "languages": [
         "language-agnostic"
       ],
-      "capabilityKind": "unclassified",
-      "invocation": "unclassified",
+      "capabilityKind": "journey",
+      "invocation": "both",
       "lifecycle": "candidate",
       "architectures": {
-        "state": "unclassified",
-        "ids": [],
-        "reason": "Architecture requires reviewed target classification."
+        "state": "applicable",
+        "ids": [
+          "product-neutral"
+        ],
+        "reason": "Documentation integration applies across Cratis products without assuming an application architecture."
       },
       "personas": {
-        "state": "unclassified",
-        "ids": [],
-        "reason": "Persona requires reviewed target classification."
+        "state": "applicable",
+        "ids": [
+          "contributor",
+          "maintainer"
+        ],
+        "reason": "Contributors and maintainers integrate reviewed Cratis documentation."
       },
       "surfaces": {
-        "state": "unclassified",
-        "ids": [],
-        "reason": "Surface requires reviewed target classification."
+        "state": "applicable",
+        "ids": [
+          "direct-agent-skills",
+          "ide"
+        ],
+        "reason": "The workflow is an instruction-only skill used from an agent or IDE session."
       },
       "repositoryProfiles": {
-        "state": "unclassified",
-        "ids": [],
-        "reason": "Repository profile requires reviewed target classification."
+        "state": "applicable",
+        "ids": [
+          "application",
+          "client",
+          "corpus",
+          "framework"
+        ],
+        "reason": "Documentation can be owned by application, client, framework, or corpus repositories."
       },
       "trust": {
         "class": "passive",
-        "assessmentState": "unclassified",
-        "effects": []
+        "assessmentState": "assessed",
+        "effects": [
+          {
+            "id": "create-documentation-page",
+            "operation": "create",
+            "resourceBoundary": "current repository worktree",
+            "scope": "one approved documentation source page",
+            "dataClassifications": [
+              "internal",
+              "public"
+            ],
+            "reversible": true,
+            "rollbackOrCompensation": "Delete the uncommitted page or revert the dedicated documentation commit.",
+            "confirmation": {
+              "required": true,
+              "timing": "before-effect",
+              "reason": "The repository maintainer confirms the exact documentation paths before files change."
+            },
+            "authorization": {
+              "required": true,
+              "authority": "Repository maintainer or task owner",
+              "evidenceIds": [
+                "ai-126"
+              ]
+            },
+            "evidenceIds": [
+              "repo-main-b795d53",
+              "reevaluation-authority"
+            ]
+          },
+          {
+            "id": "modify-documentation-navigation",
+            "operation": "modify",
+            "resourceBoundary": "current repository worktree",
+            "scope": "owning ToC and site navigation entries required for the approved page",
+            "dataClassifications": [
+              "internal",
+              "public"
+            ],
+            "reversible": true,
+            "rollbackOrCompensation": "Restore the prior navigation bytes or revert the dedicated documentation commit.",
+            "confirmation": {
+              "required": true,
+              "timing": "before-effect",
+              "reason": "The repository maintainer confirms the exact documentation paths before files change."
+            },
+            "authorization": {
+              "required": true,
+              "authority": "Repository maintainer or task owner",
+              "evidenceIds": [
+                "ai-126"
+              ]
+            },
+            "evidenceIds": [
+              "repo-main-b795d53",
+              "reevaluation-authority"
+            ]
+          }
+        ]
       },
-      "dependencyClassificationState": "unclassified",
-      "dependencyEdges": [],
-      "sourceContractState": "unclassified",
-      "sourceContractIds": [],
-      "sourceAuthoritySubjects": [],
-      "authoringContractState": "unclassified",
-      "authoringContractIds": [],
+      "dependencyClassificationState": "classified",
+      "dependencyEdges": [
+        {
+          "dependencyId": "cratis-engineering-docs-authoring",
+          "category": "target",
+          "strength": "soft",
+          "reason": "A new page needs approved content after placement is known.",
+          "missingBehavior": {
+            "action": "degrade",
+            "description": "Place only already approved content; otherwise stop after the placement plan."
+          }
+        },
+        {
+          "dependencyId": "cratis-engineering-docs-visual-qa",
+          "category": "target",
+          "strength": "optional",
+          "reason": "Rendered visual review is a separate completion enhancement.",
+          "missingBehavior": {
+            "action": "omit",
+            "description": "Report visual QA as outstanding without claiming rendered quality."
+          }
+        }
+      ],
+      "sourceContractState": "classified",
+      "sourceContractIds": [
+        "cratis-ai-composition"
+      ],
+      "sourceAuthoritySubjects": [
+        "capability-composition"
+      ],
+      "authoringContractState": "classified",
+      "authoringContractIds": [
+        "cratis-skill-clean-room-v1"
+      ],
       "capability": "Cratis documentation page creation",
       "positiveTriggerIntent": "Use by Cratis maintainers to add a source-owned product documentation page.",
       "nearMissExclusions": [
@@ -3907,12 +4004,20 @@
         "cratis-engineering-docs-authoring"
       ],
       "dependencies": {
-        "targets": [],
+        "targets": [
+          "cratis-engineering-docs-authoring",
+          "cratis-engineering-docs-visual-qa"
+        ],
         "internalArtifacts": [],
         "externalTools": []
       },
       "runtimePayloadPolicy": {
-        "allowed": [],
+        "allowed": [
+          "SKILL.md",
+          "references/**",
+          "assets/**",
+          "LICENSE*"
+        ],
         "forbidden": [
           "scripts/**",
           "evals/**",
@@ -4075,48 +4180,7 @@
         ]
       },
       "dependencyClassificationState": "classified",
-      "dependencyEdges": [
-        {
-          "dependencyId": ".ai/rules/documentation-structure-and-formatting.md",
-          "category": "internal-artifact",
-          "strength": "hard",
-          "reason": "The rule defines the site-compatible document structure.",
-          "missingBehavior": {
-            "action": "block",
-            "description": "Stop rather than inventing documentation structure."
-          }
-        },
-        {
-          "dependencyId": ".ai/rules/writing-cratis-docs.md",
-          "category": "internal-artifact",
-          "strength": "hard",
-          "reason": "The rule defines the Cratis documentation voice and quality bar.",
-          "missingBehavior": {
-            "action": "block",
-            "description": "Stop rather than drafting without the Cratis writing contract."
-          }
-        },
-        {
-          "dependencyId": "cratis-engineering-docs-add-page",
-          "category": "target",
-          "strength": "soft",
-          "reason": "New pages need repository placement and navigation wiring.",
-          "missingBehavior": {
-            "action": "degrade",
-            "description": "Draft content only and disclose that placement and navigation remain unresolved."
-          }
-        },
-        {
-          "dependencyId": "cratis-engineering-docs-edit-page",
-          "category": "target",
-          "strength": "soft",
-          "reason": "Existing pages need source-of-truth discovery and sync guidance.",
-          "missingBehavior": {
-            "action": "degrade",
-            "description": "Draft content only and disclose that source discovery and integration remain unresolved."
-          }
-        }
-      ],
+      "dependencyEdges": [],
       "sourceContractState": "classified",
       "sourceContractIds": [
         "cratis-ai-composition"
@@ -4138,14 +4202,8 @@
         "cratis-engineering-docs-edit-page"
       ],
       "dependencies": {
-        "targets": [
-          "cratis-engineering-docs-add-page",
-          "cratis-engineering-docs-edit-page"
-        ],
-        "internalArtifacts": [
-          ".ai/rules/documentation-structure-and-formatting.md",
-          ".ai/rules/writing-cratis-docs.md"
-        ],
+        "targets": [],
+        "internalArtifacts": [],
         "externalTools": []
       },
       "runtimePayloadPolicy": {
@@ -4224,41 +4282,110 @@
       "languages": [
         "language-agnostic"
       ],
-      "capabilityKind": "unclassified",
-      "invocation": "unclassified",
+      "capabilityKind": "journey",
+      "invocation": "both",
       "lifecycle": "candidate",
       "architectures": {
-        "state": "unclassified",
-        "ids": [],
-        "reason": "Architecture requires reviewed target classification."
+        "state": "applicable",
+        "ids": [
+          "product-neutral"
+        ],
+        "reason": "Documentation integration applies across Cratis products without assuming an application architecture."
       },
       "personas": {
-        "state": "unclassified",
-        "ids": [],
-        "reason": "Persona requires reviewed target classification."
+        "state": "applicable",
+        "ids": [
+          "contributor",
+          "maintainer"
+        ],
+        "reason": "Contributors and maintainers integrate reviewed Cratis documentation."
       },
       "surfaces": {
-        "state": "unclassified",
-        "ids": [],
-        "reason": "Surface requires reviewed target classification."
+        "state": "applicable",
+        "ids": [
+          "direct-agent-skills",
+          "ide"
+        ],
+        "reason": "The workflow is an instruction-only skill used from an agent or IDE session."
       },
       "repositoryProfiles": {
-        "state": "unclassified",
-        "ids": [],
-        "reason": "Repository profile requires reviewed target classification."
+        "state": "applicable",
+        "ids": [
+          "application",
+          "client",
+          "corpus",
+          "framework"
+        ],
+        "reason": "Documentation can be owned by application, client, framework, or corpus repositories."
       },
       "trust": {
         "class": "passive",
-        "assessmentState": "unclassified",
-        "effects": []
+        "assessmentState": "assessed",
+        "effects": [
+          {
+            "id": "modify-documentation-page",
+            "operation": "modify",
+            "resourceBoundary": "current repository worktree",
+            "scope": "one authoritative existing documentation source page and navigation only when its title or slug changes",
+            "dataClassifications": [
+              "internal",
+              "public"
+            ],
+            "reversible": true,
+            "rollbackOrCompensation": "Restore the prior source/navigation bytes or revert the dedicated documentation commit.",
+            "confirmation": {
+              "required": true,
+              "timing": "before-effect",
+              "reason": "The repository maintainer confirms the exact documentation paths before files change."
+            },
+            "authorization": {
+              "required": true,
+              "authority": "Repository maintainer or task owner",
+              "evidenceIds": [
+                "ai-126"
+              ]
+            },
+            "evidenceIds": [
+              "repo-main-b795d53",
+              "reevaluation-authority"
+            ]
+          }
+        ]
       },
-      "dependencyClassificationState": "unclassified",
-      "dependencyEdges": [],
-      "sourceContractState": "unclassified",
-      "sourceContractIds": [],
-      "sourceAuthoritySubjects": [],
-      "authoringContractState": "unclassified",
-      "authoringContractIds": [],
+      "dependencyClassificationState": "classified",
+      "dependencyEdges": [
+        {
+          "dependencyId": "cratis-engineering-docs-authoring",
+          "category": "target",
+          "strength": "soft",
+          "reason": "Substantial content redesign is delegated to the authoring workflow.",
+          "missingBehavior": {
+            "action": "degrade",
+            "description": "Apply only narrow source-backed corrections; block substantial redesign."
+          }
+        },
+        {
+          "dependencyId": "cratis-engineering-docs-visual-qa",
+          "category": "target",
+          "strength": "optional",
+          "reason": "Rendered visual review is a separate completion enhancement.",
+          "missingBehavior": {
+            "action": "omit",
+            "description": "Report visual QA as outstanding without claiming rendered quality."
+          }
+        }
+      ],
+      "sourceContractState": "classified",
+      "sourceContractIds": [
+        "cratis-ai-composition"
+      ],
+      "sourceAuthoritySubjects": [
+        "capability-composition"
+      ],
+      "authoringContractState": "classified",
+      "authoringContractIds": [
+        "cratis-skill-clean-room-v1"
+      ],
       "capability": "Cratis documentation page editing",
       "positiveTriggerIntent": "Use by Cratis maintainers to edit the source-owned copy of an existing documentation page.",
       "nearMissExclusions": [
@@ -4269,12 +4396,20 @@
         "cratis-engineering-docs-visual-qa"
       ],
       "dependencies": {
-        "targets": [],
+        "targets": [
+          "cratis-engineering-docs-authoring",
+          "cratis-engineering-docs-visual-qa"
+        ],
         "internalArtifacts": [],
         "externalTools": []
       },
       "runtimePayloadPolicy": {
-        "allowed": [],
+        "allowed": [
+          "SKILL.md",
+          "references/**",
+          "assets/**",
+          "LICENSE*"
+        ],
         "forbidden": [
           "scripts/**",
           "evals/**",

--- a/distribution/engineering-artifact-matrix.json
+++ b/distribution/engineering-artifact-matrix.json
@@ -9,6 +9,20 @@
     "canonicalSourcePath": "engineering/skills/cratis-engineering-docs-authoring",
     "rawSourcePackagingAllowed": false
   },
+  "companionTargets": [
+    {
+      "targetId": "cratis-engineering-docs-add-page",
+      "state": "SOURCE_RECONCILED_NOT_EVALUATED",
+      "canonicalSourcePath": "engineering/skills/cratis-engineering-docs-add-page",
+      "rawSourcePackagingAllowed": false
+    },
+    {
+      "targetId": "cratis-engineering-docs-edit-page",
+      "state": "SOURCE_RECONCILED_NOT_EVALUATED",
+      "canonicalSourcePath": "engineering/skills/cratis-engineering-docs-edit-page",
+      "rawSourcePackagingAllowed": false
+    }
+  ],
   "packageBoundaries": [
     {
       "id": "engineering-passive-low-trust",

--- a/tooling/generate-catalog-v2.mjs
+++ b/tooling/generate-catalog-v2.mjs
@@ -43,6 +43,26 @@ const internalTargets = new Map([
 
 const sourceOverrides = new Map([
     [
+        "add-cratis-docs-page",
+        {
+            sourcePath:
+                "engineering/skills/cratis-engineering-docs-add-page",
+            sourceRevision:
+                "684d03755bacd40af95463b81b4a0c8b9f088ec1",
+            evidenceId: "engineering-docs-add-page-source-684d037",
+        },
+    ],
+    [
+        "edit-cratis-docs",
+        {
+            sourcePath:
+                "engineering/skills/cratis-engineering-docs-edit-page",
+            sourceRevision:
+                "684d03755bacd40af95463b81b4a0c8b9f088ec1",
+            evidenceId: "engineering-docs-edit-page-source-684d037",
+        },
+    ],
+    [
         "write-documentation",
         {
             sourcePath: "engineering/skills/cratis-engineering-docs-authoring",
@@ -52,7 +72,157 @@ const sourceOverrides = new Map([
     ],
 ]);
 
+function documentationEffect(id, operation, scope, rollback) {
+    return {
+        id,
+        operation,
+        resourceBoundary: "current repository worktree",
+        scope,
+        dataClassifications: ["internal", "public"],
+        reversible: true,
+        rollbackOrCompensation: rollback,
+        confirmation: {
+            required: true,
+            timing: "before-effect",
+            reason: "The repository maintainer confirms the exact documentation paths before files change.",
+        },
+        authorization: {
+            required: true,
+            authority: "Repository maintainer or task owner",
+            evidenceIds: ["ai-126"],
+        },
+        evidenceIds: ["repo-main-b795d53", "reevaluation-authority"],
+    };
+}
+
+function documentationCompanionClassification({
+    effects,
+    dependencyEdges,
+    targetDependencies,
+}) {
+    return {
+        capabilityKind: "journey",
+        invocation: "both",
+        architectures: {
+            state: "applicable",
+            ids: ["product-neutral"],
+            reason: "Documentation integration applies across Cratis products without assuming an application architecture.",
+        },
+        personas: {
+            state: "applicable",
+            ids: ["contributor", "maintainer"],
+            reason: "Contributors and maintainers integrate reviewed Cratis documentation.",
+        },
+        surfaces: {
+            state: "applicable",
+            ids: ["direct-agent-skills", "ide"],
+            reason: "The workflow is an instruction-only skill used from an agent or IDE session.",
+        },
+        repositoryProfiles: {
+            state: "applicable",
+            ids: ["application", "client", "corpus", "framework"],
+            reason: "Documentation can be owned by application, client, framework, or corpus repositories.",
+        },
+        trust: {
+            class: "passive",
+            assessmentState: "assessed",
+            effects,
+        },
+        dependencyEdges,
+        targetDependencies,
+        internalArtifacts: [],
+        sourceContractIds: ["cratis-ai-composition"],
+        sourceAuthoritySubjects: ["capability-composition"],
+        authoringContractIds: ["cratis-skill-clean-room-v1"],
+        runtimeAllowed: ["SKILL.md", "references/**", "assets/**", "LICENSE*"],
+    };
+}
+
 const engineeringClassifications = new Map([
+    [
+        "cratis-engineering-docs-add-page",
+        documentationCompanionClassification({
+            effects: [
+                documentationEffect(
+                    "create-documentation-page",
+                    "create",
+                    "one approved documentation source page",
+                    "Delete the uncommitted page or revert the dedicated documentation commit.",
+                ),
+                documentationEffect(
+                    "modify-documentation-navigation",
+                    "modify",
+                    "owning ToC and site navigation entries required for the approved page",
+                    "Restore the prior navigation bytes or revert the dedicated documentation commit.",
+                ),
+            ],
+            dependencyEdges: [
+                {
+                    dependencyId: "cratis-engineering-docs-authoring",
+                    category: "target",
+                    strength: "soft",
+                    reason: "A new page needs approved content after placement is known.",
+                    missingBehavior: {
+                        action: "degrade",
+                        description: "Place only already approved content; otherwise stop after the placement plan.",
+                    },
+                },
+                {
+                    dependencyId: "cratis-engineering-docs-visual-qa",
+                    category: "target",
+                    strength: "optional",
+                    reason: "Rendered visual review is a separate completion enhancement.",
+                    missingBehavior: {
+                        action: "omit",
+                        description: "Report visual QA as outstanding without claiming rendered quality.",
+                    },
+                },
+            ],
+            targetDependencies: [
+                "cratis-engineering-docs-authoring",
+                "cratis-engineering-docs-visual-qa",
+            ],
+        }),
+    ],
+    [
+        "cratis-engineering-docs-edit-page",
+        documentationCompanionClassification({
+            effects: [
+                documentationEffect(
+                    "modify-documentation-page",
+                    "modify",
+                    "one authoritative existing documentation source page and navigation only when its title or slug changes",
+                    "Restore the prior source/navigation bytes or revert the dedicated documentation commit.",
+                ),
+            ],
+            dependencyEdges: [
+                {
+                    dependencyId: "cratis-engineering-docs-authoring",
+                    category: "target",
+                    strength: "soft",
+                    reason: "Substantial content redesign is delegated to the authoring workflow.",
+                    missingBehavior: {
+                        action: "degrade",
+                        description: "Apply only narrow source-backed corrections; block substantial redesign.",
+                    },
+                },
+                {
+                    dependencyId: "cratis-engineering-docs-visual-qa",
+                    category: "target",
+                    strength: "optional",
+                    reason: "Rendered visual review is a separate completion enhancement.",
+                    missingBehavior: {
+                        action: "omit",
+                        description: "Report visual QA as outstanding without claiming rendered quality.",
+                    },
+                },
+            ],
+            targetDependencies: [
+                "cratis-engineering-docs-authoring",
+                "cratis-engineering-docs-visual-qa",
+            ],
+        }),
+    ],
     [
         "cratis-engineering-docs-authoring",
         {
@@ -132,61 +302,9 @@ const engineeringClassifications = new Map([
                     },
                 ],
             },
-            dependencyEdges: [
-                {
-                    dependencyId:
-                        ".ai/rules/documentation-structure-and-formatting.md",
-                    category: "internal-artifact",
-                    strength: "hard",
-                    reason: "The rule defines the site-compatible document structure.",
-                    missingBehavior: {
-                        action: "block",
-                        description:
-                            "Stop rather than inventing documentation structure.",
-                    },
-                },
-                {
-                    dependencyId: ".ai/rules/writing-cratis-docs.md",
-                    category: "internal-artifact",
-                    strength: "hard",
-                    reason: "The rule defines the Cratis documentation voice and quality bar.",
-                    missingBehavior: {
-                        action: "block",
-                        description:
-                            "Stop rather than drafting without the Cratis writing contract.",
-                    },
-                },
-                {
-                    dependencyId: "cratis-engineering-docs-add-page",
-                    category: "target",
-                    strength: "soft",
-                    reason: "New pages need repository placement and navigation wiring.",
-                    missingBehavior: {
-                        action: "degrade",
-                        description:
-                            "Draft content only and disclose that placement and navigation remain unresolved.",
-                    },
-                },
-                {
-                    dependencyId: "cratis-engineering-docs-edit-page",
-                    category: "target",
-                    strength: "soft",
-                    reason: "Existing pages need source-of-truth discovery and sync guidance.",
-                    missingBehavior: {
-                        action: "degrade",
-                        description:
-                            "Draft content only and disclose that source discovery and integration remain unresolved.",
-                    },
-                },
-            ],
-            targetDependencies: [
-                "cratis-engineering-docs-add-page",
-                "cratis-engineering-docs-edit-page",
-            ],
-            internalArtifacts: [
-                ".ai/rules/documentation-structure-and-formatting.md",
-                ".ai/rules/writing-cratis-docs.md",
-            ],
+            dependencyEdges: [],
+            targetDependencies: [],
+            internalArtifacts: [],
             sourceContractIds: ["cratis-ai-composition"],
             sourceAuthoritySubjects: ["capability-composition"],
             routingEvaluationEvidenceId:
@@ -953,7 +1071,8 @@ const targets = allTargetIds.map((targetId) => {
                     : "missing",
                 evidenceIds: [],
             },
-            positiveTrigger: engineeringClassification
+            positiveTrigger:
+                engineeringClassification?.routingEvaluationEvidenceId
                 ? {
                       status: "passing",
                       evidenceIds: [
@@ -961,7 +1080,8 @@ const targets = allTargetIds.map((targetId) => {
                       ],
                   }
                 : { status: "missing", evidenceIds: [] },
-            negativeTrigger: engineeringClassification
+            negativeTrigger:
+                engineeringClassification?.routingEvaluationEvidenceId
                 ? {
                       status: "passing",
                       evidenceIds: [
@@ -969,7 +1089,8 @@ const targets = allTargetIds.map((targetId) => {
                       ],
                   }
                 : { status: "missing", evidenceIds: [] },
-            collision: engineeringClassification
+            collision:
+                engineeringClassification?.routingEvaluationEvidenceId
                 ? {
                       status: "passing",
                       evidenceIds: [
@@ -1277,6 +1398,28 @@ const evidence = [
         applicableVersion: revision,
         confidence: "high",
         immutableRevision: revision,
+    },
+    {
+        id: "engineering-docs-add-page-source-684d037",
+        officialUrl:
+            "https://github.com/Cratis/AI/tree/684d03755bacd40af95463b81b4a0c8b9f088ec1/engineering/skills/cratis-engineering-docs-add-page",
+        sourceKind: "repository-snapshot",
+        verifiedOn: "2026-08-22",
+        expiresOn: "2027-08-22",
+        applicableVersion: "684d03755bacd40af95463b81b4a0c8b9f088ec1",
+        confidence: "high",
+        immutableRevision: "684d03755bacd40af95463b81b4a0c8b9f088ec1",
+    },
+    {
+        id: "engineering-docs-edit-page-source-684d037",
+        officialUrl:
+            "https://github.com/Cratis/AI/tree/684d03755bacd40af95463b81b4a0c8b9f088ec1/engineering/skills/cratis-engineering-docs-edit-page",
+        sourceKind: "repository-snapshot",
+        verifiedOn: "2026-08-22",
+        expiresOn: "2027-08-22",
+        applicableVersion: "684d03755bacd40af95463b81b4a0c8b9f088ec1",
+        confidence: "high",
+        immutableRevision: "684d03755bacd40af95463b81b4a0c8b9f088ec1",
     },
     {
         id: "engineering-docs-authoring-source-f58bcf7",

--- a/tooling/specs/catalog-v2-validation.spec.mjs
+++ b/tooling/specs/catalog-v2-validation.spec.mjs
@@ -95,8 +95,13 @@ test("catalog v2 exposes closed shared taxonomies without broadening targets", (
 
 test("unreviewed targets remain explicitly unclassified and runtime ineligible", () => {
     const catalogs = loadCatalogs();
+    const classified = new Set([
+        "cratis-engineering-docs-add-page",
+        "cratis-engineering-docs-authoring",
+        "cratis-engineering-docs-edit-page",
+    ]);
     for (const target of catalogs.targets.targets) {
-        if (target.id === "cratis-engineering-docs-authoring") continue;
+        if (classified.has(target.id)) continue;
         assert.equal(target.capabilityKind, "unclassified");
         assert.equal(target.invocation, "unclassified");
         assert.equal(target.lifecycle, "candidate");
@@ -147,15 +152,9 @@ test("documentation authoring is classified but remains unapproved", () => {
         ["create", "modify"],
     );
     assert.equal(target.dependencyClassificationState, "classified");
-    assert.equal(target.dependencyEdges.length, 4);
-    assert.deepEqual(target.dependencies.targets, [
-        "cratis-engineering-docs-add-page",
-        "cratis-engineering-docs-edit-page",
-    ]);
-    assert.deepEqual(target.dependencies.internalArtifacts, [
-        ".ai/rules/documentation-structure-and-formatting.md",
-        ".ai/rules/writing-cratis-docs.md",
-    ]);
+    assert.deepEqual(target.dependencyEdges, []);
+    assert.deepEqual(target.dependencies.targets, []);
+    assert.deepEqual(target.dependencies.internalArtifacts, []);
     assert.equal(target.sourceContractState, "classified");
     assert.deepEqual(target.sourceContractIds, ["cratis-ai-composition"]);
     assert.deepEqual(target.sourceAuthoritySubjects, [
@@ -200,6 +199,87 @@ test("documentation authoring is classified but remains unapproved", () => {
     }
     assert.equal(target.approval.state, "candidate");
     assert.equal(target.includeInRuntime, false);
+});
+
+test("documentation companions are classified and bound but unevaluated", () => {
+    const catalogs = loadCatalogs();
+    const expectations = [
+        {
+            targetId: "cratis-engineering-docs-add-page",
+            sourceId: "add-cratis-docs-page",
+            sourcePath: "engineering/skills/cratis-engineering-docs-add-page",
+            evidenceId: "engineering-docs-add-page-source-684d037",
+            effects: ["create", "modify"],
+        },
+        {
+            targetId: "cratis-engineering-docs-edit-page",
+            sourceId: "edit-cratis-docs",
+            sourcePath: "engineering/skills/cratis-engineering-docs-edit-page",
+            evidenceId: "engineering-docs-edit-page-source-684d037",
+            effects: ["modify"],
+        },
+    ];
+    for (const expected of expectations) {
+        const target = catalogs.targets.targets.find(
+            candidate => candidate.id === expected.targetId,
+        );
+        const source = catalogs.sources.sources.find(
+            candidate => candidate.id === expected.sourceId,
+        );
+        assert.equal(target.capabilityKind, "journey");
+        assert.equal(target.invocation, "both");
+        assert.deepEqual(target.architectures.ids, ["product-neutral"]);
+        assert.deepEqual(target.personas.ids, ["contributor", "maintainer"]);
+        assert.deepEqual(target.surfaces.ids, ["direct-agent-skills", "ide"]);
+        assert.deepEqual(target.repositoryProfiles.ids, [
+            "application",
+            "client",
+            "corpus",
+            "framework",
+        ]);
+        assert.equal(target.trust.class, "passive");
+        assert.equal(target.trust.assessmentState, "assessed");
+        assert.deepEqual(
+            target.trust.effects.map(effect => effect.operation),
+            expected.effects,
+        );
+        assert(
+            target.trust.effects.every(
+                effect =>
+                    effect.confirmation.required === true &&
+                    effect.confirmation.timing === "before-effect" &&
+                    effect.authorization.required === true &&
+                    effect.reversible === true,
+            ),
+        );
+        assert.equal(target.dependencyClassificationState, "classified");
+        assert.deepEqual(target.dependencies.targets, [
+            "cratis-engineering-docs-authoring",
+            "cratis-engineering-docs-visual-qa",
+        ]);
+        assert.deepEqual(
+            target.dependencyEdges.map(edge => edge.strength),
+            ["soft", "optional"],
+        );
+        assert.equal(target.sourceContractState, "classified");
+        assert.deepEqual(target.sourceContractIds, ["cratis-ai-composition"]);
+        assert.equal(target.authoringContractState, "classified");
+        assert.deepEqual(target.authoringContractIds, [
+            "cratis-skill-clean-room-v1",
+        ]);
+        assert.equal(target.evaluations.behavior.status, "missing");
+        assert.equal(target.evaluations.positiveTrigger.status, "missing");
+        assert.equal(target.evaluations.negativeTrigger.status, "missing");
+        assert.equal(target.evaluations.collision.status, "missing");
+        assert.equal(target.approval.state, "candidate");
+        assert.equal(target.includeInRuntime, false);
+        assert.equal(source.sourcePath, expected.sourcePath);
+        assert.equal(
+            source.sourceRevision,
+            "684d03755bacd40af95463b81b4a0c8b9f088ec1",
+        );
+        assert(source.evidenceIds.includes(expected.evidenceId));
+    }
 });
 
 test("source digests remain bound to the current source bytes", () => {

--- a/tooling/specs/engineering-distribution.spec.mjs
+++ b/tooling/specs/engineering-distribution.spec.mjs
@@ -53,6 +53,29 @@ test("first engineering target is classified but cannot package raw source", () 
     assert.equal(first.includeInRuntime, false);
 });
 
+test("documentation companion sources remain reconciled but unevaluated", () => {
+    const matrix = readJson("distribution/engineering-artifact-matrix.json");
+    assert.deepEqual(
+        matrix.companionTargets.map(target => ({
+            targetId: target.targetId,
+            state: target.state,
+            rawSourcePackagingAllowed: target.rawSourcePackagingAllowed,
+        })),
+        [
+            {
+                targetId: "cratis-engineering-docs-add-page",
+                state: "SOURCE_RECONCILED_NOT_EVALUATED",
+                rawSourcePackagingAllowed: false,
+            },
+            {
+                targetId: "cratis-engineering-docs-edit-page",
+                state: "SOURCE_RECONCILED_NOT_EVALUATED",
+                rawSourcePackagingAllowed: false,
+            },
+        ],
+    );
+});
+
 test("effectful and executable engineering capabilities stay separate", () => {
     const matrix = readJson("distribution/engineering-artifact-matrix.json");
     const lowTrust = matrix.packageBoundaries.find(


### PR DESCRIPTION
# Summary

Binds and classifies the two canonical documentation companion targets while keeping their evaluation, approval, runtime and package gates closed.

## Changed

- Point add-page and edit-page source identities at immutable canonical revision `684d037` (#126)
- Classify product-neutral profiles, contributor/maintainer applicability, direct-skill/IDE surfaces and passive trust (#126)
- Require path confirmation and owner authorization for reversible create/modify effects (#126)
- Classify soft docs-authoring and optional visual-QA dependencies with explicit degraded behavior (#126)
- Keep behavior/trigger/collision evidence missing, targets candidate, and runtime disabled (#126)
