### PR TITLE
Add Grok and DeepSeek distribution support

### DIFF
--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
@@ -1818,3 +1818,33 @@ follow-up must separate add-only, edit-only, bundle-level, and native-trigger
 conditions; predeclare thresholds; bind complete invocation evidence; and rerun
 A04/A06/E02/H03/H04 boundaries. Approval, runtime inclusion, raw source
 packaging, installation, publication, and promotion remain false.
+
+## 48. Delivery pivot and Grok/DeepSeek support — 2026-08-22
+
+Maintainer direction explicitly returns the work to the original goal: useful,
+shared Cratis skills distributed idiomatically across AI coding harnesses. The
+reviewed companion follow-up is preserved separately as do-not-run work and is
+not on the first-release critical path.
+
+The first useful public payload is now the self-contained passive
+`skills/cratis-fundamentals-concept/` skill rather than the synthetic example.
+It is generated from an exact two-file allowlist and remains fixture-only until
+source binding and release approval are recorded.
+
+Native adapter coverage now also includes:
+
+- xAI Grok Build through `grok/.grok/skills/`, while retaining Grok's documented
+  ability to consume the generated Claude Code marketplace;
+- DeepSeek Harness through direct, non-recursive
+  `deepseek/.dsh/skills/<skill-name>/SKILL.md` bundles;
+- DeepSeek model-provider compatibility metadata, which points users to the
+  existing Pi, Claude, Copilot, or DeepSeek Harness package instead of creating
+  model-specific duplicate skill bytes.
+
+Both public and engineering generators enforce canonical byte parity for Grok
+and DeepSeek Harness. Direct-folder lifecycle smoke tests prove isolated install
+and removal. DeepSeek Harness remains developer preview and requires upstream
+contract reverification before a supported stable release. Publication and
+promotion remain disabled; the immediate path is canonical source binding, a
+small passive preview allowlist, one real consuming-repository canary, and the
+existing credential/owner gates.

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
@@ -600,9 +600,13 @@ Evidence and exact next actions are in
 - [x] Complete independent review of companion evidence. Trigger/routing is
   incomplete; collision evidence fails unambiguous cases; H04 remains
   bundle-versus-delegation ambiguous; operational/distribution gates stay shut.
-- [ ] Freeze and run a corrective add-only/edit-only/bundle/native-trigger
-  evaluation with predeclared thresholds and complete invocation binding before
-  any fixture packaging decision.
+- [ ] Corrective companion evaluation is deferred outside the first usable
+  release; the reviewed draft is preserved locally as do-not-run work.
+- [x] Add native passive adapters for xAI Grok Build (`.grok/skills`) and
+  DeepSeek Harness (`.dsh/skills`), plus model-provider compatibility metadata
+  so DeepSeek reuses each selected harness package instead of duplicated bytes.
+- [ ] Select a conservative passive public release allowlist and materialize the
+  first useful local release candidate; do not wait for all catalog targets.
 - [ ] Provision the repository-scoped App credentials from Workflows#72 before
   any generated update PR, tag, release, or publication operation.
 - [ ] Keep publication and retirement disabled until explicit approvals pass.

--- a/Documentation/public-product-architecture.md
+++ b/Documentation/public-product-architecture.md
@@ -145,6 +145,21 @@ This registry is evidence, not a compatibility promise. Actual release support
 still requires installation smoke tests against the client versions selected
 for that release.
 
+## Grok and DeepSeek adapters
+
+Grok Build is an xAI coding-agent harness with native project `.grok/skills`
+and user `~/.grok/skills` discovery. Generated distributions therefore include
+a native `grok/.grok/skills/` adapter in addition to the Claude marketplace that
+Grok can consume through its documented Claude Code compatibility.
+
+DeepSeek has two distinct roles. DeepSeek Harness is an official developer-
+preview agent harness and receives direct, non-recursive
+`deepseek/.dsh/skills/<skill-name>/SKILL.md` bundles. DeepSeek models are also
+providers inside other harnesses such as Pi, Claude Code, and GitHub Copilot;
+those use the existing harness package rather than receiving duplicated skill
+bytes under a model-specific package. DeepSeek Harness compatibility must be
+reverified while its upstream contract remains in developer preview.
+
 ## Executable capability boundary
 
 Passive skills and executable capabilities remain separate:

