### PR TITLE
Bind first public skill source

### DIFF
--- a/catalog/generated/human-catalog/catalog.json
+++ b/catalog/generated/human-catalog/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractVersion": 1,
   "disclaimer": "Catalog inclusion, evaluation evidence, bundle generation, or publication does not grant runtime permission or approval.",
-  "inputDigest": "efa7aaa7e60944c122a7b611e97baf545bf8da18e1df20e16a4eca93667a4024",
+  "inputDigest": "5efec12307e6ab7d9951862e6819f1ba11bd3357fc4edda367a210ee9274dada",
   "capabilities": [
     {
       "id": "cratis-application-react-specifications",

--- a/catalog/generated/human-catalog/manifest.json
+++ b/catalog/generated/human-catalog/manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "contractVersion": 1,
-  "inputDigest": "efa7aaa7e60944c122a7b611e97baf545bf8da18e1df20e16a4eca93667a4024",
+  "inputDigest": "5efec12307e6ab7d9951862e6819f1ba11bd3357fc4edda367a210ee9274dada",
   "files": [
     {
       "path": "CATALOG.md",
@@ -11,7 +11,7 @@
     {
       "path": "catalog.json",
       "size": 64765,
-      "sha256": "74a026a5ea76b84d7d3813e19842837ace4a2dbdda65d5822cad09fa12474ae2"
+      "sha256": "d300401ebf7e302eb5e5e5597b3e6f3c2b7e3c51ada25b4c0b3225510a99623a"
     }
   ]
 }

--- a/catalog/v2/evidence.json
+++ b/catalog/v2/evidence.json
@@ -50,6 +50,16 @@
       "immutableRevision": "b795d5307e20f7f7458a67708b4f26975e223796"
     },
     {
+      "id": "public-fundamentals-concept-source-422ec8e",
+      "officialUrl": "https://github.com/Cratis/AI/tree/422ec8eebc198f9c25c28831a94623a3d4432fea/skills/cratis-fundamentals-concept",
+      "sourceKind": "repository-snapshot",
+      "verifiedOn": "2026-08-22",
+      "expiresOn": "2027-08-22",
+      "applicableVersion": "422ec8eebc198f9c25c28831a94623a3d4432fea",
+      "confidence": "high",
+      "immutableRevision": "422ec8eebc198f9c25c28831a94623a3d4432fea"
+    },
+    {
       "id": "engineering-docs-add-page-source-684d037",
       "officialUrl": "https://github.com/Cratis/AI/tree/684d03755bacd40af95463b81b4a0c8b9f088ec1/engineering/skills/cratis-engineering-docs-add-page",
       "sourceKind": "repository-snapshot",

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -2205,7 +2205,7 @@
       "id": "public-skill-sources-and-resources",
       "sourcePathPatterns": [
         ".ai/skills/add-business-rule/**",
-        ".ai/skills/add-concept/**",
+        "skills/cratis-fundamentals-concept/**",
         ".ai/skills/add-ef-migration/**",
         ".ai/skills/add-projection/**",
         ".ai/skills/add-reactor/**",
@@ -2239,6 +2239,7 @@
         ".ai/skills/write-specs-events/**",
         ".ai/skills/write-specs-frontend/**",
         ".ai/skills/write-specs-readmodels/**",
+        ".ai/skills/add-concept/**",
         "skills/**"
       ],
       "artifactType": "skill-source-and-resources",

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "53596486c904df07cc18580519cd3e88aea7c5b93762d6b02bf7e8aec78f6833",
+  "indexDigest": "147837c5795858cccd951705cc961dc70430542b4860dcf4e8d02f2fa66a1f9a",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/catalog/v2/sources.json
+++ b/catalog/v2/sources.json
@@ -24,20 +24,22 @@
     },
     {
       "id": "add-concept",
-      "sourcePath": ".ai/skills/add-concept",
+      "sourcePath": "skills/cratis-fundamentals-concept",
       "artifactType": "agent-skill-source",
       "currentOwner": "reusable Cratis engineering behavior",
       "targetOwner": "public Cratis product capability",
       "audience": "public",
       "bundledPaths": [
-        ".ai/skills/add-concept/SKILL.md"
+        "skills/cratis-fundamentals-concept/LICENSE",
+        "skills/cratis-fundamentals-concept/SKILL.md"
       ],
-      "sourceRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-      "contentDigest": "f761a6f1f8dfc0b2a8308546bce03ae9391e756d5e6f1a236154e1dfc64cb9ba",
+      "sourceRevision": "422ec8eebc198f9c25c28831a94623a3d4432fea",
+      "contentDigest": "426775e9afc2ff0adb0d8adfd7a5fdaa71c74c60726f11272a224707bf1369c6",
       "publicationApproval": false,
       "evidenceIds": [
         "repo-main-b795d53",
-        "reevaluation-authority"
+        "reevaluation-authority",
+        "public-fundamentals-concept-source-422ec8e"
       ]
     },
     {

--- a/tooling/generate-catalog-v2.mjs
+++ b/tooling/generate-catalog-v2.mjs
@@ -43,6 +43,14 @@ const internalTargets = new Map([
 
 const sourceOverrides = new Map([
     [
+        "add-concept",
+        {
+            sourcePath: "skills/cratis-fundamentals-concept",
+            sourceRevision: "422ec8eebc198f9c25c28831a94623a3d4432fea",
+            evidenceId: "public-fundamentals-concept-source-422ec8e",
+        },
+    ],
+    [
         "add-cratis-docs-page",
         {
             sourcePath: "engineering/skills/cratis-engineering-docs-add-page",
@@ -1397,6 +1405,17 @@ const evidence = [
         applicableVersion: revision,
         confidence: "high",
         immutableRevision: revision,
+    },
+    {
+        id: "public-fundamentals-concept-source-422ec8e",
+        officialUrl:
+            "https://github.com/Cratis/AI/tree/422ec8eebc198f9c25c28831a94623a3d4432fea/skills/cratis-fundamentals-concept",
+        sourceKind: "repository-snapshot",
+        verifiedOn: "2026-08-22",
+        expiresOn: "2027-08-22",
+        applicableVersion: "422ec8eebc198f9c25c28831a94623a3d4432fea",
+        confidence: "high",
+        immutableRevision: "422ec8eebc198f9c25c28831a94623a3d4432fea",
     },
     {
         id: "engineering-docs-add-page-source-684d037",

--- a/tooling/generate-repository-inventory.mjs
+++ b/tooling/generate-repository-inventory.mjs
@@ -128,6 +128,7 @@ const publicSkillRoots = [
     ...v2Sources.sources
         .filter((source) => source.audience === "public")
         .map((source) => `${source.sourcePath}/**`),
+    ".ai/skills/add-concept/**",
     "skills/**",
 ];
 const legacyEngineeringSkillNames = [

--- a/tooling/specs/catalog-v2-validation.spec.mjs
+++ b/tooling/specs/catalog-v2-validation.spec.mjs
@@ -201,6 +201,33 @@ test("documentation authoring is classified but remains unapproved", () => {
     assert.equal(target.includeInRuntime, false);
 });
 
+test("first useful public skill is bound to immutable canonical source", () => {
+    const catalogs = loadCatalogs();
+    const source = catalogs.sources.sources.find(
+        candidate => candidate.id === "add-concept",
+    );
+    const target = catalogs.targets.targets.find(
+        candidate => candidate.id === "cratis-fundamentals-concept",
+    );
+    assert.equal(source.sourcePath, "skills/cratis-fundamentals-concept");
+    assert.equal(
+        source.sourceRevision,
+        "422ec8eebc198f9c25c28831a94623a3d4432fea",
+    );
+    assert.deepEqual(source.bundledPaths, [
+        "skills/cratis-fundamentals-concept/LICENSE",
+        "skills/cratis-fundamentals-concept/SKILL.md",
+    ]);
+    assert(
+        source.evidenceIds.includes(
+            "public-fundamentals-concept-source-422ec8e",
+        ),
+    );
+    assert.deepEqual(target.sourceSkillIds, ["add-concept"]);
+    assert.equal(target.approval.state, "candidate");
+    assert.equal(target.includeInRuntime, false);
+});
+
 test("documentation companions are classified and bound but unevaluated", () => {
     const catalogs = loadCatalogs();
     const expectations = [

--- a/tooling/specs/distribution-fixture.spec.mjs
+++ b/tooling/specs/distribution-fixture.spec.mjs
@@ -103,10 +103,7 @@ test("distribution requirements and artifact matrix stay authority bounded", () 
     assert.equal(matrix.state, "FIXTURE_ONLY_LOCAL_STAGING");
     assert.equal(matrix.publicationEligible, false);
     assert.equal(matrix.promotionEligible, false);
-    assert.equal(
-        matrix.repository.status,
-        "INITIALIZED_PROTECTED_FIXTURE",
-    );
+    assert.equal(matrix.repository.status, "INITIALIZED_PROTECTED_FIXTURE");
     const requirementIds = new Set(
         requirements.requirements.map((item) => item.id),
     );
@@ -408,7 +405,10 @@ test("distribution generator CLI binds the requested fixture version", () => {
         execFileSync(
             process.execPath,
             [
-                join(repositoryRoot, "tooling/generate-distribution-fixture.mjs"),
+                join(
+                    repositoryRoot,
+                    "tooling/generate-distribution-fixture.mjs",
+                ),
                 stage,
                 "0.0.5-fixture",
             ],
@@ -418,20 +418,19 @@ test("distribution generator CLI binds the requested fixture version", () => {
             readJson(join(stage, "distribution-manifest.json")).version,
             "0.0.5-fixture",
         );
-        assert.throws(
-            () =>
-                execFileSync(
-                    process.execPath,
-                    [
-                        join(
-                            repositoryRoot,
-                            "tooling/generate-distribution-fixture.mjs",
-                        ),
-                        join(root, "invalid"),
-                        "latest",
-                    ],
-                    { cwd: repositoryRoot, stdio: "pipe" },
-                ),
+        assert.throws(() =>
+            execFileSync(
+                process.execPath,
+                [
+                    join(
+                        repositoryRoot,
+                        "tooling/generate-distribution-fixture.mjs",
+                    ),
+                    join(root, "invalid"),
+                    "latest",
+                ],
+                { cwd: repositoryRoot, stdio: "pipe" },
+            ),
         );
     });
 });

--- a/tooling/specs/engineering-distribution-fixture.spec.mjs
+++ b/tooling/specs/engineering-distribution-fixture.spec.mjs
@@ -285,10 +285,7 @@ test("engineering Grok and DeepSeek fixtures install and remove", () => {
             { installed: true, removed: true },
         );
         assert.deepEqual(
-            smokeDeepSeekEngineeringFixture(
-                stage,
-                join(root, "deepseek-home"),
-            ),
+            smokeDeepSeekEngineeringFixture(stage, join(root, "deepseek-home")),
             { installed: true, removed: true },
         );
     });


### PR DESCRIPTION
# Summary

Binds the first useful public skill to the immutable canonical source created by #162 and preserves generated formatter output.

## Changed

- Bind `add-concept` source identity to `skills/cratis-fundamentals-concept` at `422ec8e` (#148)
- Add immutable repository-snapshot evidence (#148)
- Preserve the superseded legacy source in repository inventory without making it packageable (#148)
- Keep target approval candidate-only and runtime disabled pending named owner review (#148)
