### PR TITLE
Format engineering distribution tooling

### DIFF
--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "d47670aaf9440306f8e212d0c152af8b14f56d706c025636e9ddbc6ff2ad3ead",
+  "indexDigest": "b29fc14a61b33d49d000a1e0bb6245ba1a9c312f0a4308cd3d4f00aa94815e60",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/tooling/engineering-docs-companions-validation.mjs
+++ b/tooling/engineering-docs-companions-validation.mjs
@@ -7,7 +7,9 @@ import { lstatSync, readFileSync, readdirSync, realpathSync } from "node:fs";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const defaultRepositoryRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const defaultRepositoryRoot = resolve(
+    fileURLToPath(new URL("..", import.meta.url)),
+);
 const addRoot = "engineering/skills/cratis-engineering-docs-add-page";
 const editRoot = "engineering/skills/cratis-engineering-docs-edit-page";
 const evaluationRoot = "evals/cratis-engineering-docs-companions";
@@ -69,7 +71,9 @@ function safePath(path) {
         typeof path === "string" &&
         !isAbsolute(path) &&
         !path.includes("\\") &&
-        path.split("/").every(segment => segment && segment !== "." && segment !== "..")
+        path
+            .split("/")
+            .every((segment) => segment && segment !== "." && segment !== "..")
     );
 }
 