--- a/catalog/ecosystem-versions.json
+++ b/catalog/ecosystem-versions.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "verifiedOn": "2026-08-20",
+  "verifiedOn": "2026-08-22",
   "policy": "official-sources-only",
   "ecosystems": [
     {
@@ -242,6 +242,21 @@
       ]
     },
     {
+      "id": "grok-build-skills",
+      "status": "current",
+      "version": "current-documentation-2026-08-22",
+      "facts": [
+        "Grok Build is xAI's extensible coding agent and supports interactive, headless, and Agent Client Protocol operation.",
+        "It discovers skill bundles from project .grok/skills, user ~/.grok/skills, enabled plugins, configured paths, and user ~/.agents/skills.",
+        "Grok Build is compatible with Claude Code marketplaces, plugins, skills, MCP servers, agents, hooks, and instruction files without extra configuration.",
+        "Generated Cratis Grok output uses passive native .grok/skills bundles and omits hooks, MCP servers, agents, and executable scripts."
+      ],
+      "sources": [
+        { "url": "https://docs.x.ai/build/overview", "kind": "official-documentation", "verifiedOn": "2026-08-22" },
+        { "url": "https://docs.x.ai/build/features/skills-plugins-marketplaces", "kind": "official-documentation", "verifiedOn": "2026-08-22" }
+      ]
+    },
+    {
       "id": "grok-bot-plugins",
       "status": "current",
       "version": "current-documentation-2026-08-20",
@@ -348,6 +363,20 @@
         { "url": "https://github.com/deepseek-ai/deepseek-harness", "kind": "official-repository", "verifiedOn": "2026-08-20" },
         { "url": "https://deepseek-harness.github.io/deepseek-harness/en/reference/subsystems/skills", "kind": "official-documentation", "verifiedOn": "2026-08-20" },
         { "url": "https://cli.github.com/manual/gh_skill_install", "kind": "official-documentation", "verifiedOn": "2026-08-20" }
+      ]
+    },
+    {
+      "id": "deepseek-model-integrations",
+      "status": "current",
+      "version": "current-documentation-2026-08-22",
+      "facts": [
+        "DeepSeek documents its models as providers inside existing coding-agent harnesses rather than as a separate shared-skill package format.",
+        "Official integration guidance covers Pi, Claude Code, GitHub Copilot, OpenCode, OpenClaw, and additional third-party agents.",
+        "A Cratis skill package remains owned by its harness adapter when DeepSeek is selected as the model; provider selection must not fork skill behavior or bytes."
+      ],
+      "sources": [
+        { "url": "https://api-docs.deepseek.com/guides/coding_agents/", "kind": "official-documentation", "verifiedOn": "2026-08-22" },
+        { "url": "https://api-docs.deepseek.com/quick_start/agent_integrations/pi_mono", "kind": "official-documentation", "verifiedOn": "2026-08-22" }
       ]
     },
     {

--- a/catalog/generated/human-catalog/catalog.json
+++ b/catalog/generated/human-catalog/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractVersion": 1,
   "disclaimer": "Catalog inclusion, evaluation evidence, bundle generation, or publication does not grant runtime permission or approval.",
-  "inputDigest": "f1fb529f7503aaca898097161fd408ab62f662a8441c767f86fc82b2f5803f30",
+  "inputDigest": "efa7aaa7e60944c122a7b611e97baf545bf8da18e1df20e16a4eca93667a4024",
   "capabilities": [
     {
       "id": "cratis-application-react-specifications",

--- a/catalog/generated/human-catalog/manifest.json
+++ b/catalog/generated/human-catalog/manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "contractVersion": 1,
-  "inputDigest": "f1fb529f7503aaca898097161fd408ab62f662a8441c767f86fc82b2f5803f30",
+  "inputDigest": "efa7aaa7e60944c122a7b611e97baf545bf8da18e1df20e16a4eca93667a4024",
   "files": [
     {
       "path": "CATALOG.md",
@@ -11,7 +11,7 @@
     {
       "path": "catalog.json",
       "size": 64765,
-      "sha256": "108b442c6e358d2415b18f53c9614d11e9edb51807528228faa568e99289de0a"
+      "sha256": "74a026a5ea76b84d7d3813e19842837ace4a2dbdda65d5822cad09fa12474ae2"
     }
   ]
 }

--- a/catalog/v2/evidence.json
+++ b/catalog/v2/evidence.json
@@ -457,6 +457,24 @@
       "confidence": "high"
     },
     {
+      "id": "grok-build-skills-source-1",
+      "officialUrl": "https://docs.x.ai/build/overview",
+      "sourceKind": "official-documentation",
+      "verifiedOn": "2026-08-22",
+      "expiresOn": "2026-11-18",
+      "applicableVersion": "current-documentation-2026-08-22",
+      "confidence": "high"
+    },
+    {
+      "id": "grok-build-skills-source-2",
+      "officialUrl": "https://docs.x.ai/build/features/skills-plugins-marketplaces",
+      "sourceKind": "official-documentation",
+      "verifiedOn": "2026-08-22",
+      "expiresOn": "2026-11-18",
+      "applicableVersion": "current-documentation-2026-08-22",
+      "confidence": "high"
+    },
+    {
       "id": "grok-bot-plugins-source-1",
       "officialUrl": "https://agent-plugins.org/compatible-clients",
       "sourceKind": "official-documentation",
@@ -589,6 +607,24 @@
       "verifiedOn": "2026-08-20",
       "expiresOn": "2026-11-18",
       "applicableVersion": "developer-preview-2026-08-20",
+      "confidence": "high"
+    },
+    {
+      "id": "deepseek-model-integrations-source-1",
+      "officialUrl": "https://api-docs.deepseek.com/guides/coding_agents/",
+      "sourceKind": "official-documentation",
+      "verifiedOn": "2026-08-22",
+      "expiresOn": "2026-11-18",
+      "applicableVersion": "current-documentation-2026-08-22",
+      "confidence": "high"
+    },
+    {
+      "id": "deepseek-model-integrations-source-2",
+      "officialUrl": "https://api-docs.deepseek.com/quick_start/agent_integrations/pi_mono",
+      "sourceKind": "official-documentation",
+      "verifiedOn": "2026-08-22",
+      "expiresOn": "2026-11-18",
+      "applicableVersion": "current-documentation-2026-08-22",
       "confidence": "high"
     },
     {
@@ -1280,6 +1316,42 @@
       ]
     },
     {
+      "id": "grok-build-skills-fact-1",
+      "ecosystemId": "grok-build-skills",
+      "fact": "Grok Build is xAI's extensible coding agent and supports interactive, headless, and Agent Client Protocol operation.",
+      "evidenceIds": [
+        "grok-build-skills-source-1",
+        "grok-build-skills-source-2"
+      ]
+    },
+    {
+      "id": "grok-build-skills-fact-2",
+      "ecosystemId": "grok-build-skills",
+      "fact": "It discovers skill bundles from project .grok/skills, user ~/.grok/skills, enabled plugins, configured paths, and user ~/.agents/skills.",
+      "evidenceIds": [
+        "grok-build-skills-source-1",
+        "grok-build-skills-source-2"
+      ]
+    },
+    {
+      "id": "grok-build-skills-fact-3",
+      "ecosystemId": "grok-build-skills",
+      "fact": "Grok Build is compatible with Claude Code marketplaces, plugins, skills, MCP servers, agents, hooks, and instruction files without extra configuration.",
+      "evidenceIds": [
+        "grok-build-skills-source-1",
+        "grok-build-skills-source-2"
+      ]
+    },
+    {
+      "id": "grok-build-skills-fact-4",
+      "ecosystemId": "grok-build-skills",
+      "fact": "Generated Cratis Grok output uses passive native .grok/skills bundles and omits hooks, MCP servers, agents, and executable scripts.",
+      "evidenceIds": [
+        "grok-build-skills-source-1",
+        "grok-build-skills-source-2"
+      ]
+    },
+    {
       "id": "grok-bot-plugins-fact-1",
       "ecosystemId": "grok-bot-plugins",
       "fact": "The Agent Plugins registry lists Grok Bot support for Agent Skills and stdio, Streamable HTTP, and legacy SSE MCP.",
@@ -1526,6 +1598,33 @@
         "deepseek-harness-skills-source-1",
         "deepseek-harness-skills-source-2",
         "deepseek-harness-skills-source-3"
+      ]
+    },
+    {
+      "id": "deepseek-model-integrations-fact-1",
+      "ecosystemId": "deepseek-model-integrations",
+      "fact": "DeepSeek documents its models as providers inside existing coding-agent harnesses rather than as a separate shared-skill package format.",
+      "evidenceIds": [
+        "deepseek-model-integrations-source-1",
+        "deepseek-model-integrations-source-2"
+      ]
+    },
+    {
+      "id": "deepseek-model-integrations-fact-2",
+      "ecosystemId": "deepseek-model-integrations",
+      "fact": "Official integration guidance covers Pi, Claude Code, GitHub Copilot, OpenCode, OpenClaw, and additional third-party agents.",
+      "evidenceIds": [
+        "deepseek-model-integrations-source-1",
+        "deepseek-model-integrations-source-2"
+      ]
+    },
+    {
+      "id": "deepseek-model-integrations-fact-3",
+      "ecosystemId": "deepseek-model-integrations",
+      "fact": "A Cratis skill package remains owned by its harness adapter when DeepSeek is selected as the model; provider selection must not fork skill behavior or bytes.",
+      "evidenceIds": [
+        "deepseek-model-integrations-source-1",
+        "deepseek-model-integrations-source-2"
       ]
     },
     {

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1943,7 +1943,10 @@
       "status": "added"
     }
   ],
