### PR TITLE
Format companion evaluation specs

### DIFF
--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "5c2bfc685701d20692f9bb4025411ea51252671ac4451b1eb5fc2b01a39e0144",
+  "indexDigest": "be2539a2416c3f691ca72b66557cad3672850e167c1e00b3d9a08b8c57025cba",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/tooling/specs/engineering-docs-companions-evaluation.spec.mjs
+++ b/tooling/specs/engineering-docs-companions-evaluation.spec.mjs
@@ -172,7 +172,9 @@ test("companion grader requires exact run metadata and immutable output hashes",
         "utf8",
     );
     assert(
-        grader.includes("Run manifest does not exactly match the frozen run matrix"),
+        grader.includes(
+            "Run manifest does not exactly match the frozen run matrix",
+        ),
     );
     assert(
         grader.includes("Run manifest does not exactly cover run directories"),


### PR DESCRIPTION
# Summary

Preserves formatter output produced after the companion-evaluation merge and refreshes the generated inventory digest. Behavior and evidence are unchanged.

## Changed

- Format companion evaluation specs (#126)