@@ -97,10 +101,10 @@ function inventory(repositoryRoot, path, expected, errors) {
         const root = realpathSync(repositoryRoot);
         const absolute = join(root, path);
         const entries = readdirSync(absolute, { withFileTypes: true });
-        const names = entries.map(entry => entry.name).sort();
+        const names = entries.map((entry) => entry.name).sort();
         if (
             JSON.stringify(names) !== JSON.stringify([...expected].sort()) ||
-            entries.some(entry => !entry.isFile() && !entry.isDirectory())
+            entries.some((entry) => !entry.isFile() && !entry.isDirectory())
         )
             errors.push(`${path}: inventory changed`);
     } catch {
@@ -123,10 +127,13 @@ function frontmatter(markdown) {
     const match = markdown.match(/^---\n([\s\S]*?)\n---\n/);
     if (!match) return null;
     return new Map(
-        match[1].split("\n").map(line => {
+        match[1].split("\n").map((line) => {
             const separator = line.indexOf(":");
             return separator > 0
-                ? [line.slice(0, separator).trim(), line.slice(separator + 1).trim()]
+                ? [
+                      line.slice(0, separator).trim(),
+                      line.slice(separator + 1).trim(),
+                  ]
                 : ["", ""];
         }),
     );
@@ -140,9 +147,19 @@ function validateSkill(
     requiredRoutes,
     errors,
 ) {
-    inventory(repositoryRoot, root, ["LICENSE", "SKILL.md", "references"], errors);
+    inventory(
+        repositoryRoot,
+        root,
+        ["LICENSE", "SKILL.md", "references"],
+        errors,
+    );
     inventory(repositoryRoot, `${root}/references`, [reference], errors);
-    const skill = readContained(repositoryRoot, `${root}/SKILL.md`, 131072, errors);
+    const skill = readContained(
+        repositoryRoot,
+        `${root}/SKILL.md`,
+        131072,
+        errors,
+    );
     if (skill === null) return;
     const metadata = frontmatter(skill);
     if (
@@ -237,15 +254,23 @@ export function validateEngineeringDocsCompanions(
     );
     const cases = [];
     if (casesContent !== null) {
-        for (const [index, line] of casesContent.split(/\r?\n/).filter(Boolean).entries()) {
+        for (const [index, line] of casesContent
+            .split(/\r?\n/)
+            .filter(Boolean)
+            .entries()) {
             try {
                 cases.push(JSON.parse(line));
             } catch {
-                errors.push(`${evaluationRoot}/cases.jsonl:${index + 1}: invalid JSON`);
+                errors.push(
+                    `${evaluationRoot}/cases.jsonl:${index + 1}: invalid JSON`,
+                );
             }
         }
     }
-    if (JSON.stringify(cases.map(item => item?.id).sort()) !== JSON.stringify(caseIds))
+    if (
+        JSON.stringify(cases.map((item) => item?.id).sort()) !==
+        JSON.stringify(caseIds)
+    )
         errors.push("CASE_INVENTORY");
     for (const testCase of cases) {
         const expected = decisions[testCase?.id];

--- a/tooling/generate-catalog-v2.mjs
+++ b/tooling/generate-catalog-v2.mjs
@@ -45,20 +45,16 @@ const sourceOverrides = new Map([
     [
         "add-cratis-docs-page",
         {
-            sourcePath:
-                "engineering/skills/cratis-engineering-docs-add-page",
-            sourceRevision:
-                "684d03755bacd40af95463b81b4a0c8b9f088ec1",
+            sourcePath: "engineering/skills/cratis-engineering-docs-add-page",
+            sourceRevision: "684d03755bacd40af95463b81b4a0c8b9f088ec1",
             evidenceId: "engineering-docs-add-page-source-684d037",
         },
     ],
     [
         "edit-cratis-docs",
         {
-            sourcePath:
-                "engineering/skills/cratis-engineering-docs-edit-page",
-            sourceRevision:
-                "684d03755bacd40af95463b81b4a0c8b9f088ec1",
+            sourcePath: "engineering/skills/cratis-engineering-docs-edit-page",
+            sourceRevision: "684d03755bacd40af95463b81b4a0c8b9f088ec1",
             evidenceId: "engineering-docs-edit-page-source-684d037",
         },
     ],
@@ -164,7 +160,8 @@ const engineeringClassifications = new Map([
                     reason: "A new page needs approved content after placement is known.",
                     missingBehavior: {
                         action: "degrade",
-                        description: "Place only already approved content; otherwise stop after the placement plan.",
+                        description:
+                            "Place only already approved content; otherwise stop after the placement plan.",
                     },
                 },
                 {
@@ -174,7 +171,8 @@ const engineeringClassifications = new Map([
                     reason: "Rendered visual review is a separate completion enhancement.",
                     missingBehavior: {
                         action: "omit",
-                        description: "Report visual QA as outstanding without claiming rendered quality.",
+                        description:
+                            "Report visual QA as outstanding without claiming rendered quality.",
                     },
                 },
             ],
@@ -203,7 +201,8 @@ const engineeringClassifications = new Map([
                     reason: "Substantial content redesign is delegated to the authoring workflow.",
                     missingBehavior: {
                         action: "degrade",
-                        description: "Apply only narrow source-backed corrections; block substantial redesign.",
+                        description:
+                            "Apply only narrow source-backed corrections; block substantial redesign.",
                     },
                 },
                 {
@@ -213,7 +212,8 @@ const engineeringClassifications = new Map([
                     reason: "Rendered visual review is a separate completion enhancement.",
                     missingBehavior: {
                         action: "omit",
-                        description: "Report visual QA as outstanding without claiming rendered quality.",
+                        description:
+                            "Report visual QA as outstanding without claiming rendered quality.",
                     },
                 },
             ],
@@ -1073,24 +1073,23 @@ const targets = allTargetIds.map((targetId) => {
             },
             positiveTrigger:
                 engineeringClassification?.routingEvaluationEvidenceId
-                ? {
-                      status: "passing",
-                      evidenceIds: [
-                          engineeringClassification.routingEvaluationEvidenceId,
-                      ],
-                  }
-                : { status: "missing", evidenceIds: [] },
+                    ? {
+                          status: "passing",
+                          evidenceIds: [
+                              engineeringClassification.routingEvaluationEvidenceId,
+                          ],
+                      }
+                    : { status: "missing", evidenceIds: [] },
             negativeTrigger:
                 engineeringClassification?.routingEvaluationEvidenceId
-                ? {
-                      status: "passing",
-                      evidenceIds: [
-                          engineeringClassification.routingEvaluationEvidenceId,
-                      ],
-                  }
-                : { status: "missing", evidenceIds: [] },
-            collision:
-                engineeringClassification?.routingEvaluationEvidenceId
+                    ? {
+                          status: "passing",
+                          evidenceIds: [
+                              engineeringClassification.routingEvaluationEvidenceId,
+                          ],
+                      }
+                    : { status: "missing", evidenceIds: [] },
+            collision: engineeringClassification?.routingEvaluationEvidenceId
                 ? {
                       status: "passing",
                       evidenceIds: [

--- a/tooling/generate-engineering-distribution-fixture.mjs
+++ b/tooling/generate-engineering-distribution-fixture.mjs
@@ -113,20 +113,17 @@ export function validateEngineeringDistributionConfiguration(
             join(repositoryRoot, "catalog/v2/targets.json"),
         ).targets;
         const fixture = artifacts.find(
-            artifact =>
-                artifact.id ===
-                "sanitized-engineering-docs-authoring-fixture",
+            (artifact) =>
+                artifact.id === "sanitized-engineering-docs-authoring-fixture",
         );
         const planned = artifacts.find(
-            artifact =>
-                artifact.id === "planned-passive-engineering-release",
+            (artifact) => artifact.id === "planned-passive-engineering-release",
         );
         const target = targets.find(
-            candidate =>
-                candidate.id === "cratis-engineering-docs-authoring",
+            (candidate) => candidate.id === "cratis-engineering-docs-authoring",
         );
         const expectedExactPaths = approvedFiles.map(
-            path => `engineering/${path}`,
+            (path) => `engineering/${path}`,
         );
         if (
             artifactMatrix.firstPassiveTarget.state !==
@@ -233,10 +230,7 @@ export function generateEngineeringDistributionFixture({
         );
 
         const codexRoot = join(root, "codex");
-        copyCanonical(
-            canonicalRoot,
-            join(codexRoot, `plugins/${pluginName}`),
-        );
+        copyCanonical(canonicalRoot, join(codexRoot, `plugins/${pluginName}`));
         writeJson(join(codexRoot, ".agents/plugins/marketplace.json"), {
             name: pluginName,
             interface: { displayName: "Cratis Engineering Fixture" },
@@ -256,10 +250,7 @@ export function generateEngineeringDistributionFixture({
             ],
         });
         writeJson(
-            join(
-                codexRoot,
-                `plugins/${pluginName}/.codex-plugin/plugin.json`,
-            ),
+            join(codexRoot, `plugins/${pluginName}/.codex-plugin/plugin.json`),
             {
                 name: pluginName,
                 version,
@@ -302,10 +293,7 @@ export function generateEngineeringDistributionFixture({
         });
 
         const cursorRoot = join(root, "cursor");
-        copyCanonical(
-            canonicalRoot,
-            join(cursorRoot, `plugins/${pluginName}`),
-        );
+        copyCanonical(canonicalRoot, join(cursorRoot, `plugins/${pluginName}`));
         writeJson(join(cursorRoot, ".cursor-plugin/marketplace.json"), {
             name: pluginName,
             owner: { name: "Cratis" },
@@ -360,10 +348,7 @@ export function generateEngineeringDistributionFixture({
             license: "MIT",
         });
 
-        const junieRoot = join(
-            root,
-            `junie/extensions/${pluginName}`,
-        );
+        const junieRoot = join(root, `junie/extensions/${pluginName}`);
         copyCanonical(canonicalRoot, junieRoot);
         writeJson(join(junieRoot, "extension.json"), {
             name: pluginName,
@@ -596,12 +581,7 @@ export function smokeNpmEngineeringUpdateRollback(
             const packed = JSON.parse(
                 execFileSync(
                     "npm",
-                    [
-                        "pack",
-                        "--json",
-                        "--pack-destination",
-                        packRoot,
-                    ],
+                    ["pack", "--json", "--pack-destination", packRoot],
                     {
                         cwd: join(outputRoot, "pi/package"),
                         encoding: "utf8",
@@ -623,23 +603,14 @@ export function smokeNpmEngineeringUpdateRollback(
     };
     const firstTarball = pack(firstOutputRoot, "first");
     const secondTarball = pack(secondOutputRoot, "second");
-    const install = tarball => {
+    const install = (tarball) => {
         execFileSync(
             "npm",
-            [
-                "install",
-                tarball,
-                "--ignore-scripts",
-                "--no-audit",
-                "--no-fund",
-            ],
+            ["install", tarball, "--ignore-scripts", "--no-audit", "--no-fund"],
             { cwd: installRoot, stdio: "pipe" },
         );
         return readJson(
-            join(
-                installRoot,
-                `node_modules/${packageName}/package.json`,
-            ),
+            join(installRoot, `node_modules/${packageName}/package.json`),
         ).version;
     };
     const firstVersion = install(firstTarball);
@@ -647,7 +618,9 @@ export function smokeNpmEngineeringUpdateRollback(
     const rolledBackVersion = install(firstTarball);
     for (const [path, content] of Object.entries(projectFiles))
         if (readFileSync(join(installRoot, path), "utf8") !== content)
-            throw new Error(`Engineering package changed project context: ${path}`);
+            throw new Error(
+                `Engineering package changed project context: ${path}`,
+            );
     execFileSync(
         "npm",
         [
@@ -661,7 +634,9 @@ export function smokeNpmEngineeringUpdateRollback(
     );
     for (const [path, content] of Object.entries(projectFiles))
         if (readFileSync(join(installRoot, path), "utf8") !== content)
-            throw new Error(`Engineering uninstall changed project context: ${path}`);
+            throw new Error(
+                `Engineering uninstall changed project context: ${path}`,
+            );
     return {
         firstVersion,
         secondVersion,
@@ -842,11 +817,10 @@ export function smokeGeminiEngineeringFixture(
         throw new Error(
             "Gemini engineering fixture extension was not observable",
         );
-    execFileSync(
-        geminiCommand,
-        ["extensions", "uninstall", pluginName],
-        { env: environment, stdio: "pipe" },
-    );
+    execFileSync(geminiCommand, ["extensions", "uninstall", pluginName], {
+        env: environment,
+        stdio: "pipe",
+    });
     if (existsSync(installedRoot))
         throw new Error(
             "Gemini engineering fixture uninstall left extension content",

--- a/tooling/run-engineering-docs-authoring-canary.mjs
+++ b/tooling/run-engineering-docs-authoring-canary.mjs
@@ -44,7 +44,7 @@ function git(repository, arguments_) {
 
 function contextSnapshot(repository) {
     return Object.fromEntries(
-        contextPaths.map(path => {
+        contextPaths.map((path) => {
             const absolute = join(repository, path);
             if (!existsSync(absolute) && !lstatExists(absolute))
                 return [path, "MISSING"];
@@ -109,7 +109,9 @@ function runPi({ configRoot, sessionRoot, consumerRoot, prompt }) {
         "PUBLICATION_ELIGIBLE",
     ])
         if (output.includes(forbidden))
-            throw new Error(`Canary output leaked forbidden value: ${forbidden}`);
+            throw new Error(
+                `Canary output leaked forbidden value: ${forbidden}`,
+            );
     return output;
 }
 
@@ -153,7 +155,11 @@ export function runEngineeringDocsAuthoringCanary({
         throw new Error(`Pi auth file is unavailable: ${authFile}`);
     if (existsSync(evidencePath))
         throw new Error(`Canary evidence already exists: ${evidencePath}`);
-    const beforeStatus = git(consumer, ["status", "--porcelain=v1", "--untracked-files=all"]);
+    const beforeStatus = git(consumer, [
+        "status",
+        "--porcelain=v1",
+        "--untracked-files=all",
+    ]);
     if (beforeStatus !== "")
         throw new Error("Canary consumer repository must be clean");
     const beforeContext = contextSnapshot(consumer);
@@ -186,8 +192,7 @@ export function runEngineeringDocsAuthoringCanary({
             configRoot,
             sessionRoot,
             consumerRoot: consumer,
-            prompt:
-                `Use the cratis-engineering-docs-authoring skill. An existing Cratis page is outdated, but its owning product repository and source page are unknown. ${outputContract}`,
+            prompt: `Use the cratis-engineering-docs-authoring skill. An existing Cratis page is outdated, but its owning product repository and source page are unknown. ${outputContract}`,
         });
         expectDecision(explicitOutput, "DEFER_TO_EDIT_PAGE");
 
@@ -196,8 +201,7 @@ export function runEngineeringDocsAuthoringCanary({
             configRoot,
             sessionRoot,
             consumerRoot: consumer,
-            prompt:
-                `Create a new Cratis how-to page, but the owning repository and navigation position have not been decided. ${outputContract}`,
+            prompt: `Create a new Cratis how-to page, but the owning repository and navigation position have not been decided. ${outputContract}`,
         });
         expectDecision(implicitOutput, "DEFER_TO_ADD_PAGE");
 
@@ -206,8 +210,7 @@ export function runEngineeringDocsAuthoringCanary({
             configRoot,
             sessionRoot,
             consumerRoot: consumer,
-            prompt:
-                `Use the Cratis documentation authoring workflow. Write a runnable Chronicle example from memory even though no first-party source or revision is available. ${outputContract}`,
+            prompt: `Use the Cratis documentation authoring workflow. Write a runnable Chronicle example from memory even though no first-party source or revision is available. ${outputContract}`,
         });
         expectDecision(rollbackOutput, "BLOCK");
 
@@ -272,11 +275,9 @@ export function runEngineeringDocsAuthoringCanary({
             remainingGates: ["owner approval"],
         };
         mkdirSync(dirname(evidencePath), { recursive: true });
-        writeFileSync(
-            evidencePath,
-            `${JSON.stringify(evidence, null, 2)}\n`,
-            { flag: "wx" },
-        );
+        writeFileSync(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`, {
+            flag: "wx",
+        });
         return evidence;
     } finally {
         rmSync(temporaryRoot, { recursive: true, force: true });

--- a/tooling/specs/catalog-v2-validation.spec.mjs
+++ b/tooling/specs/catalog-v2-validation.spec.mjs
@@ -221,10 +221,10 @@ test("documentation companions are classified and bound but unevaluated", () => 
     ];
     for (const expected of expectations) {
         const target = catalogs.targets.targets.find(
-            candidate => candidate.id === expected.targetId,
+            (candidate) => candidate.id === expected.targetId,
         );
         const source = catalogs.sources.sources.find(
-            candidate => candidate.id === expected.sourceId,
+            (candidate) => candidate.id === expected.sourceId,
         );
         assert.equal(target.capabilityKind, "journey");
         assert.equal(target.invocation, "both");
@@ -240,12 +240,12 @@ test("documentation companions are classified and bound but unevaluated", () => 
         assert.equal(target.trust.class, "passive");
         assert.equal(target.trust.assessmentState, "assessed");
         assert.deepEqual(
-            target.trust.effects.map(effect => effect.operation),
+            target.trust.effects.map((effect) => effect.operation),
             expected.effects,
         );
         assert(
             target.trust.effects.every(
-                effect =>
+                (effect) =>
                     effect.confirmation.required === true &&
                     effect.confirmation.timing === "before-effect" &&
                     effect.authorization.required === true &&
@@ -258,7 +258,7 @@ test("documentation companions are classified and bound but unevaluated", () => 
             "cratis-engineering-docs-visual-qa",
         ]);
         assert.deepEqual(
-            target.dependencyEdges.map(edge => edge.strength),
+            target.dependencyEdges.map((edge) => edge.strength),
             ["soft", "optional"],
         );
         assert.equal(target.sourceContractState, "classified");

--- a/tooling/specs/engineering-distribution-fixture.spec.mjs
+++ b/tooling/specs/engineering-distribution-fixture.spec.mjs
@@ -27,7 +27,10 @@ import {
     validateEngineeringDistributionFixture,
 } from "../generate-engineering-distribution-fixture.mjs";
 
-const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const repositoryRoot = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    "../..",
+);
 
 function commandAvailable(command) {
     try {
@@ -67,10 +70,7 @@ test("engineering fixture workflow remains read-only and non-promoting", () => {
     );
     assert.match(workflow, /workflow_dispatch:/);
     assert.match(workflow, /permissions:\n  contents: read/);
-    assert.match(
-        workflow,
-        /0\.0\.N-engineering-fixture/,
-    );
+    assert.match(workflow, /0\.0\.N-engineering-fixture/);
     assert.match(workflow, /engineering-distribution-fixture\.spec\.mjs/);
     for (const forbidden of [
         "id-token: write",
@@ -94,7 +94,7 @@ test("engineering fixture evidence remains local and non-promoting", () => {
     assert.equal(evidence.state, "ENGINEERING_FIXTURE_ONLY");
     assert.equal(evidence.targetId, "cratis-engineering-docs-authoring");
     assert(
-        evidence.results.every(result => result.status.startsWith("PASS")),
+        evidence.results.every((result) => result.status.startsWith("PASS")),
     );
     assert.equal(evidence.targetApproval, false);
     assert.equal(evidence.installationEligible, false);
@@ -103,7 +103,7 @@ test("engineering fixture evidence remains local and non-promoting", () => {
 });
 
 test("engineering fixture generation is deterministic and non-installable", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const firstRoot = join(root, "first");
         const secondRoot = join(root, "second");
         const first = generateEngineeringDistributionFixture({
@@ -138,12 +138,15 @@ test("engineering fixture generation is deterministic and non-installable", () =
                 readFileSync(join(secondRoot, file.path)),
             );
         }
-        assert.deepEqual(validateEngineeringDistributionFixture(firstRoot), first);
+        assert.deepEqual(
+            validateEngineeringDistributionFixture(firstRoot),
+            first,
+        );
     });
 });
 
 test("engineering fixture contains one passive skill and no project context", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const stage = join(root, "stage");
         generateEngineeringDistributionFixture({
             repositoryRoot,
@@ -152,13 +155,10 @@ test("engineering fixture contains one passive skill and no project context", ()
         const manifest = readJson(
             join(stage, "engineering-distribution-manifest.json"),
         );
-        assert.equal(
-            manifest.skillName,
-            "cratis-engineering-docs-authoring",
-        );
+        assert.equal(manifest.skillName, "cratis-engineering-docs-authoring");
         assert(
             manifest.files.some(
-                file =>
+                (file) =>
                     file.path ===
                     "canonical/skills/cratis-engineering-docs-authoring/SKILL.md",
             ),
@@ -176,7 +176,7 @@ test("engineering fixture contains one passive skill and no project context", ()
             "/prompts/",
         ])
             assert(
-                manifest.files.every(file => !file.path.includes(forbidden)),
+                manifest.files.every((file) => !file.path.includes(forbidden)),
                 forbidden,
             );
         assert.equal(
@@ -222,7 +222,7 @@ test("engineering fixture contains one passive skill and no project context", ()
 });
 
 test("engineering fixture detects canonical payload tampering", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const stage = join(root, "stage");
         generateEngineeringDistributionFixture({
             repositoryRoot,
@@ -243,7 +243,7 @@ test("engineering fixture detects canonical payload tampering", () => {
 });
 
 test("engineering npm fixture packs installs and uninstalls", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const stage = join(root, "stage");
         const smokeRoot = join(root, "smoke");
         generateEngineeringDistributionFixture({
@@ -261,7 +261,7 @@ test("engineering npm fixture packs installs and uninstalls", () => {
 });
 
 test("engineering npm fixture updates rolls back and preserves project context", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const first = join(root, "first");
         const second = join(root, "second");
         const smokeRoot = join(root, "smoke");
@@ -289,109 +289,99 @@ test("engineering npm fixture updates rolls back and preserves project context",
     });
 });
 
-test(
-    "engineering Pi fixture installs and removes in an isolated home",
-    { skip: !piAvailable },
-    () => {
-        withTemporaryDirectory(root => {
-            const stage = join(root, "stage");
-            const home = join(root, "home");
-            generateEngineeringDistributionFixture({
-                repositoryRoot,
-                outputRoot: stage,
-            });
-            mkdirSync(home);
-            assert.deepEqual(smokePiEngineeringFixture(stage, home), {
-                installed: true,
-                removed: true,
-            });
+test("engineering Pi fixture installs and removes in an isolated home", {
+    skip: !piAvailable,
+}, () => {
+    withTemporaryDirectory((root) => {
+        const stage = join(root, "stage");
+        const home = join(root, "home");
+        generateEngineeringDistributionFixture({
+            repositoryRoot,
+            outputRoot: stage,
         });
-    },
-);
+        mkdirSync(home);
+        assert.deepEqual(smokePiEngineeringFixture(stage, home), {
+            installed: true,
+            removed: true,
+        });
+    });
+});
 
-test(
-    "engineering Claude fixture validates installs and removes",
-    { skip: !claudeAvailable },
-    () => {
-        withTemporaryDirectory(root => {
-            const stage = join(root, "stage");
-            const home = join(root, "home");
-            generateEngineeringDistributionFixture({
-                repositoryRoot,
-                outputRoot: stage,
-            });
-            mkdirSync(home);
-            assert.deepEqual(smokeClaudeEngineeringFixture(stage, home), {
-                validated: true,
-                installed: true,
-                removed: true,
-            });
+test("engineering Claude fixture validates installs and removes", {
+    skip: !claudeAvailable,
+}, () => {
+    withTemporaryDirectory((root) => {
+        const stage = join(root, "stage");
+        const home = join(root, "home");
+        generateEngineeringDistributionFixture({
+            repositoryRoot,
+            outputRoot: stage,
         });
-    },
-);
+        mkdirSync(home);
+        assert.deepEqual(smokeClaudeEngineeringFixture(stage, home), {
+            validated: true,
+            installed: true,
+            removed: true,
+        });
+    });
+});
 
-test(
-    "engineering Copilot fixture installs and removes",
-    { skip: !copilotAvailable },
-    () => {
-        withTemporaryDirectory(root => {
-            const stage = join(root, "stage");
-            const home = join(root, "home");
-            generateEngineeringDistributionFixture({
-                repositoryRoot,
-                outputRoot: stage,
-            });
-            mkdirSync(home);
-            assert.deepEqual(smokeCopilotEngineeringFixture(stage, home), {
-                installed: true,
-                removed: true,
-            });
+test("engineering Copilot fixture installs and removes", {
+    skip: !copilotAvailable,
+}, () => {
+    withTemporaryDirectory((root) => {
+        const stage = join(root, "stage");
+        const home = join(root, "home");
+        generateEngineeringDistributionFixture({
+            repositoryRoot,
+            outputRoot: stage,
         });
-    },
-);
+        mkdirSync(home);
+        assert.deepEqual(smokeCopilotEngineeringFixture(stage, home), {
+            installed: true,
+            removed: true,
+        });
+    });
+});
 
-test(
-    "engineering Codex fixture marketplace adds and removes",
-    { skip: !codexAvailable },
-    () => {
-        withTemporaryDirectory(root => {
-            const stage = join(root, "stage");
-            const home = join(root, "home");
-            generateEngineeringDistributionFixture({
-                repositoryRoot,
-                outputRoot: stage,
-            });
-            mkdirSync(home);
-            assert.deepEqual(smokeCodexEngineeringFixture(stage, home), {
-                added: true,
-                removed: true,
-            });
+test("engineering Codex fixture marketplace adds and removes", {
+    skip: !codexAvailable,
+}, () => {
+    withTemporaryDirectory((root) => {
+        const stage = join(root, "stage");
+        const home = join(root, "home");
+        generateEngineeringDistributionFixture({
+            repositoryRoot,
+            outputRoot: stage,
         });
-    },
-);
+        mkdirSync(home);
+        assert.deepEqual(smokeCodexEngineeringFixture(stage, home), {
+            added: true,
+            removed: true,
+        });
+    });
+});
 
-test(
-    "engineering Gemini fixture links and removes",
-    { skip: !geminiAvailable },
-    () => {
-        withTemporaryDirectory(root => {
-            const stage = join(root, "stage");
-            const home = join(root, "home");
-            generateEngineeringDistributionFixture({
-                repositoryRoot,
-                outputRoot: stage,
-            });
-            mkdirSync(home);
-            assert.deepEqual(smokeGeminiEngineeringFixture(stage, home), {
-                linked: true,
-                removed: true,
-            });
+test("engineering Gemini fixture links and removes", {
+    skip: !geminiAvailable,
+}, () => {
+    withTemporaryDirectory((root) => {
+        const stage = join(root, "stage");
+        const home = join(root, "home");
+        generateEngineeringDistributionFixture({
+            repositoryRoot,
+            outputRoot: stage,
         });
-    },
-);
+        mkdirSync(home);
+        assert.deepEqual(smokeGeminiEngineeringFixture(stage, home), {
+            linked: true,
+            removed: true,
+        });
+    });
+});
 
 test("engineering fixture CLI binds version and rejects release-shaped values", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const stage = join(root, "stage");
         execFileSync(
             process.execPath,

--- a/tooling/specs/engineering-distribution.spec.mjs
+++ b/tooling/specs/engineering-distribution.spec.mjs
@@ -56,7 +56,7 @@ test("first engineering target is classified but cannot package raw source", () 
 test("documentation companion sources remain reconciled but unevaluated", () => {
     const matrix = readJson("distribution/engineering-artifact-matrix.json");
     assert.deepEqual(
-        matrix.companionTargets.map(target => ({
+        matrix.companionTargets.map((target) => ({
             targetId: target.targetId,
             state: target.state,
             rawSourcePackagingAllowed: target.rawSourcePackagingAllowed,

--- a/tooling/specs/engineering-docs-authoring-canary.spec.mjs
+++ b/tooling/specs/engineering-docs-authoring-canary.spec.mjs
@@ -3,19 +3,17 @@
 
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import {
-    mkdtempSync,
-    readFileSync,
-    rmSync,
-    writeFileSync,
-} from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 import { runEngineeringDocsAuthoringCanary } from "../run-engineering-docs-authoring-canary.mjs";
 
-const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const repositoryRoot = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    "../..",
+);
 const scriptPath = join(
     repositoryRoot,
     "tooling/run-engineering-docs-authoring-canary.mjs",
@@ -74,7 +72,10 @@ test("engineering real-repository canary remains no-tools and isolated", () => {
     assert.match(script, /PI_CODING_AGENT_DIR: configRoot/);
     assert.match(script, /PI_CODING_AGENT_SESSION_DIR: sessionRoot/);
     assert.match(script, /copyFileSync\(authFile/);
-    assert.match(script, /chmodSync\(join\(configRoot, "auth\.json"\), 0o600\)/);
+    assert.match(
+        script,
+        /chmodSync\(join\(configRoot, "auth\.json"\), 0o600\)/,
+    );
     assert.match(script, /rmSync\(temporaryRoot/);
 });
 
@@ -102,7 +103,7 @@ test("engineering canary checks update rollback uninstall and project context", 
 });
 
 test("engineering canary rejects a dirty consuming repository before auth use", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         execFileSync("git", ["init", "--initial-branch", "main"], {
             cwd: root,
             stdio: "pipe",
@@ -110,9 +111,13 @@ test("engineering canary rejects a dirty consuming repository before auth use", 
         execFileSync("git", ["config", "user.name", "Canary Spec"], {
             cwd: root,
         });
-        execFileSync("git", ["config", "user.email", "canary@invalid.example"], {
-            cwd: root,
-        });
+        execFileSync(
+            "git",
+            ["config", "user.email", "canary@invalid.example"],
+            {
+                cwd: root,
+            },
+        );
         writeFileSync(join(root, "README.md"), "# Canary\n");
         execFileSync("git", ["add", "README.md"], { cwd: root });
         execFileSync("git", ["commit", "-m", "Initial"], {
@@ -135,7 +140,7 @@ test("engineering canary rejects a dirty consuming repository before auth use", 
 });
 
 test("engineering canary rejects missing auth and preexisting evidence", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         execFileSync("git", ["init", "--initial-branch", "main"], {
             cwd: root,
             stdio: "pipe",
@@ -143,9 +148,13 @@ test("engineering canary rejects missing auth and preexisting evidence", () => {
         execFileSync("git", ["config", "user.name", "Canary Spec"], {
             cwd: root,
         });
-        execFileSync("git", ["config", "user.email", "canary@invalid.example"], {
-            cwd: root,
-        });
+        execFileSync(
+            "git",
+            ["config", "user.email", "canary@invalid.example"],
+            {
+                cwd: root,
+            },
+        );
         writeFileSync(join(root, "README.md"), "# Canary\n");
         execFileSync("git", ["add", "README.md"], { cwd: root });
         execFileSync("git", ["commit", "-m", "Initial"], {

--- a/tooling/specs/engineering-docs-companions.spec.mjs
+++ b/tooling/specs/engineering-docs-companions.spec.mjs
@@ -47,8 +47,8 @@ test("engineering documentation companions and twelve cases pass", () => {
     assert.deepEqual(validateEngineeringDocsCompanions(), []);
     const cases = readCases();
     assert.equal(cases.length, 12);
-    assert.equal(cases.filter(item => item.kind === "positive").length, 4);
-    assert.equal(cases.filter(item => item.kind === "negative").length, 8);
+    assert.equal(cases.filter((item) => item.kind === "positive").length, 4);
+    assert.equal(cases.filter((item) => item.kind === "negative").length, 8);
 });
 
 test("add-page companion owns placement and routes near misses", () => {
@@ -86,7 +86,7 @@ test("edit-page companion discovers authoritative source and avoids outputs", ()
 });
 
 test("companion cases preserve new existing visual authority and scope routing", () => {
-    const cases = new Map(readCases().map(item => [item.id, item.expected]));
+    const cases = new Map(readCases().map((item) => [item.id, item.expected]));
     assert.equal(cases.get("A01").decision, "PLACE_PRODUCT_PAGE");
     assert.equal(cases.get("A02").decision, "PLACE_SITE_PAGE");
     assert.equal(cases.get("A03").decision, "DEFER_TO_EDIT_PAGE");
@@ -102,7 +102,7 @@ test("companion cases preserve new existing visual authority and scope routing",
 });
 
 test("companion validation rejects executable payload and source coupling", () => {
-    withFixture(root => {
+    withFixture((root) => {
         const skillPath = join(
             root,
             "engineering/skills/cratis-engineering-docs-add-page/SKILL.md",
@@ -130,31 +130,31 @@ test("companion validation rejects executable payload and source coupling", () =
             ),
         );
         assert(
-            errors.some(error =>
+            errors.some((error) =>
                 error.includes(
                     "engineering/skills/cratis-engineering-docs-edit-page: inventory changed",
                 ),
             ),
         );
-        assert(errors.some(error => error.includes("digest changed")));
+        assert(errors.some((error) => error.includes("digest changed")));
     });
 });
 
 test("companion validation rejects decision oracle drift", () => {
-    withFixture(root => {
+    withFixture((root) => {
         const path = join(
             root,
             "evals/cratis-engineering-docs-companions/cases.jsonl",
         );
         const cases = readCases(root);
-        cases.find(item => item.id === "A04").expected.decision =
+        cases.find((item) => item.id === "A04").expected.decision =
             "PLACE_PRODUCT_PAGE";
         writeFileSync(
             path,
-            `${cases.map(item => JSON.stringify(item)).join("\n")}\n`,
+            `${cases.map((item) => JSON.stringify(item)).join("\n")}\n`,
         );
         const errors = validateEngineeringDocsCompanions(root);
         assert(errors.includes("A04:CASE_ORACLE"));
-        assert(errors.some(error => error.includes("digest changed")));
+        assert(errors.some((error) => error.includes("digest changed")));
     });
 });


### PR DESCRIPTION
# Summary

Preserves repository formatter output produced after the companion-classification merge and refreshes its generated inventory digest. Behavior is unchanged.

## Changed

- Apply repository formatting to engineering distribution, canary and companion tooling (#126)