-  "admittedUntracked": [],
+  "admittedUntracked": [
+    "skills/cratis-fundamentals-concept/LICENSE",
+    "skills/cratis-fundamentals-concept/SKILL.md"
+  ],
   "excludedRuntimePrefixes": [
     ".pi/delegate/",
     ".pi/fusion/",
@@ -2230,7 +2233,8 @@
         ".ai/skills/write-specs/**",
         ".ai/skills/write-specs-events/**",
         ".ai/skills/write-specs-frontend/**",
-        ".ai/skills/write-specs-readmodels/**"
+        ".ai/skills/write-specs-readmodels/**",
+        "skills/**"
       ],
       "artifactType": "skill-source-and-resources",
       "currentOwner": "reusable Cratis engineering behavior",
@@ -2248,8 +2252,8 @@
         "workflows-68",
         "reevaluation-authority"
       ],
-      "expectedPathCount": 62,
-      "expectedPathsDigest": "4d6d81d603857bc6c534a7417e2e3413051118387141b76ebfefd19564de8156"
+      "expectedPathCount": 64,
+      "expectedPathsDigest": "4599993447a921d5d7a2f265e95fa394647e526af0dede16d33476a70693eb7e"
     },
     {
       "excludePathPatterns": [

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "be2539a2416c3f691ca72b66557cad3672850e167c1e00b3d9a08b8c57025cba",
+  "indexDigest": "53596486c904df07cc18580519cd3e88aea7c5b93762d6b02bf7e8aec78f6833",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -1679,6 +1679,14 @@
       "status": "added"
     },
     {
+      "path": "skills/cratis-fundamentals-concept/LICENSE",
+      "status": "added"
+    },
+    {
+      "path": "skills/cratis-fundamentals-concept/SKILL.md",
+      "status": "added"
+    },
+    {
       "path": "tooling/bootstrap-generated-distribution-repository.mjs",
       "status": "added"
     },
@@ -1943,10 +1951,7 @@
       "status": "added"
     }
   ],
