### PR TITLE
Format public source catalog specs

### DIFF
--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "147837c5795858cccd951705cc961dc70430542b4860dcf4e8d02f2fa66a1f9a",
+  "indexDigest": "50de38f16d5d3440145c66887de5d925f56da5277ded1049323963c9d4d956bf",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/tooling/specs/catalog-v2-validation.spec.mjs
+++ b/tooling/specs/catalog-v2-validation.spec.mjs
@@ -204,10 +204,10 @@ test("documentation authoring is classified but remains unapproved", () => {
 test("first useful public skill is bound to immutable canonical source", () => {
     const catalogs = loadCatalogs();
     const source = catalogs.sources.sources.find(
-        candidate => candidate.id === "add-concept",
+        (candidate) => candidate.id === "add-concept",
     );
     const target = catalogs.targets.targets.find(
-        candidate => candidate.id === "cratis-fundamentals-concept",
+        (candidate) => candidate.id === "cratis-fundamentals-concept",
     );
     assert.equal(source.sourcePath, "skills/cratis-fundamentals-concept");
     assert.equal(


### PR DESCRIPTION
# Summary

Preserves formatter output produced after the immutable public-source binding merge and refreshes the generated inventory digest. Behavior and approval state are unchanged.

## Changed

- Format public source catalog specs (#148)