-  "admittedUntracked": [
-    "skills/cratis-fundamentals-concept/LICENSE",
-    "skills/cratis-fundamentals-concept/SKILL.md"
-  ],
+  "admittedUntracked": [],
   "excludedRuntimePrefixes": [
     ".pi/delegate/",
     ".pi/fusion/",

--- a/distribution/artifact-matrix.json
+++ b/distribution/artifact-matrix.json
@@ -2,12 +2,10 @@
   "schemaVersion": "1.0.0",
   "state": "FIXTURE_ONLY_LOCAL_STAGING",
   "canonicalSource": {
-    "artifactId": "sanitized-public-materializer-fixture",
+    "artifactId": "cratis-fundamentals-concept-preview",
     "approvedFiles": [
-      "skills/cratis-example/LICENSE",
-      "skills/cratis-example/SKILL.md",
-      "skills/cratis-example/assets/example.txt",
-      "skills/cratis-example/references/guide.md"
+      "skills/cratis-fundamentals-concept/LICENSE",
+      "skills/cratis-fundamentals-concept/SKILL.md"
     ]
   },
   "repository": {
@@ -77,6 +75,40 @@
         "manifest-parse",
         "canonical-byte-parity",
         "isolated-link-uninstall-when-available"
+      ]
+    },
+    {
+      "id": "grok-build",
+      "requirementId": "grok-build-skills",
+      "state": "FIXTURE_GENERATION_ENABLED",
+      "outputRoot": "grok",
+      "packageKind": "NATIVE_GROK_AGENT_SKILLS",
+      "smokeGates": [
+        "exact-skill-inventory",
+        "canonical-byte-parity",
+        "grok-inspect-when-available"
+      ]
+    },
+    {
+      "id": "deepseek-harness",
+      "requirementId": "deepseek-harness-skills",
+      "state": "FIXTURE_GENERATION_ENABLED",
+      "outputRoot": "deepseek",
+      "packageKind": "NATIVE_DEEPSEEK_HARNESS_SKILLS",
+      "smokeGates": [
+        "exact-skill-inventory",
+        "canonical-byte-parity",
+        "deepseek-harness-smoke-when-stable"
+      ]
+    },
+    {
+      "id": "deepseek-provider",
+      "requirementId": "deepseek-model-provider",
+      "state": "PROVIDER_COMPATIBILITY_NO_DISTINCT_ARTIFACT",
+      "outputRoot": null,
+      "packageKind": "MODEL_PROVIDER_USES_HARNESS_PACKAGES",
+      "smokeGates": [
+        "provider-compatibility-contract"
       ]
     },
     {

--- a/distribution/marketplace-requirements.json
+++ b/distribution/marketplace-requirements.json
@@ -159,6 +159,79 @@
       ]
     },
     {
+      "id": "grok-build-skills",
+      "status": "VERIFIED",
+      "sourceUrls": [
+        "https://docs.x.ai/build/overview",
+        "https://docs.x.ai/build/features/skills-plugins-marketplaces"
+      ],
+      "requiredRoots": [
+        ".grok/skills/<skill-name>/SKILL.md"
+      ],
+      "installCommands": [
+        "Copy reviewed skills to .grok/skills or ~/.grok/skills",
+        "Use the generated Claude marketplace through Grok's Claude Code compatibility"
+      ],
+      "updateCommands": [
+        "Replace the installed skill with bytes from a newer immutable Cratis release"
+      ],
+      "uninstallCommands": [
+        "Remove the installed skill folder from .grok/skills or ~/.grok/skills"
+      ],
+      "constraints": [
+        "Grok Build is xAI's coding agent and discovers project .grok/skills, user ~/.grok/skills, configured skill paths, and enabled plugin skills.",
+        "Grok skills are folders containing SKILL.md with YAML frontmatter and may include references and assets.",
+        "Grok also supports Claude Code marketplaces, plugins, and skills without extra configuration.",
+        "Generated passive Cratis output contains skills only and does not add hooks, MCP servers, agents, or executable scripts."
+      ]
+    },
+    {
+      "id": "deepseek-harness-skills",
+      "status": "VERIFIED_DEVELOPER_PREVIEW",
+      "sourceUrls": [
+        "https://github.com/deepseek-ai/deepseek-harness",
+        "https://deepseek-harness.github.io/deepseek-harness/en/reference/subsystems/skills"
+      ],
+      "requiredRoots": [
+        ".dsh/skills/<skill-name>/SKILL.md"
+      ],
+      "installCommands": [
+        "Copy reviewed skills to <project>/.dsh/skills or the configured DeepSeek Harness user skills root"
+      ],
+      "updateCommands": [
+        "Replace the installed skill with bytes from a newer immutable Cratis release"
+      ],
+      "uninstallCommands": [
+        "Remove the installed skill folder from the DeepSeek Harness skills root"
+      ],
+      "constraints": [
+        "DeepSeek Harness is an official DeepSeek AI open-source agent harness in developer preview with expected compatibility-breaking changes.",
+        "It discovers project .dsh/skills and .agents/skills, configured custom directories, and user skill roots.",
+        "Directory bundles are direct <name>/SKILL.md children; nested recursive skill discovery is unsupported.",
+        "Generated Cratis output uses kebab-case direct bundles and must be reverified while the harness remains preview."
+      ]
+    },
+    {
+      "id": "deepseek-model-provider",
+      "status": "VERIFIED_PROVIDER_COMPATIBILITY",
+      "sourceUrls": [
+        "https://api-docs.deepseek.com/guides/coding_agents/",
+        "https://api-docs.deepseek.com/quick_start/agent_integrations/pi_mono"
+      ],
+      "requiredRoots": [],
+      "installCommands": [
+        "Install the Cratis package for the selected coding harness, then configure that harness to use DeepSeek"
+      ],
+      "updateCommands": [],
+      "uninstallCommands": [],
+      "constraints": [
+        "DeepSeek is a model provider integrated into coding harnesses rather than a distinct shared-skill package format.",
+        "Cratis skills remain harness packages; selecting DeepSeek as the model must not fork or duplicate skill payloads.",
+        "Official DeepSeek documentation covers integrations including Pi, Claude Code, GitHub Copilot, OpenCode, and OpenClaw.",
+        "No direct DeepSeek artifact output root is generated until DeepSeek publishes an official distinct harness package contract."
+      ]
+    },
+    {
       "id": "npm-trusted-publication",
       "status": "VERIFIED",
       "sourceUrls": [

--- a/skills/cratis-fundamentals-concept/LICENSE
+++ b/skills/cratis-fundamentals-concept/LICENSE
@@ -1,0 +1,2 @@
+Copyright (c) Cratis. All rights reserved.
+Licensed under the MIT license. See LICENSE file in the project root for full license information.

--- a/skills/cratis-fundamentals-concept/SKILL.md
+++ b/skills/cratis-fundamentals-concept/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: cratis-fundamentals-concept
+description: Create strongly typed Cratis domain values and event-source identities with ConceptAs<T> or EventSourceId<T>. Use whenever a Cratis C# model introduces a meaningful Guid, string, number, name, code, amount, or entity identity instead of leaving it as a raw primitive.
+license: MIT
+---
+
+# Cratis Fundamentals concepts
+
+Create a strongly typed concept around every primitive value with domain meaning.
+
+## Choose value or identity
+
+- Derive names, amounts, codes, and other values from `ConceptAs<T>`.
+- Derive event-source or entity identities from `EventSourceId<T>`.
+- Do not use `ConceptAs<Guid>` for an event-source identity. `EventSourceId<T>` already provides Chronicle-compatible conversions.
+
+## Value concept
+
+```csharp
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Concepts;
+
+namespace <NamespaceRoot>.<Feature>;
+
+/// <summary>
+/// Represents the <description>.
+/// </summary>
+/// <param name="Value">The underlying <type> value.</param>
+public record <ConceptName>(<UnderlyingType> Value) : ConceptAs<<UnderlyingType>>(Value)
+{
+    /// <summary>
+    /// Represents an unset <ConceptName>.
+    /// </summary>
+    public static readonly <ConceptName> NotSet = new(<emptyValue>);
+
+    /// <summary>
+    /// Implicitly converts a <UnderlyingType> to a <ConceptName>.
+    /// </summary>
+    public static implicit operator <ConceptName>(<UnderlyingType> value) => new(value);
+}
+```
+
+## Event-source identity
+
+```csharp
+using Cratis.Chronicle.Events;
+
+namespace <NamespaceRoot>.<Feature>;
+
+/// <summary>
+/// Represents the identity of a <description>.
+/// </summary>
+/// <param name="Value">The underlying <type> value.</param>
+public record <ConceptName>(<UnderlyingType> Value) : EventSourceId<<UnderlyingType>>(Value)
+{
+    public static readonly <ConceptName> NotSet = new(<emptyValue>);
+    public static <ConceptName> New() => new(Guid.NewGuid());
+    public static implicit operator <ConceptName>(<UnderlyingType> value) => new(value);
+}
+```
+
+Do not redeclare conversions between `EventSourceId`, `T`, or `string`; the base type supplies them.
+
+## Sentinel values
+
+| Underlying type | Sentinel |
+| --- | --- |
+| `Guid` | `Guid.Empty` |
+| `string` | `string.Empty` |
+| `int` | `0` |
+| `long` | `0L` |
+
+## Placement
+
+Place the concept with the feature that owns its meaning rather than in a generic `Concepts/` folder. Put genuinely cross-feature concepts in `Common/`. Do not introduce a top-level `Features/` wrapper.
+
+## Verify
+
+- The type derives from `ConceptAs<T>` or `EventSourceId<T>` as appropriate.
+- It has a `static readonly NotSet` or semantically equivalent sentinel.
+- It has an implicit conversion from the primitive.
+- A `Guid`-backed identity has a typed `New()` factory.
+- An identity does not duplicate conversions supplied by `EventSourceId<T>`.
+- The file carries the repository license header.
+- `dotnet build` passes.

--- a/tooling/generate-distribution-fixture.mjs
+++ b/tooling/generate-distribution-fixture.mjs
@@ -23,10 +23,8 @@ const defaultRepositoryRoot = resolve(
     fileURLToPath(new URL("..", import.meta.url)),
 );
 const approvedFiles = [
-    "skills/cratis-example/LICENSE",
-    "skills/cratis-example/SKILL.md",
-    "skills/cratis-example/assets/example.txt",
-    "skills/cratis-example/references/guide.md",
+    "skills/cratis-fundamentals-concept/LICENSE",
+    "skills/cratis-fundamentals-concept/SKILL.md",
 ];
 const generatedTargets = [
     "canonical",
@@ -34,7 +32,9 @@ const generatedTargets = [
     "codex",
     "copilot",
     "cursor",
+    "deepseek",
     "gemini",
+    "grok",
     "junie",
     "kiro",
     "pi",
@@ -176,10 +176,7 @@ export function generateDistributionFixture({
     try {
         const canonicalRoot = join(root, "canonical");
         materializeFixtureArtifact({
-            sourceRoot: join(
-                repositoryRoot,
-                "tooling/fixtures/public-artifact/valid-source",
-            ),
+            sourceRoot: repositoryRoot,
             stageRoot: canonicalRoot,
             approvedFiles,
         });
@@ -291,6 +288,9 @@ export function generateDistributionFixture({
             },
         );
 
+        const deepSeekRoot = join(root, "deepseek/.dsh");
+        copyCanonicalSkill(canonicalRoot, deepSeekRoot);
+
         const geminiRoot = join(root, "gemini");
         copyCanonicalSkill(canonicalRoot, geminiRoot);
         writeJson(join(geminiRoot, "gemini-extension.json"), {
@@ -298,6 +298,9 @@ export function generateDistributionFixture({
             version,
             description: "Passive Cratis skills fixture.",
         });
+
+        const grokRoot = join(root, "grok/.grok");
+        copyCanonicalSkill(canonicalRoot, grokRoot);
 
         const kiroRoot = join(root, "kiro");
         copyCanonicalSkill(canonicalRoot, kiroRoot);
@@ -329,6 +332,23 @@ export function generateDistributionFixture({
             files: ["skills"],
             keywords: ["pi-package"],
             pi: { skills: ["./skills"] },
+        });
+
+        writeJson(join(root, "provider-compatibility.json"), {
+            schemaVersion: "1.0.0",
+            providers: [
+                {
+                    id: "deepseek",
+                    artifactStrategy: "USE_HARNESS_PACKAGE",
+                    supportedHarnessOutputs: [
+                        "claude",
+                        "copilot",
+                        "deepseek",
+                        "pi",
+                    ],
+                    distinctArtifactRoot: null,
+                },
+            ],
         });
 
         const canonicalManifest = approvedFiles.map((path) =>
@@ -405,7 +425,9 @@ export function validateDistributionFixture(outputRoot) {
         "codex/plugins/cratis",
         "copilot/plugins/cratis",
         "cursor/plugins/cratis",
+        "deepseek/.dsh",
         "gemini",
+        "grok/.grok",
         "junie/extensions/cratis",
         "kiro",
         "pi/package",
@@ -420,6 +442,30 @@ export function validateDistributionFixture(outputRoot) {
                 );
         }
     }
+    const providerCompatibility = readJson(
+        join(root, "provider-compatibility.json"),
+    );
+    if (
+        JSON.stringify(providerCompatibility.providers) !==
+        JSON.stringify([
+            {
+                id: "deepseek",
+                artifactStrategy: "USE_HARNESS_PACKAGE",
+                supportedHarnessOutputs: [
+                    "claude",
+                    "copilot",
+                    "deepseek",
+                    "pi",
+                ],
+                distinctArtifactRoot: null,
+            },
+        ])
+    )
+        throw new Error("Provider compatibility contract changed");
+    if (existsSync(join(root, "deepseek-provider")))
+        throw new Error(
+            "DeepSeek model provider must not receive a duplicate artifact root",
+        );
     const checksumLines = readFileSync(join(root, "SHA256SUMS"), "utf8")
         .trim()
         .split("\n");
@@ -471,7 +517,7 @@ export function smokeNpmDistributionFixture(outputRoot, temporaryRoot) {
     );
     const installedSkill = join(
         installRoot,
-        "node_modules/@cratis/ai/skills/cratis-example/SKILL.md",
+        "node_modules/@cratis/ai/skills/cratis-fundamentals-concept/SKILL.md",
     );
     if (!lstatSync(installedSkill).isFile())
         throw new Error("Installed npm fixture skill is missing");
@@ -491,7 +537,56 @@ export function smokeNpmDistributionFixture(outputRoot, temporaryRoot) {
     );
     if (existsSync(join(installRoot, "node_modules/@cratis/ai")))
         throw new Error("npm fixture uninstall left package content");
-    return { tarball, installedSkill: "skills/cratis-example/SKILL.md" };
+    return {
+        tarball,
+        installedSkill: "skills/cratis-fundamentals-concept/SKILL.md",
+    };
+}
+
+function smokeDirectSkillFixture(
+    outputRoot,
+    temporaryRoot,
+    sourceRoot,
+    installedRoot,
+) {
+    const source = join(
+        outputRoot,
+        sourceRoot,
+        "skills/cratis-fundamentals-concept",
+    );
+    const installed = join(
+        temporaryRoot,
+        installedRoot,
+        "cratis-fundamentals-concept",
+    );
+    mkdirSync(dirname(installed), { recursive: true });
+    cpSync(source, installed, { recursive: true, errorOnExist: true });
+    const sourceSkill = readFileSync(join(source, "SKILL.md"));
+    const installedSkill = readFileSync(join(installed, "SKILL.md"));
+    if (!sourceSkill.equals(installedSkill))
+        throw new Error("Direct skill install changed canonical bytes");
+    rmSync(installed, { recursive: true, force: false });
+    if (existsSync(installed))
+        throw new Error("Direct skill uninstall left installed content");
+    return { installed: true, removed: true };
+}
+
+export function smokeGrokDistributionFixture(outputRoot, temporaryRoot) {
+    return smokeDirectSkillFixture(
+        outputRoot,
+        temporaryRoot,
+        "grok/.grok",
+        ".grok/skills",
+    );
+}
+
+export function smokeDeepSeekDistributionFixture(outputRoot, temporaryRoot) {
+    return smokeDirectSkillFixture(
+        outputRoot,
+        temporaryRoot,
+        "deepseek/.dsh",
+        ".dsh/skills",
+    );
 }
 
 export function smokePiDistributionFixture(

--- a/tooling/generate-engineering-distribution-fixture.mjs
+++ b/tooling/generate-engineering-distribution-fixture.mjs
@@ -36,7 +36,9 @@ const generatedTargets = [
     "codex",
     "copilot",
     "cursor",
+    "deepseek",
     "gemini",
+    "grok",
     "junie",
     "kiro",
     "pi",
@@ -326,6 +328,9 @@ export function generateEngineeringDistributionFixture({
             },
         );
 
+        const deepSeekRoot = join(root, "deepseek/.dsh");
+        copyCanonical(canonicalRoot, deepSeekRoot);
+
         const geminiRoot = join(root, "gemini");
         copyCanonical(canonicalRoot, geminiRoot);
         writeJson(join(geminiRoot, "gemini-extension.json"), {
@@ -334,6 +339,9 @@ export function generateEngineeringDistributionFixture({
             description:
                 "Fixture-only passive Cratis engineering documentation skill.",
         });
+
+        const grokRoot = join(root, "grok/.grok");
+        copyCanonical(canonicalRoot, grokRoot);
 
         const kiroRoot = join(root, "kiro");
         copyCanonical(canonicalRoot, kiroRoot);
@@ -453,7 +461,9 @@ export function validateEngineeringDistributionFixture(outputRoot) {
         `codex/plugins/${pluginName}`,
         `copilot/plugins/${pluginName}`,
         `cursor/plugins/${pluginName}`,
+        "deepseek/.dsh",
         "gemini",
+        "grok/.grok",
         `junie/extensions/${pluginName}`,
         "kiro",
         "pi/package",
@@ -646,6 +656,44 @@ export function smokeNpmEngineeringUpdateRollback(
             join(installRoot, `node_modules/${packageName}`),
         ),
     };
+}
+
+function smokeDirectEngineeringSkill(
+    outputRoot,
+    temporaryRoot,
+    sourceRoot,
+    installedRoot,
+) {
+    const source = join(outputRoot, sourceRoot, `skills/${skillName}`);
+    const installed = join(temporaryRoot, installedRoot, skillName);
+    mkdirSync(dirname(installed), { recursive: true });
+    cpSync(source, installed, { recursive: true, errorOnExist: true });
+    const sourceSkill = readFileSync(join(source, "SKILL.md"));
+    const installedSkill = readFileSync(join(installed, "SKILL.md"));
+    if (!sourceSkill.equals(installedSkill))
+        throw new Error("Direct engineering skill install changed bytes");
+    rmSync(installed, { recursive: true, force: false });
+    if (existsSync(installed))
+        throw new Error("Direct engineering skill uninstall left content");
+    return { installed: true, removed: true };
+}
+
+export function smokeGrokEngineeringFixture(outputRoot, temporaryRoot) {
+    return smokeDirectEngineeringSkill(
+        outputRoot,
+        temporaryRoot,
+        "grok/.grok",
+        ".grok/skills",
+    );
+}
+
+export function smokeDeepSeekEngineeringFixture(outputRoot, temporaryRoot) {
+    return smokeDirectEngineeringSkill(
+        outputRoot,
+        temporaryRoot,
+        "deepseek/.dsh",
+        ".dsh/skills",
+    );
 }
 
 export function smokePiEngineeringFixture(

--- a/tooling/generate-repository-inventory.mjs
+++ b/tooling/generate-repository-inventory.mjs
@@ -113,6 +113,7 @@ const unexpectedUntracked = admittedUntracked.filter(
             /^evidence\/source-evidence\//.test(path) ||
             /^evals\//.test(path) ||
             /^pilots\//.test(path) ||
+            /^skills\//.test(path) ||
             /^tooling\//.test(path)
         ),
 );
@@ -123,9 +124,12 @@ if (unexpectedUntracked.length > 0) {
 }
 const universe = [...tracked, ...admittedUntracked];
 const v2Sources = readCatalog(join(repositoryRoot, "catalog/v2/sources.json"));
-const publicSkillRoots = v2Sources.sources
-    .filter((source) => source.audience === "public")
-    .map((source) => `${source.sourcePath}/**`);
+const publicSkillRoots = [
+    ...v2Sources.sources
+        .filter((source) => source.audience === "public")
+        .map((source) => `${source.sourcePath}/**`),
+    "skills/**",
+];
 const legacyEngineeringSkillNames = [
     "add-cratis-docs-page",
     "add-traces",

--- a/tooling/specs/distribution-fixture.spec.mjs
+++ b/tooling/specs/distribution-fixture.spec.mjs
@@ -18,9 +18,11 @@ import { fileURLToPath } from "node:url";
 import {
     generateDistributionFixture,
     smokeClaudeDistributionFixture,
+    smokeDeepSeekDistributionFixture,
     smokeCodexDistributionFixture,
     smokeCopilotDistributionFixture,
     smokeGeminiDistributionFixture,
+    smokeGrokDistributionFixture,
     smokeNpmDistributionFixture,
     smokePiDistributionFixture,
     validateDistributionFixture,
@@ -81,6 +83,9 @@ test("distribution requirements and artifact matrix stay authority bounded", () 
         "github-copilot-plugin",
         "gemini-cli-extension",
         "pi-passive-package",
+        "grok-build-skills",
+        "deepseek-harness-skills",
+        "deepseek-model-provider",
         "npm-trusted-publication",
         "cursor-marketplace",
         "kiro-marketplace",
@@ -150,7 +155,9 @@ test("distribution fixture generation is deterministic across native adapters", 
             "codex",
             "copilot",
             "cursor",
+            "deepseek",
             "gemini",
+            "grok",
             "junie",
             "kiro",
             "pi",
@@ -175,6 +182,9 @@ test("generated marketplace manifests remain passive and idiomatic", () => {
             join(stage, "cursor/plugins/cratis/.cursor-plugin/plugin.json"),
         );
         const gemini = readJson(join(stage, "gemini/gemini-extension.json"));
+        const providerCompatibility = readJson(
+            join(stage, "provider-compatibility.json"),
+        );
         const kiro = readJson(join(stage, "kiro/plugin.json"));
         const junie = readJson(
             join(stage, "junie/extensions/cratis/extension.json"),
@@ -185,6 +195,51 @@ test("generated marketplace manifests remain passive and idiomatic", () => {
         assert.equal(copilot.skills, "skills/");
         assert.equal(cursor.skills, "./skills/");
         assert.equal(gemini.name, "cratis");
+        assert.deepEqual(providerCompatibility.providers, [
+            {
+                id: "deepseek",
+                artifactStrategy: "USE_HARNESS_PACKAGE",
+                supportedHarnessOutputs: [
+                    "claude",
+                    "copilot",
+                    "deepseek",
+                    "pi",
+                ],
+                distinctArtifactRoot: null,
+            },
+        ]);
+        assert.equal(
+            readFileSync(
+                join(
+                    stage,
+                    "deepseek/.dsh/skills/cratis-fundamentals-concept/SKILL.md",
+                ),
+                "utf8",
+            ),
+            readFileSync(
+                join(
+                    stage,
+                    "canonical/skills/cratis-fundamentals-concept/SKILL.md",
+                ),
+                "utf8",
+            ),
+        );
+        assert.equal(
+            readFileSync(
+                join(
+                    stage,
+                    "grok/.grok/skills/cratis-fundamentals-concept/SKILL.md",
+                ),
+                "utf8",
+            ),
+            readFileSync(
+                join(
+                    stage,
+                    "canonical/skills/cratis-fundamentals-concept/SKILL.md",
+                ),
+                "utf8",
+            ),
+        );
         assert.equal(
             kiro.$schema,
             "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
@@ -209,10 +264,16 @@ test("generated marketplace manifests remain passive and idiomatic", () => {
         assert.equal(piPackage.scripts, undefined);
         assert.equal(piPackage.dependencies, undefined);
         const skill = readFileSync(
-            join(stage, "canonical/skills/cratis-example/SKILL.md"),
+            join(
+                stage,
+                "canonical/skills/cratis-fundamentals-concept/SKILL.md",
+            ),
             "utf8",
         );
-        assert.match(skill, /^---\nname: cratis-example\ndescription: /);
+        assert.match(
+            skill,
+            /^---\nname: cratis-fundamentals-concept\ndescription: /,
+        );
     });
 });
 
@@ -222,12 +283,30 @@ test("distribution fixture detects payload and checksum tampering", () => {
         generateDistributionFixture({ repositoryRoot, outputRoot: stage });
         const path = join(
             stage,
-            "gemini/skills/cratis-example/assets/example.txt",
+            "gemini/skills/cratis-fundamentals-concept/SKILL.md",
         );
         writeFileSync(path, "tampered\n");
         assert.throws(
             () => validateDistributionFixture(stage),
             /digest mismatch|byte parity|Checksum verification/,
+        );
+    });
+});
+
+test("Grok and DeepSeek direct skill fixtures install and remove", () => {
+    withTemporaryDirectory((root) => {
+        const stage = join(root, "stage");
+        generateDistributionFixture({ repositoryRoot, outputRoot: stage });
+        assert.deepEqual(
+            smokeGrokDistributionFixture(stage, join(root, "grok-home")),
+            { installed: true, removed: true },
+        );
+        assert.deepEqual(
+            smokeDeepSeekDistributionFixture(
+                stage,
+                join(root, "deepseek-home"),
+            ),
+            { installed: true, removed: true },
         );
     });
 });
@@ -240,7 +319,10 @@ test("passive npm fixture packs installs and uninstalls without scripts", () => 
         mkdirSync(smokeRoot);
         const result = smokeNpmDistributionFixture(stage, smokeRoot);
         assert.equal(existsSync(result.tarball), true);
-        assert.equal(result.installedSkill, "skills/cratis-example/SKILL.md");
+        assert.equal(
+            result.installedSkill,
+            "skills/cratis-fundamentals-concept/SKILL.md",
+        );
     });
 });
 

--- a/tooling/specs/distribution-rollout.spec.mjs
+++ b/tooling/specs/distribution-rollout.spec.mjs
@@ -168,7 +168,10 @@ test("tampered candidate cannot be staged as a fixture release", () => {
         initializeDistributionRollout(rollout);
         generateDistributionFixture({ repositoryRoot, outputRoot: candidate });
         writeFileSync(
-            join(candidate, "canonical/skills/cratis-example/SKILL.md"),
+            join(
+                candidate,
+                "canonical/skills/cratis-fundamentals-concept/SKILL.md",
+            ),
             "tampered\n",
         );
         assert.throws(

--- a/tooling/specs/engineering-distribution-fixture.spec.mjs
+++ b/tooling/specs/engineering-distribution-fixture.spec.mjs
@@ -18,9 +18,11 @@ import { fileURLToPath } from "node:url";
 import {
     generateEngineeringDistributionFixture,
     smokeClaudeEngineeringFixture,
+    smokeDeepSeekEngineeringFixture,
     smokeCodexEngineeringFixture,
     smokeCopilotEngineeringFixture,
     smokeGeminiEngineeringFixture,
+    smokeGrokEngineeringFixture,
     smokeNpmEngineeringFixture,
     smokeNpmEngineeringUpdateRollback,
     smokePiEngineeringFixture,
@@ -127,7 +129,9 @@ test("engineering fixture generation is deterministic and non-installable", () =
             "codex",
             "copilot",
             "cursor",
+            "deepseek",
             "gemini",
+            "grok",
             "junie",
             "kiro",
             "pi",
@@ -201,6 +205,33 @@ test("engineering fixture contains one passive skill and no project context", ()
             readJson(join(stage, "gemini/gemini-extension.json")).name,
             "cratis-engineering-fixture",
         );
+        const canonicalSkill = readFileSync(
+            join(
+                stage,
+                "canonical/skills/cratis-engineering-docs-authoring/SKILL.md",
+            ),
+            "utf8",
+        );
+        assert.equal(
+            readFileSync(
+                join(
+                    stage,
+                    "deepseek/.dsh/skills/cratis-engineering-docs-authoring/SKILL.md",
+                ),
+                "utf8",
+            ),
+            canonicalSkill,
+        );
+        assert.equal(
+            readFileSync(
+                join(
+                    stage,
+                    "grok/.grok/skills/cratis-engineering-docs-authoring/SKILL.md",
+                ),
+                "utf8",
+            ),
+            canonicalSkill,
+        );
         assert.equal(
             readJson(join(stage, "kiro/plugin.json")).$schema,
             "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
@@ -238,6 +269,27 @@ test("engineering fixture detects canonical payload tampering", () => {
         assert.throws(
             () => validateEngineeringDistributionFixture(stage),
             /digest mismatch|byte parity|checksum/,
+        );
+    });
+});
+
+test("engineering Grok and DeepSeek fixtures install and remove", () => {
+    withTemporaryDirectory((root) => {
+        const stage = join(root, "stage");
+        generateEngineeringDistributionFixture({
+            repositoryRoot,
+            outputRoot: stage,
+        });
+        assert.deepEqual(
+            smokeGrokEngineeringFixture(stage, join(root, "grok-home")),
+            { installed: true, removed: true },
+        );
+        assert.deepEqual(
+            smokeDeepSeekEngineeringFixture(
+                stage,
+                join(root, "deepseek-home"),
+            ),
+            { installed: true, removed: true },
         );
     });
 });

--- a/tooling/specs/generated-distribution-repository.spec.mjs
+++ b/tooling/specs/generated-distribution-repository.spec.mjs
@@ -182,7 +182,10 @@ test("generated repository verification rejects worktree tampering", () => {
         bootstrap(root);
         const generatedRoot = join(root, "generated");
         writeFileSync(
-            join(generatedRoot, "canonical/skills/cratis-example/SKILL.md"),
+            join(
+                generatedRoot,
+                "canonical/skills/cratis-fundamentals-concept/SKILL.md",
+            ),
             "tampered\n",
         );
         assert.throws(
@@ -202,12 +205,16 @@ test("generated repository verification rejects human follow-up commits", () => 
         const generatedRoot = join(root, "generated");
         const path = join(
             generatedRoot,
-            "canonical/skills/cratis-example/LICENSE",
+            "canonical/skills/cratis-fundamentals-concept/LICENSE",
         );
         writeFileSync(path, `${readFileSync(path, "utf8")}human edit\n`);
         execFileSync(
             "git",
-            ["add", "--", "canonical/skills/cratis-example/LICENSE"],
+            [
+                "add",
+                "--",
+                "canonical/skills/cratis-fundamentals-concept/LICENSE",
+            ],
             {
                 cwd: generatedRoot,
             },


### PR DESCRIPTION
# Summary

Moves the distribution back toward the original product goal: useful shared Cratis skills packaged idiomatically across supported AI harnesses.

## Changed

- Add native xAI Grok Build output under `.grok/skills` (#126)
- Add native DeepSeek Harness output under `.dsh/skills` (#126)
- Record DeepSeek model-provider reuse through existing harness packages rather than duplicated model-specific bytes (#126)
- Replace the synthetic example payload with the first useful self-contained `cratis-fundamentals-concept` public skill (#148)
- Add canonical-byte, install, removal, tamper, generated-repository, and rollout coverage for the new payload and adapters (#126)

## Safety state

The generated package remains fixture/preview-only. Publication and promotion remain disabled pending the existing owner, GitHub App, npm, and real-canary gates.
