### PR TITLE
Add profile subscriptions and release hardening

### DIFF
--- a/.ai/README.md
+++ b/.ai/README.md
@@ -1,6 +1,14 @@
-# Shared AI Assistant Configuration
+# Repository-local AI corpus
 
-`.ai/` is the **single source of truth** for all AI-assistant configuration — rules, agents, prompts, skills, hooks. Everything is written once here and surfaced to each tool through adapters (path-reference files or symlinks). **Never edit files under `.github/`, `.claude/`, `.agents/`, or root `AGENTS.md` directly** — they are adapters, and any direct edit is lost the next time the source changes.
+`.ai/` is the **single source of truth inside this repository** for legacy and
+repository-local rules, agents, prompts, skills, and hooks surfaced through
+adapters. It is not a package root and is never propagated wholesale.
+Canonical public and maintainer package sources live under `skills/` and
+`engineering/`; see
+[`Documentation/ai-distribution-and-subscriptions.md`](../Documentation/ai-distribution-and-subscriptions.md).
+
+**Never edit files under `.github/`, `.claude/`, `.agents/`, or root `AGENTS.md`
+directly** when they are adapters to `.ai/`; fix the local canonical source.
 
 ## Authority model
 
@@ -17,9 +25,13 @@ A skill may refine *how* to apply a rule, but must not contradict a non-negotiab
 
 Every rule is one of: **Framework contract** (enforced by Arc/Chronicle source/analyzers/runtime) · **Cratis convention** (house default for maintainability — the framework does not enforce it) · **Product policy** (belongs in a downstream app's own `.ai/`, not here). Rules state which they are; never claim "the framework requires" a convention.
 
-## Profiles
+## Local rule profiles
 
-The corpus serves two repo types from one source: **application** (building *on* Cratis — event-sourced vertical slices) and **framework** (contributing to Cratis libraries — Arc/Chronicle/Fundamentals/Components, see `rules/framework.md`). A rule declares `profile: application` or `profile: framework`; rules with no `profile:` are universal. `general.md` routes by profile; `applyTo`/`paths` scope by file type, `profile:` by repo type.
+The local corpus distinguishes **application** and **framework** rules.
+Versioned distribution uses narrower product and repository profiles from
+[`distribution/profile-catalog.json`](../distribution/profile-catalog.json),
+including Arc, Chronicle, Fundamentals, Components, Studio, Stagehand, clients,
+documentation, and corpus work.
 
 ## Structure
 
@@ -45,8 +57,13 @@ Scoped rules include both `applyTo` (Copilot matching) and `paths` (Claude match
 
 Run `.ai/hooks/scripts/validate-ai-setup.sh` after changing rules/skills/adapters — it validates frontmatter, adapter integrity (path-reference *or* symlink resolving to the right rule), resolving adapter targets, Codex adapters, and content-drift guards (warnings). Structural/adapter/Codex failures are fatal; drift guards are advisory warnings. Fix reported issues before committing.
 
-## Propagation
+## Distribution
 
-This repo is the hub that can propagate `.ai/` content to other Cratis repositories. The propagation workflow and any profile/repo-type scoping are managed separately from the corpus content itself — see `rules/managing-ai-rules.md` for how propagation interacts with adapters.
+Broad propagation and reverse synchronization are retired. Consuming
+repositories select profiles and pin exact versions; improvements return through
+issues or pull requests to `Cratis/AI`, then flow downstream in a new immutable
+release and reviewed update pull requests.
 
-See `rules/managing-ai-rules.md` for the full guide on adding, updating, and renaming rules/skills/agents/prompts/hooks.
+See `rules/managing-ai-rules.md` for local adapter maintenance and the
+[distribution guide](../Documentation/ai-distribution-and-subscriptions.md) for
+shared package behavior.

--- a/.ai/agents/coordinator.md
+++ b/.ai/agents/coordinator.md
@@ -22,15 +22,16 @@ You are the **Coordinator** for Cratis-based projects.
 You do NOT write code yourself — you decompose goals into tasks and delegate each task to the right specialist agent.
 
 Always read and follow:
+
 - `.github/copilot-instructions.md`
-- `.github/instructions/vertical-slices.instructions.md`
+- `.ai/rules/vertical-slices.md`
 
 ---
 
 ## Available specialist agents
 
 | Agent | Handles |
-|---|---|
+| --- | --- |
 | `backend-developer` | C# slice files — commands, events, validators, constraints, projections, reactors |
 | `frontend-developer` | React/TypeScript components, composition pages, routing |
 | `spec-writer` | Integration specs (C#) and unit specs (TypeScript) |

--- a/.ai/agents/orchestrator.md
+++ b/.ai/agents/orchestrator.md
@@ -23,15 +23,16 @@ You are the **top-level team manager** — the entry point for any complex goal 
 You do NOT write code or documentation yourself — you assemble the right team, sequence their work, and ensure nothing falls through the cracks.
 
 Always read and follow:
+
 - `.github/copilot-instructions.md`
-- `.github/instructions/vertical-slices.instructions.md`
+- `.ai/rules/vertical-slices.md`
 
 ---
 
 ## Your team
 
 | Agent | Best for |
-|---|---|
+| --- | --- |
 | `coordinator` | Cross-cutting implementation work — backend + frontend + reviews across multiple concerns |
 | `planner` | One or more complete vertical slices end-to-end (backend → build → frontend → specs) |
 | `backend-developer` | C# slice files only (when you want direct control, not via planner) |
@@ -46,7 +47,7 @@ Always read and follow:
 ## When to use which orchestration agent
 
 | Use `orchestrator` when… | Delegate to `coordinator` when… | Delegate to `planner` when… |
-|---|---|---|
+| --- | --- | --- |
 | The goal spans implementation + documentation + review | The goal is implementation only (backend + frontend) | The goal is one or more vertical slices |
 | Multiple independent workstreams need to run in parallel | Work crosses multiple concerns but stays within implementation | You need a slice from command to React component |
 | You're unsure what combination of agents is needed | You need infrastructure changes + slice implementation | You know exactly which slices to build |

--- a/.ai/agents/performance-reviewer.md
+++ b/.ai/agents/performance-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: Performance Reviewer
 description: >
-  Performance-focused review agent for Cratis-based projects. Analyses changed
+  Performance-focused review agent for Cratis-based projects. Analyzes changed
   files for projection efficiency, query patterns, unnecessary allocations,
   React render overhead, and Chronicle anti-patterns before merge.
 model: claude-sonnet-4-5
@@ -23,7 +23,7 @@ Your responsibility is to identify performance problems in changed code before t
 
 ### Chronicle / Event Sourcing
 
-- [ ] Projections use `.AutoMap()` — avoids manual field mapping cost
+- [ ] Projections rely on AutoMap's on-by-default behavior and do not call `.AutoMap()` unless re-enabling it inside a `.NoAutoMap()` scope
 - [ ] Projections do NOT perform joins on the read model (Chronicle re-hydrates from events; joining on the model forces a full re-read)
 - [ ] Reactors do NOT re-query the event log inside their `On()` handler — use event data directly
 - [ ] No eager loading of entire event logs or event sequences without paging/filtering
@@ -56,7 +56,7 @@ Your responsibility is to identify performance problems in changed code before t
 
 ### General .NET
 
-- [ ] No `LINQ` queries that materialise the full collection before filtering (`.ToList()` before `.Where()`)
+- [ ] No `LINQ` queries that materialize the full collection before filtering (`.ToList()` before `.Where()`)
 - [ ] `IEnumerable<T>` is not enumerated multiple times — if multiple iterations are needed, `.ToList()` once
 - [ ] No string concatenation in hot paths — use `StringBuilder` or interpolation
 - [ ] Logging of large objects / collections uses `{@obj}` only at Debug level — never at Info/Warning/Error
@@ -66,7 +66,7 @@ Your responsibility is to identify performance problems in changed code before t
 ## Risk classification
 
 | Label | Meaning |
-|-------|---------|
+| ------- | --------- |
 | 🔴 High | Will cause measurable degradation at moderate load — must fix before merge |
 | 🟡 Medium | Could degrade under load or at scale — should fix soon |
 | 🟢 Low | Minor inefficiency or style issue — fix when convenient |
@@ -83,17 +83,17 @@ Group findings by category:
 ```
 ### MongoDB / Read Models
 
-🟡 **Medium** — `Features/Projects/Listing/AllProjects.cs`
+🟡 **Medium** — `<AppSourceRoot>/Projects/Listing/AllProjects.cs`
 > The query does not specify a sort order or index hint, which will result in a
 > collection scan once the `projects` collection grows.
 > Fix: Add `.SortBy(m => m.Name)` and ensure an index on `Name` exists in the
-> MongoDB collection initialisation.
+> MongoDB collection initialization.
 ```
 
 End with a summary table:
 
 | Category | Status |
-|----------|--------|
+| ---------- | -------- |
 | Chronicle / Event Sourcing | ✅ / ⚠️ / ❌ |
 | MongoDB / Read Models | ✅ / ⚠️ / ❌ |
 | ASP.NET Core / Commands & Queries | ✅ / ⚠️ / ❌ |

--- a/.ai/agents/planner.md
+++ b/.ai/agents/planner.md
@@ -20,8 +20,10 @@ Your responsibility is to **plan, sequence, and coordinate** the implementation 
 You do NOT write code yourself — you decompose the work and delegate it.
 
 Always read and follow:
-- `.github/instructions/vertical-slices.instructions.md`
-- `.github/copilot-instructions.md`
+
+- `AGENTS.md`
+- `.ai/rules/vertical-slices.md`
+- the consuming repository's `.agents/PROJECT.md` when present
 
 ---
 
@@ -45,22 +47,24 @@ For each slice, produce a numbered task list using this template:
 ## Plan for <Feature> / <Slice>  (Type: <SliceType>)
 
 ### Phase 1 — Backend  [delegate to: backend-developer]
-1. Create `Features/<Feature>/<Slice>/<Slice>.cs` with ALL artifacts
+1. Create `<AppSourceRoot>/<Module?>/<Feature>/<Slice>/<Slice>.cs` with all backend artifacts. Omit `<Module?>` when no natural domain grouping exists; never introduce a top-level `Features/` wrapper.
 
-### Phase 2 — Specs  [delegate to: spec-writer]  (State Change slices only)
-2. Write integration specs in `Features/<Feature>/<Slice>/when_<behavior>/`
+### Phase 2 — Specs  [delegate to: spec-writer]
+2. Write in-process scenario specs in `<AppSourceRoot>/<Module?>/<Feature>/<Slice>/when_<behavior>/` for every slice type.
 
-### Phase 3 — Build  [run: dotnet build]
-3. Run `dotnet build` to generate TypeScript proxies
+### Phase 3 — Build  [run: Debug, then Release]
+3. Run `dotnet build -c Debug` to validate spec code and generate TypeScript proxies.
+4. Run `dotnet build -c Release -p:CratisProxiesOutputPath=` as a build-only release check.
 
 ### Phase 4 — Frontend  [delegate to: frontend-developer]
-4. Create React component(s) in `Features/<Feature>/<Slice>/`
-5. Register component in the composition page `Features/<Feature>/<Feature>.tsx`
-6. Update routing if this slice introduces a new page
+5. Create React component(s) beside the slice in `<AppSourceRoot>/<Module?>/<Feature>/<Slice>/`.
+6. Register the component in `<AppSourceRoot>/<Module?>/<Feature>/<Feature>.tsx`.
+7. Update routing if this slice introduces a new page.
 
 ### Phase 5 — Quality Gates  [delegate to: code-reviewer, then security-reviewer]
-7. Code review
-8. Security review
+8. Run relevant specs and frontend lint/test/build gates.
+9. Code review.
+10. Security review.
 ```
 
 ---
@@ -80,7 +84,7 @@ For each slice, produce a numbered task list using this template:
 When handing off to a specialist:
 
 1. State exactly which files need to be created or modified.
-2. Quote the relevant section of `vertical-slices.instructions.md` that applies.
+2. Quote the relevant section of `.ai/rules/vertical-slices.md` that applies.
 3. State the acceptance criteria (what "done" looks like for this task).
 4. Tell the specialist which agent to hand back to when finished.
 
@@ -106,6 +110,7 @@ A slice is **not done** until:
 ## Session management
 
 For large features with many slices, use these techniques to keep context manageable:
+
 - **`/compact`** after completing each phase to free context space. Add focus notes: `/compact focus on remaining slices and unresolved issues`.
 - **`/fork`** before exploring an alternative design approach, so the original plan is preserved.
 - The **Explore subagent** automatically handles codebase research on a fast model — let it work rather than doing manual searches.
@@ -118,11 +123,11 @@ Always produce your plan as a markdown checklist so progress can be tracked.
 Each task entry must include the delegating agent in square brackets, e.g.:
 
 ```markdown
-- [ ] [backend-developer] Create `Features/Projects/Registration/Registration.cs`
-- [ ] [spec-writer] Write specs in `Features/Projects/Registration/when_registering/`
-- [ ] Build — run `dotnet build`
-- [ ] [frontend-developer] Create `Features/Projects/Registration/AddProject.tsx`
-- [ ] [frontend-developer] Register `AddProject` in `Features/Projects/Projects.tsx`
+- [ ] [backend-developer] Create `<AppSourceRoot>/Projects/Registration/Registration.cs`
+- [ ] [spec-writer] Write specs in `<AppSourceRoot>/Projects/Registration/when_registering/`
+- [ ] Build — run Debug, then the build-only Release command
+- [ ] [frontend-developer] Create `<AppSourceRoot>/Projects/Registration/AddProject.tsx`
+- [ ] [frontend-developer] Register `AddProject` in `<AppSourceRoot>/Projects/Projects.tsx`
 - [ ] [code-reviewer] Review all changed files
 - [ ] [security-reviewer] Security review of all changed files
 ```

--- a/.ai/rules/managing-ai-rules.md
+++ b/.ai/rules/managing-ai-rules.md
@@ -9,9 +9,18 @@ paths:
   - "README.md"
 ---
 
-# Managing AI Rules and Instructions
+# Managing repository-local AI rules and instructions
 
-`.ai/` is the **single source of truth** for all AI assistant configuration in this repository — rules, agents, prompts, skills, and hooks. Everything is written once in `.ai/` and surfaced to each AI tool through adapters: folder symlinks, per-file symlinks, or small **path-reference files** whose body is the relative path to the canonical source.
+> **Scope:** `.ai/` is the source for the legacy and repository-local adapters in
+> this repository. It is not a package root and is never propagated wholesale.
+> Canonical public skills live under `skills/`, canonical maintainer skills live
+> under `engineering/`, and profile releases follow
+> [`Documentation/ai-distribution-and-subscriptions.md`](../../Documentation/ai-distribution-and-subscriptions.md).
+
+Within this repository, `.ai/` remains the **single source of truth** for rules,
+agents, prompts, legacy skills, and hooks surfaced through local adapters:
+folder symlinks, per-file symlinks, or small **path-reference files** whose body
+is the relative path to the canonical source.
 
 > **Never edit files under `.github/`, `.claude/`, `.agents/`, or the root `AGENTS.md` directly.** They are all adapters. Any direct edit would be lost the next time the canonical source changes, and would diverge from it.
 
@@ -53,7 +62,7 @@ AGENTS.md                        ← Codex root instructions → .ai/rules/gener
 **Each tool has its own conventions, so adapters differ by surface** (verified against each tool's docs):
 
 | Surface | Copilot | Claude Code | Codex |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Root instructions | `copilot-instructions.md` → `general.md` | `CLAUDE.md` → `general.md` | `AGENTS.md` → `general.md` |
 | Scoped rules | `instructions/` (folder symlink → `.ai/rules`) | `rules/<n>.md` (per-file) | — |
 | Agents | `agents/<n>.agent.md` (per-file, `.agent.md` suffix) | `agents/` (folder symlink, `<n>.md`) | — |
@@ -123,13 +132,17 @@ Always edit the canonical file in the relevant `.ai/` subfolder — never the ad
 
 - **Skills** (`.ai/skills/<n>/SKILL.md`) — folder symlinks on all three sides pick up new/renamed skills automatically. No adapter step.
 - **Agents** (`.ai/agents/<n>.md`) — Claude's `.claude/agents` folder symlink is automatic, but **Copilot needs a per-file `.agent.md` adapter**:
+
   ```bash
   ln -s ../../.ai/agents/<n>.md .github/agents/<n>.agent.md
   ```
+
 - **Prompts** (`.ai/prompts/<n>.prompt.md`) — Copilot's `.github/prompts` folder symlink is automatic, but **Claude needs a per-file command adapter**:
+
   ```bash
   ln -s ../../.ai/prompts/<n>.prompt.md .claude/commands/<n>.md
   ```
+
 - **Hooks** (`.ai/hooks/*.md`) — these are *guidance*, not wired hooks. To enforce, add the real artifact per tool (Claude `.claude/settings.json`; Copilot `.github/hooks/*.json`).
 
 Run `hooks/scripts/validate-ai-setup.sh` after adding an agent or prompt to confirm its adapter resolves.
@@ -152,7 +165,7 @@ Run `hooks/scripts/validate-ai-setup.sh` after adding an agent or prompt to conf
 An adapter's target (the symlink target, or the path-reference file's body) uses a **relative path** from the adapter's location to the canonical file:
 
 | Adapter location | Target |
-|---|---|
+| --- | --- |
 | `.github/instructions` (folder symlink) | `../.ai/rules` |
 | `.claude/rules/<name>.md` | `../../.ai/rules/<name>.md` |
 | `.github/agents/<name>.agent.md` | `../../.ai/agents/<name>.md` |
@@ -162,10 +175,26 @@ An adapter's target (the symlink target, or the path-reference file's body) uses
 | `AGENTS.md` (repo root, Codex) | `.ai/rules/general.md` |
 | `.agents/skills`, `.github/prompts`, `.github/skills`, `.claude/agents`, `.claude/skills` (folder symlinks) | the matching `.ai/<sub>` folder |
 
-## Propagation and adapters
+## Distribution and adapters
 
-The cross-repository propagation workflow is a broadcast sync: any Cratis repository can be the source, and changes propagate to the other repositories, including `Cratis/AI` when the source is not `Cratis/AI`. Propagation normalizes known adapter paths before broadcasting them. When the matching canonical `.ai` file exists in the source tree, an adapter path is written as the expected symlink or path-reference file, even if the source repository currently contains copied content at that adapter path. Do not materialize adapter targets into copied `.ai` content in tool-specific files; that breaks the `.ai/` source-of-truth model and causes drift between adapters and canonical corpus files.
+Cross-repository broadcast propagation and reverse synchronization are retired.
+`Cratis/AI` is the canonical merge point for shared behavior. Consuming
+repositories select profiles and exact versions in project-owned subscriptions;
+generated packages flow downstream through reviewed update pull requests.
+
+An improvement discovered elsewhere is proposed upstream with its originating
+repository, immutable revision, product authority, affected profiles, and
+compatibility impact. After review, `Cratis/AI` releases a new immutable version.
+No consuming repository publishes packages, pushes generated bytes, or writes
+changes directly back into this source tree.
+
+Local adapter symlinks and path-reference files remain an implementation detail
+inside this repository. Do not materialize their targets into copied `.ai`
+content.
 
 ## Shared workflows
 
-Workflow files intended to be synced to other repositories live in `.ai/workflows/`. They follow the same symlink pattern — the propagate workflow copies `.ai/workflows/` content to target repositories.
+Reusable workflow behavior is versioned and reviewed like other shared behavior;
+it is not synchronized from `.ai/workflows/` into consuming repositories.
+Product repositories own their workflow invocation and exact immutable workflow
+reference.

--- a/.github/ISSUE_TEMPLATE/shared-ai-improvement.yml
+++ b/.github/ISSUE_TEMPLATE/shared-ai-improvement.yml
@@ -1,0 +1,74 @@
+name: Propose a shared Cratis AI improvement
+description: Upstream a skill, rule, profile, or product-authority improvement from a Cratis repository.
+title: "[AI improvement]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Shared AI behavior is changed in Cratis/AI and released back to subscribers. Do not copy or publish generated package bytes from a consuming repository.
+  - type: input
+    id: source-repository
+    attributes:
+      label: Originating repository
+      description: The Cratis repository where the improvement was discovered.
+      placeholder: Cratis/Chronicle
+    validations:
+      required: true
+  - type: input
+    id: source-revision
+    attributes:
+      label: Immutable source revision
+      description: Full commit SHA containing the evidence or motivating change.
+      placeholder: 40-character commit SHA
+    validations:
+      required: true
+  - type: dropdown
+    id: audience
+    attributes:
+      label: Audience
+      options:
+        - Public developers
+        - Cratis engineering maintainers
+        - Both through separate artifacts
+    validations:
+      required: true
+  - type: input
+    id: profiles
+    attributes:
+      label: Affected profiles and products
+      description: Name every profile/product that should receive the change.
+      placeholder: engineering-framework-chronicle, public-chronicle
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem and proposed behavior
+      description: Explain the observed failure or improvement and the desired shared behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: authority
+    attributes:
+      label: Product authority and evidence
+      description: Link first-party APIs, docs, specs, tests, or owner decisions. Do not infer product facts.
+    validations:
+      required: true
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility and migration impact
+      description: Note trigger collisions, renamed behavior, supported versions, and downstream migration needs.
+    validations:
+      required: true
+  - type: checkboxes
+    id: contract
+    attributes:
+      label: Contribution contract
+      options:
+        - label: I am proposing canonical source behavior, not editing generated distribution bytes.
+          required: true
+        - label: I understand delivery flows downstream through a new immutable release and reviewed update PRs.
+          required: true

--- a/.github/workflows/distribution-canary-rollback.yml
+++ b/.github/workflows/distribution-canary-rollback.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           set -euo pipefail
           node tooling/stage-distribution-candidate.mjs \
-            --artifact sanitized-public-materializer-fixture \
+            --artifact cratis-fundamentals-concept-preview \
             --output "$RUNNER_TEMP/distribution-candidate" \
             --record "$RUNNER_TEMP/distribution-candidate.json"
           node tooling/generate-distribution-fixture.mjs \

--- a/.github/workflows/propagate-copilot-instructions.yml
+++ b/.github/workflows/propagate-copilot-instructions.yml
@@ -1,98 +1,27 @@
-name: Propagate Copilot Instructions
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+name: Retired - Propagate Copilot Instructions
 
 on:
-  push:
-    branches: ["main"]
-    paths:
-      - ".ai/**"
-      - ".claude/**"
-      - ".github/copilot-instructions.md"
-      - ".github/instructions/**"
-      - ".github/agents/**"
-      - ".github/skills/**"
-      - ".github/prompts/**"
-      - ".github/hooks/**"
-  workflow_dispatch:
+        workflow_dispatch:
 
 permissions:
-  contents: read
+        contents: read
 
 jobs:
-  propagate:
-    uses: Cratis/Workflows/.github/workflows/propagate-copilot-instructions.yml@main
-    with:
-      event_name: ${{ github.event_name }}
-    secrets: inherit
+        retired:
+                runs-on: ubuntu-latest
+                steps:
+                        - name: Explain the replacement
+                          run: |
+                                  cat <<'EOF'
+                                  Broad corpus propagation is retired.
 
-  # The fan-out is a matrix with fail-fast disabled, so one target failing leaves
-  # the other 33 to finish - which is right, but it means a partial failure is
-  # only visible to someone who opens the run and reads 34 job results. Run
-  # 32255505376 propagated to 29 repositories and failed on 7, and the corpus in
-  # those 7 went stale without anyone being told.
-  #
-  # This job says which repositories are behind, by name, in the run summary and
-  # in the log. It reads the conclusions of this same run's matrix jobs through
-  # the Actions API - the caller cannot see them any other way, since a reusable
-  # workflow reports one aggregate result to its caller.
-  report-fan-out:
-    needs: propagate
-    if: ${{ always() && github.repository_owner == 'Cratis' }}
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-    steps:
-      - name: Report which repositories received the corpus
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RUN_ID: ${{ github.run_id }}
-        run: |
-          set -euo pipefail
+                                  Shared behavior is released from Cratis/AI as immutable, profile-scoped
+                                  packages. Consuming repositories pin exact versions and receive reviewed
+                                  update pull requests. Improvements flow upstream through Cratis/AI issues
+                                  or pull requests; generated or copied folders never sync bidirectionally.
 
-          # `propagate (<repo>)` is the matrix job name; the reusable workflow
-          # prefixes it, so match on the suffix rather than anchoring the whole
-          # string. Paginated because a 34-way matrix plus its parents exceeds
-          # the default page size.
-          jobs_json=$(gh api --paginate \
-            "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs?per_page=100" \
-            --jq '[.jobs[] | select(.name | test("propagate \\(")) | {
-                    repo: (.name | capture("propagate \\((?<r>[^)]+)\\)").r),
-                    conclusion: .conclusion
-                  }]' | jq -sc 'add // []')
-
-          total=$(echo "$jobs_json" | jq 'length')
-          if [ "$total" -eq 0 ]; then
-            # No matrix jobs at all: the fan-out was skipped because nothing
-            # needed propagating. That is a normal outcome, not a failure.
-            echo "No propagation targets ran - nothing to report."
-            echo "No propagation targets ran for this change." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          succeeded=$(echo "$jobs_json" | jq '[.[] | select(.conclusion == "success")] | length')
-          behind=$(echo "$jobs_json" | jq -r '[.[] | select(.conclusion != "success") | .repo] | sort | .[]')
-
-          {
-            echo "## Corpus propagation"
-            echo
-            echo "${succeeded} of ${total} repositories received the corpus."
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          if [ -z "$behind" ]; then
-            echo "All ${total} repositories received the corpus."
-            exit 0
-          fi
-
-          {
-            echo
-            echo "### These repositories are now behind"
-            echo
-            while IFS= read -r repo; do
-              [ -n "$repo" ] && echo "- ${repo}"
-            done <<< "$behind"
-            echo
-            echo "They kept the corpus they already had. Their agents are working from"
-            echo "older rules until this is resolved and propagation runs again."
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          echo "::error::Propagation reached ${succeeded} of ${total} repositories. Behind: $(echo "$behind" | tr '\n' ' ')"
-          exit 1
+                                  See Documentation/ai-distribution-and-subscriptions.md.
+                                  EOF

--- a/.github/workflows/sync-copilot-instructions.yml
+++ b/.github/workflows/sync-copilot-instructions.yml
@@ -1,16 +1,26 @@
-name: Sync Copilot Instructions
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+name: Retired - Sync Copilot Instructions
 
 on:
-  workflow_dispatch:
-    inputs:
-      source_repository:
-        description: 'Source repository (owner/repo format)'
-        required: true
-        type: string
+        workflow_dispatch:
+
+permissions:
+        contents: read
 
 jobs:
-  sync:
-    uses: Cratis/Workflows/.github/workflows/sync-copilot-instructions.yml@main
-    with:
-      source_repository: ${{ inputs.source_repository }}
-    secrets: inherit
+        retired:
+                runs-on: ubuntu-latest
+                steps:
+                        - name: Explain the replacement
+                          run: |
+                                  cat <<'EOF'
+                                  Repository-to-repository instruction synchronization is retired.
+
+                                  Select a profile and exact version in project-owned .cratis/ai.json.
+                                  Package updates arrive as reviewed pull requests. Propose shared behavior
+                                  changes upstream in Cratis/AI instead of copying generated files back.
+
+                                  See Documentation/ai-distribution-and-subscriptions.md.
+                                  EOF

--- a/.github/workflows/verify-ai-corpus.yml
+++ b/.github/workflows/verify-ai-corpus.yml
@@ -4,83 +4,103 @@
 name: Verify AI Corpus
 
 on:
-  pull_request:
-    paths:
-      - ".ai/**"
-      - ".github/workflows/verify-ai-corpus.yml"
-      - "AI-REPOSITORY-REDESIGN-*.md"
-      - "Documentation/**"
-      - "catalog/**"
-      - "tooling/**"
-  push:
-    branches: ["main"]
-    paths:
-      - ".ai/**"
-      - ".github/workflows/verify-ai-corpus.yml"
-      - "AI-REPOSITORY-REDESIGN-*.md"
-      - "Documentation/**"
-      - "catalog/**"
-      - "tooling/**"
-  workflow_dispatch:
+    pull_request:
+        paths:
+            - ".ai/**"
+            - ".agents/**"
+            - ".github/ISSUE_TEMPLATE/**"
+            - ".github/workflows/**"
+            - "AGENTS.md"
+            - "README.md"
+            - "AI-REPOSITORY-REDESIGN-*.md"
+            - "Documentation/**"
+            - "catalog/**"
+            - "distribution/**"
+            - "engineering/**"
+            - "evals/**"
+            - "evidence/**"
+            - "pilots/**"
+            - "skills/**"
+            - "tooling/**"
+    push:
+        branches: ["main"]
+        paths:
+            - ".ai/**"
+            - ".agents/**"
+            - ".github/ISSUE_TEMPLATE/**"
+            - ".github/workflows/**"
+            - "AGENTS.md"
+            - "README.md"
+            - "AI-REPOSITORY-REDESIGN-*.md"
+            - "Documentation/**"
+            - "catalog/**"
+            - "distribution/**"
+            - "engineering/**"
+            - "evals/**"
+            - "evidence/**"
+            - "pilots/**"
+            - "skills/**"
+            - "tooling/**"
+    workflow_dispatch:
 
 permissions:
-  contents: read
+    contents: read
 
 concurrency:
-  group: verify-ai-corpus-${{ github.ref }}
-  cancel-in-progress: true
+    group: verify-ai-corpus-${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
-  verify:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Check out the complete evidence history
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
+    verify:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            - name: Check out the complete evidence history
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  fetch-depth: 0
+                  persist-credentials: false
 
-      - name: Use Node.js 24
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
+            - name: Use Node.js 24
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+              with:
+                  node-version: 24
 
-      - name: Validate the AI corpus
-        run: .ai/hooks/scripts/validate-ai-setup.sh
+            - name: Validate the AI corpus
+              run: .ai/hooks/scripts/validate-ai-setup.sh
 
-      - name: Verify generated catalogs are current
-        run: |
-          set -euo pipefail
-          node tooling/generate-catalog-v2.mjs
-          node tooling/generate-human-catalog.mjs
-          node tooling/generate-repository-inventory.mjs
-          git diff --exit-code -- catalog/v2 catalog/generated/human-catalog
+            - name: Verify generated catalogs are current
+              run: |
+                  set -euo pipefail
+                  node tooling/generate-catalog-v2.mjs
+                  node tooling/generate-human-catalog.mjs
+                  node tooling/generate-repository-inventory.mjs
+                  git diff --exit-code -- catalog/v2 catalog/generated/human-catalog
 
-      - name: Validate catalogs and specifications
-        run: |
-          set -euo pipefail
-          node tooling/validate-catalogs.mjs
-          node --test tooling/specs/*.spec.mjs
+            - name: Validate catalogs and specifications
+              run: |
+                  set -euo pipefail
+                  node tooling/validate-catalogs.mjs
+                  node --test tooling/specs/*.spec.mjs
 
-      - name: Verify strict JSON inputs
-        run: |
-          node <<'NODE'
-          const { readdirSync, readFileSync } = require('node:fs');
-          const { join } = require('node:path');
+            - name: Verify strict JSON inputs
+              run: |
+                  node <<'NODE'
+                  const { readdirSync, readFileSync } = require('node:fs');
+                  const { join } = require('node:path');
 
-          function files(root) {
-            return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
-              const path = join(root, entry.name);
-              return entry.isDirectory() ? files(path) : [path];
-            });
-          }
+                  function files(root) {
+                    return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+                      const path = join(root, entry.name);
+                      return entry.isDirectory() ? files(path) : [path];
+                    });
+                  }
 
-          const inputs = files('catalog').filter((path) =>
-            path.endsWith('.json') || path.endsWith('.yml'));
-          for (const path of inputs) JSON.parse(readFileSync(path, 'utf8'));
-          process.stdout.write(`Strict JSON inputs verified: ${inputs.length}\n`);
-          NODE
+                  const inputs = files('catalog').filter((path) =>
+                    path.endsWith('.json') || path.endsWith('.yml'));
+                  for (const path of inputs) JSON.parse(readFileSync(path, 'utf8'));
+                  process.stdout.write(`Strict JSON inputs verified: ${inputs.length}\n`);
+                  NODE
 
-      - name: Reject whitespace errors
-        run: git diff --check
+            - name: Reject whitespace errors
+              run: git diff --check

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
@@ -1848,3 +1848,54 @@ contract reverification before a supported stable release. Publication and
 promotion remain disabled; the immediate path is canonical source binding, a
 small passive preview allowlist, one real consuming-repository canary, and the
 existing credential/owner gates.
+
+## 49. Profile subscriptions and release hardening — 2026-08-22
+
+A fresh public, maintainer, distribution, security, and official-host review
+rejected any claim that the repository was done or broadly usable. It found one
+canonical public skill, zero approved/runtime targets, fixture-only packages,
+stale local agents/docs, incomplete CI path triggers, an artifact authorization
+mismatch, null public source provenance, and no production per-harness release
+implementation.
+
+The long-term decision is now explicit:
+
+- `Cratis/AI` owns shared AI behavior and profile composition;
+- product repositories own product facts and immutable authority evidence;
+- consuming repositories own `.cratis/PROJECT.md`, `.cratis/ai.json`, and
+  minimal host bootstraps;
+- `Cratis/AI.Distribution` owns bot-generated immutable artifacts;
+- public and engineering profiles are product/repository-specific rather than
+  one universal corpus;
+- all profile packages share an atomic SemVer release train and exact pins;
+- updates arrive through reviewed pull requests;
+- consuming repositories contribute improvements upstream through issues/PRs,
+  never through automatic reverse sync or generated-byte publication.
+
+`distribution/profile-catalog.json` defines five public and eleven engineering
+profiles, including Fundamentals, Arc, Chronicle, Components, applications,
+Studio, Stagehand, clients, documentation, and corpus work. Project subscription
+schema/examples and a comprehensive Pi/package/profile guide now document
+project and global installation, pinning, skill filtering, update, rollback,
+bootstrap behavior, and contribution flow. Profile packages remain planned and
+unpublished; content gaps are explicit.
+
+Immediate review findings corrected in this unit include:
+
+- Guid and non-Guid `EventSourceId<T>` templates are separated;
+- artifact catalog, rollout policy, matrix, and generated preview bytes use one
+  `cratis-fundamentals-concept-preview` identity;
+- fixture generation binds immutable source revision/digest provenance;
+- release-relevant CI paths include canonical skills, engineering content,
+  distribution, evaluations, evidence, workflows, and issue templates;
+- stale planner `Features/` paths, instruction links, and performance
+  `.AutoMap()` guidance are corrected;
+- broad propagation and reverse-sync workflows are inert;
+- README and documentation now lead with profiles, generated distribution,
+  source authority, Pi, and exact subscriptions rather than legacy propagation;
+- GitHub issue #165 requires @einari and @woksin to assign named profile owners
+  and source repositories; existing manual release gates are assigned/tagged.
+
+Production materialization, per-harness root release assets, product-owner
+approval, bot credentials, npm authority, and a real public consumer canary
+remain explicit blockers. No profile is represented as published.

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
@@ -610,3 +610,16 @@ Evidence and exact next actions are in
 - [ ] Provision the repository-scoped App credentials from Workflows#72 before
   any generated update PR, tag, release, or publication operation.
 - [ ] Keep publication and retirement disabled until explicit approvals pass.
+- [x] Re-review public, maintainer, Pi, adapter, security, documentation, and
+  distribution readiness; reject the broad done/support claim.
+- [x] Define product/repository profile subscriptions, atomic SemVer pinning,
+  project-owned `.cratis/ai.json`, Pi project/global packages, reviewed update
+  PRs, and upstream contribution without reverse sync.
+- [x] Retire active broad propagation/sync workflows and repair stale planner,
+  AutoMap, path, README, and documentation guidance.
+- [x] Reconcile the public preview artifact identity and bind fixture provenance
+  to immutable source revision/digest.
+- [ ] Implement approval-driven production materialization and per-profile,
+  per-harness root release assets after AI#148 and profile-owner issue #165.
+- [ ] Run the first real public consumer lifecycle canary and publish only a
+  narrowly labeled Fundamentals/Chronicle C# preview.

--- a/Documentation/.markdownlint.json
+++ b/Documentation/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "MD013": false,
+  "MD025": false,
+  "MD040": false
+}

--- a/Documentation/agents.md
+++ b/Documentation/agents.md
@@ -9,7 +9,7 @@ See also: [Architecture Overview](./architecture.md) · [Instructions vs Skills]
 ## Agent roster
 
 | Agent | Role | When to use |
-|---|---|---|
+| --- | --- | --- |
 | `orchestrator` | Top-level team orchestrator — assembles the team, sequences work, enforces quality gates | Any goal spanning implementation + documentation + review, or multiple independent workstreams |
 | `coordinator` | General-purpose coordinator — decomposes goals, assigns agents, tracks progress | Cross-cutting implementation work spanning multiple concerns or multiple slices |
 | `planner` | Vertical slice planner — sequences and parallelises slice implementation | Implementing one or more complete vertical slices end-to-end |
@@ -32,6 +32,7 @@ The `orchestrator` agent is the **top-level team manager** — the entry point w
 - The work involves non-implementation concerns alongside implementation
 
 The orchestrator:
+
 1. Classifies every concern in the goal (implementation, docs, testing, review)
 2. Maps each concern to the right agent or sub-orchestrator
 3. Identifies cross-stream dependencies
@@ -53,6 +54,7 @@ The `coordinator` agent is the **entry point for complex, multi-concern implemen
 - You're unsure which specialist to call first
 
 The coordinator:
+
 1. Classifies the work into task types
 2. Identifies dependencies between tasks
 3. Groups independent tasks into parallel phases
@@ -62,7 +64,7 @@ The coordinator:
 ### When to use the Orchestrator vs the Coordinator vs the Planner
 
 | Use `orchestrator` when… | Use `coordinator` when… | Use `planner` when… |
-|---|---|---|
+| --- | --- | --- |
 | Goal spans implementation + docs + review | Goal is implementation only | Goal is one or more vertical slices |
 | Multiple independent workstreams | Work crosses multiple concerns | Clear feature and slice names known |
 | Involves non-implementation tasks | Infrastructure + slice implementation | Slice type is known |
@@ -110,6 +112,7 @@ code-reviewer  →  security-reviewer
 Both can run in parallel since they are read-only reviews. The work is **not done** until both approve.
 
 Optional gates (add when relevant):
+
 - `performance-reviewer` — for changes to projections, queries, or computationally intensive code
 
 ---
@@ -159,4 +162,5 @@ Always read and follow:
 ## Completion checklist
 - [ ] ...
 ````
+
 ```

--- a/Documentation/ai-distribution-and-subscriptions.md
+++ b/Documentation/ai-distribution-and-subscriptions.md
@@ -1,0 +1,317 @@
+# Cratis AI distribution and subscriptions
+
+Cratis AI has one controlled source for shared AI behavior, product-specific
+profiles, immutable releases, and reviewed downstream updates. It does not use
+folder propagation or automatic two-way synchronization.
+
+> **Current availability:** the architecture and fixture generation exist, but
+> no supported profile package has been published yet. Commands containing
+> `1.0.0` below show the intended released workflow; do not run them until that
+> version exists in the selected channel.
+
+## Authority model
+
+Four owners cooperate without duplicating authority:
+
+| Concern | Owner | Examples |
+| --- | --- | --- |
+| Shared AI behavior | `Cratis/AI` | Skill workflows, trigger intent, engineering conventions, profile composition |
+| Product facts | Owning product repository | Arc APIs, Chronicle semantics, Components examples, supported client versions |
+| Project context | Consuming repository | Product mix, profile, credentials, endpoints, local constraints |
+| Generated artifacts | `Cratis/AI.Distribution` | Immutable host packages, manifests, checksums, provenance |
+
+`Cratis/AI` is the canonical source of shared AI behavior. A product repository
+remains authoritative for its code and documentation; an AI skill cannot invent
+or silently fork those facts. Release generation binds every imported product
+fact to an immutable source revision.
+
+A consuming repository never becomes a package publisher. It selects profiles,
+pins a version, owns its project context, and receives reviewed update pull
+requests.
+
+## Profiles instead of one universal corpus
+
+Different repositories need different behavior. A Chronicle framework change
+should not load application vertical-slice rules; a Components change should
+not load Orleans guidance; Studio and Stagehand need their own product context.
+
+The profile catalog is [`distribution/profile-catalog.json`](../distribution/profile-catalog.json).
+It defines separate public and engineering profiles.
+
+### Public profiles
+
+Public profiles help developers build with Cratis products:
+
+- `public-fundamentals`
+- `public-arc`
+- `public-chronicle`
+- `public-components`
+- `public-application`, which composes the four product profiles
+
+A repository using Chronicle without Arc subscribes only to Fundamentals and
+Chronicle. A full Arc + Chronicle + React application uses
+`public-application`.
+
+### Engineering profiles
+
+Engineering profiles add contributor behavior for Cratis-owned repositories:
+
+- `engineering-base`
+- `engineering-application`
+- `engineering-framework-fundamentals`
+- `engineering-framework-arc`
+- `engineering-framework-chronicle`
+- `engineering-framework-components`
+- `engineering-studio`
+- `engineering-stagehand`
+- `engineering-client`
+- `engineering-documentation`
+- `engineering-corpus`
+
+Profiles compose a small base rather than loading every rule and skill. Studio,
+Stagehand, client, and other content-gap profiles remain unpublished until their
+owning maintainers provide authoritative source behavior.
+
+## Repository subscription
+
+A Cratis repository records intent in project-owned `.cratis/ai.json`. The file
+contains no shared rule text; it only selects a channel, exact release, profiles,
+and harnesses.
+
+Chronicle framework example:
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "channel": "cratis-engineering",
+  "version": "1.0.0",
+  "profiles": ["engineering-framework-chronicle"],
+  "harnesses": ["claude", "codex", "copilot", "pi"],
+  "updatePolicy": "reviewed-pull-request",
+  "projectContext": ".cratis/PROJECT.md"
+}
+```
+
+Full application example:
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "channel": "public",
+  "version": "1.0.0",
+  "profiles": ["public-application"],
+  "harnesses": ["claude", "codex", "copilot", "pi"],
+  "updatePolicy": "reviewed-pull-request",
+  "projectContext": ".cratis/PROJECT.md"
+}
+```
+
+The schema is
+[`distribution/profile-subscription.schema.json`](../distribution/profile-subscription.schema.json).
+Exact versions are mandatory. `latest`, branches, and floating ranges are not
+valid subscriptions.
+
+The repository-scoped update App discovers subscriptions from committed
+`.cratis/ai.json` files in repositories where it is installed. A new release
+opens a normal pull request changing the subscription and host-native lock or
+settings files. It never merges automatically, pushes generated corpus folders,
+or receives broad organization write access.
+
+## Pi package workflow
+
+Pi is a first-class host, not a copied adapter directory. Pi packages can load
+skills from npm or Git and can be installed globally or into project settings.
+See the official [Pi package documentation](https://pi.dev/docs) and package
+gallery at [pi.dev/packages](https://pi.dev/packages). Because Pi packages and
+skills can execute or instruct powerful actions, Cratis public and base profile
+packages remain passive and are reviewed before publication.
+
+### Maintainer-wide defaults
+
+A maintainer may install a passive base profile globally after release:
+
+```bash
+pi install npm:@cratis/ai-engineering-base@1.0.0
+```
+
+This writes the exact package source to `~/.pi/agent/settings.json`.
+
+### Project-specific profile
+
+A Chronicle repository pins its profile in project scope:
+
+```bash
+cd Chronicle
+pi install -l npm:@cratis/ai-engineering-chronicle@1.0.0
+```
+
+Pi writes `.pi/settings.json`. Commit that file after review. When another
+maintainer trusts the repository, Pi installs the missing exact package.
+
+Expected settings shape:
+
+```json
+{
+  "packages": [
+    "npm:@cratis/ai-engineering-chronicle@1.0.0"
+  ],
+  "enableSkillCommands": true
+}
+```
+
+Pi exposes package skills through normal automatic discovery and
+`/skill:<name>` commands. Packages remain passive: they contain skills and
+static references, not executable extensions.
+
+A repository normally subscribes to the complete profile. For a deliberately
+narrow repository, record `skillAllowlist` in `.cratis/ai.json` and use Pi's
+package filter object:
+
+```json
+{
+  "packages": [
+    {
+      "source": "npm:@cratis/ai-chronicle@1.0.0",
+      "skills": [
+        "cratis-chronicle-projection",
+        "cratis-chronicle-read-model"
+      ],
+      "extensions": []
+    }
+  ]
+}
+```
+
+Omitting `skills` loads the profile's complete approved skill set; an empty
+array loads none. The update bot keeps `.cratis/ai.json` and `.pi/settings.json`
+aligned.
+
+### Updating a pinned Pi profile
+
+Pinned packages do not float during `pi update`. A reviewed update pull request
+changes both `.cratis/ai.json` and `.pi/settings.json` to the new exact version.
+Then run:
+
+```bash
+pi install -l npm:@cratis/ai-engineering-chronicle@1.1.0
+pi list
+```
+
+Run the repository gates before merging. Rollback restores the previous exact
+version in both files and runs `pi install -l` with that version.
+
+### Project context and always-on guidance
+
+Packages never overwrite `AGENTS.md`, `.cratis/PROJECT.md`, `.pi/settings.json`,
+or other project-owned files. Each repository keeps a minimal bootstrap that:
+
+1. identifies its project context file;
+2. names the selected Cratis profile skill;
+3. records repository-specific constraints.
+
+For example:
+
+```markdown
+# Repository AI bootstrap
+
+Read `.cratis/PROJECT.md` before changing code. For Cratis framework work, load
+the `cratis-engineering-chronicle-profile` skill before planning or editing.
+```
+
+The profile skill contains generated references to shared conventions. Product
+facts still come from the repository and its immutable source contracts.
+
+## Other harnesses
+
+The same approved skill bytes are wrapped idiomatically for each host:
+
+| Host | Generated shape |
+| --- | --- |
+| Agent Skills | `skills/<name>/SKILL.md` |
+| Claude Code | Claude plugin and marketplace |
+| Codex | Codex plugin and marketplace |
+| GitHub Copilot | Copilot plugin and marketplace |
+| Cursor | Cursor plugin |
+| Gemini CLI | Gemini extension |
+| Grok Build | `.grok/skills/<name>/SKILL.md` and Claude compatibility |
+| DeepSeek Harness | `.dsh/skills/<name>/SKILL.md` while upstream remains preview |
+| Kiro | Agent Plugin power |
+| Junie | Junie extension |
+| Pi | Versioned npm/Git Pi package |
+
+Release documentation distinguishes **generated**, **statically validated**, and
+**host-tested and supported**. A generated wrapper is not automatically a
+public marketplace listing.
+
+## Versioning and release train
+
+All profile packages use SemVer and one atomic release train. A release changes
+shared behavior only through a reviewed `Cratis/AI` commit and records:
+
+- approved target IDs;
+- exact source paths and content digests;
+- immutable AI and product source revisions;
+- package/profile inventory;
+- tested harness versions;
+- checksums and provenance;
+- canary, update, rollback, and uninstall results.
+
+A patch release corrects behavior without changing profile intent. A minor
+release adds backward-compatible skills or profiles. A major release removes,
+renames, or changes trigger/behavior contracts in a way that requires consumer
+migration.
+
+Generated artifacts are bot-authored in `Cratis/AI.Distribution`. Humans review
+the generated pull request but do not edit generated bytes.
+
+The generated repository is an index and review surface, not one universal
+install root. Every release publishes a separate root archive or immutable ref
+for each profile and harness, for example:
+
+```text
+cratis-ai-engineering-chronicle-1.0.0-pi.tgz
+cratis-ai-engineering-chronicle-1.0.0-claude.tar.gz
+cratis-ai-engineering-chronicle-1.0.0-codex.tar.gz
+```
+
+Each host receives its manifest at that artifact's root. Release verification
+uses the exact remote install command against the exact archive/ref rather than
+a convenient staging subdirectory.
+
+## Improvements from consuming repositories
+
+There is intentionally no automatic two-way or multi-way file sync. File sync
+creates competing authorities, merge ambiguity, accidental publication, and
+unreviewed behavior drift.
+
+When a product repository improves a shared skill:
+
+1. Keep the immediate product fix in the owning repository when it is a product
+   fact or local context.
+2. Open **Propose a shared Cratis AI improvement** in `Cratis/AI`.
+3. Include the originating repository, immutable revision, affected profiles,
+   product authority, behavior change, and compatibility impact.
+4. Update canonical skill/rule source in `Cratis/AI` through review.
+5. Generate and release a new immutable version.
+6. The update bot opens pull requests for subscribed repositories.
+7. Each repository runs its own canary and gates before merging.
+
+This is multi-source contribution with one canonical merge point, followed by
+one-way generated delivery. It is not bidirectional synchronization.
+
+## Adding a new product profile
+
+For a product such as Studio or Stagehand:
+
+1. The product owner defines authoritative repositories, supported versions,
+   and project profile.
+2. Add canonical product/engineering skills in `Cratis/AI`; keep environment
+   facts in the product repository.
+3. Add the profile to `distribution/profile-catalog.json`.
+4. Add focused behavior and host evidence appropriate to its risk.
+5. Generate a profile package from approved targets only.
+6. Canary it in one real product repository.
+7. Publish it in the next atomic release train.
+
+A profile with no approved target remains a visible content gap and cannot be
+published accidentally.

--- a/Documentation/architecture.md
+++ b/Documentation/architecture.md
@@ -1,6 +1,11 @@
-# Architecture Overview
+# Repository-local corpus architecture
 
-This page describes how all the components of the Cratis AI configuration fit together.
+> **Scope:** This page documents the existing repository-local Copilot-oriented
+> corpus and adapters. It is not the distribution or subscription architecture.
+> For current package profiles, Pi, pinning, generated releases, and upstream
+> contributions, see [Cratis AI distribution and subscriptions](./ai-distribution-and-subscriptions.md).
+
+This page describes how the legacy and repository-local corpus components fit together.
 
 See also: [Instructions](./instructions.md) · [Skills](./skills.md) · [Agents](./agents.md) · [Instructions vs Skills](./instructions-vs-skills.md)
 
@@ -47,6 +52,7 @@ See also: [Instructions](./instructions.md) · [Skills](./skills.md) · [Agents]
 ### Instructions load automatically
 
 When Copilot opens a file, it loads:
+
 1. `copilot-instructions.md` — always (global rules)
 2. Any `.instructions.md` whose `applyTo` glob matches the current file path
 
@@ -99,7 +105,7 @@ Instructions are loaded into every AI context window on matching files. This has
 ## File naming conventions
 
 | Artifact | Naming pattern | Example |
-|---|---|---|
+| --- | --- | --- |
 | Global instructions | `copilot-instructions.md` | `.github/copilot-instructions.md` |
 | Scoped instructions | `<topic>.instructions.md` | `csharp.instructions.md` |
 | Skills | `SKILL.md` inside a named folder | `skills/cratis-command/SKILL.md` |

--- a/Documentation/examples/ai-subscriptions/chronicle-framework.cratis-ai.json
+++ b/Documentation/examples/ai-subscriptions/chronicle-framework.cratis-ai.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": "1.0.0",
+  "channel": "cratis-engineering",
+  "version": "1.0.0",
+  "profiles": [
+    "engineering-framework-chronicle"
+  ],
+  "harnesses": [
+    "claude",
+    "codex",
+    "copilot",
+    "pi"
+  ],
+  "updatePolicy": "reviewed-pull-request",
+  "projectContext": ".cratis/PROJECT.md"
+}

--- a/Documentation/examples/ai-subscriptions/cratis-application.cratis-ai.json
+++ b/Documentation/examples/ai-subscriptions/cratis-application.cratis-ai.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": "1.0.0",
+  "channel": "public",
+  "version": "1.0.0",
+  "profiles": [
+    "public-application"
+  ],
+  "harnesses": [
+    "claude",
+    "codex",
+    "copilot",
+    "pi"
+  ],
+  "updatePolicy": "reviewed-pull-request",
+  "projectContext": ".cratis/PROJECT.md"
+}

--- a/Documentation/examples/ai-subscriptions/pi-settings.json
+++ b/Documentation/examples/ai-subscriptions/pi-settings.json
@@ -1,0 +1,6 @@
+{
+  "packages": [
+    "npm:@cratis/ai-engineering-chronicle@1.0.0"
+  ],
+  "enableSkillCommands": true
+}

--- a/Documentation/index.md
+++ b/Documentation/index.md
@@ -1,26 +1,47 @@
-# Cratis AI Configuration — Documentation
+# Cratis AI documentation
 
-This folder documents how the Cratis AI configuration is organized, the conventions it follows, and how its components work together.
+Cratis AI controls shared AI behavior for public Cratis developers and internal
+Cratis maintainers, then generates versioned packages for each supported
+harness. The mixed source repository is not itself an installation package.
 
-## Contents
+> **Availability:** no supported profile release is published yet. Architecture,
+> profile subscriptions, and fixture adapters are implemented; the first narrow
+> release still requires approval, production materialization, and a real
+> consumer canary.
+
+## Start here
+
+| Page | Purpose |
+| --- | --- |
+| [Distribution and subscriptions](./ai-distribution-and-subscriptions.md) | Source authority, product profiles, Pi, versioning, pinning, updates, rollback, and upstream improvements |
+| [Public product architecture](./public-product-architecture.md) | Public/engineering ownership and runtime payload boundaries |
+| [Project context bootstrap](./project-context-bootstrap.md) | Project-owned facts and minimal harness bootstraps |
+| [Skill authoring contract](./skill-authoring-contract.md) | Canonical source, evidence, and clean-room requirements |
+| [Capability catalog v2](./capability-catalog-v2.md) | Source, target, approval, trust, and coverage model |
+
+## Repository-local corpus reference
+
+The following pages explain the legacy and repository-local corpus surfaces.
+They remain useful for maintainers while content is reconciled into versioned
+profiles, but they do not describe a supported installation channel:
 
 | Page | What it covers |
-|---|---|
-| [Architecture Overview](./architecture.md) | How the overall system fits together — instructions, skills, agents, prompts, and hooks |
-| [Instructions](./instructions.md) | What instruction files are, when they load, and how to write focused ones |
-| [Skills](./skills.md) | What skills are, how they differ from instructions, and how to create new ones |
-| [Agents](./agents.md) | The team of agents, their roles, and the coordinator pattern for parallel work |
-| [Using the Orchestrator](./orchestrator.md) | How to use the orchestrator to coordinate multiple agents as a team |
-| [Instructions vs Skills](./instructions-vs-skills.md) | The clear distinction between "what/when" (instructions) and "how" (skills) |
+| --- | --- |
+| [Architecture overview](./architecture.md) | Existing instructions, skills, agents, prompts, and hooks |
+| [Instructions](./instructions.md) | Scoped instruction files and their current adapters |
+| [Skills](./skills.md) | Legacy skill inventory and authoring patterns |
+| [Agents](./agents.md) | Specialist agents and coordinator patterns |
+| [Using the orchestrator](./orchestrator.md) | Repository-local multi-agent coordination |
+| [Instructions vs skills](./instructions-vs-skills.md) | Always-on constraints versus on-demand workflows |
 
-## Quick orientation
+## Core rules
 
-The Cratis AI configuration is a **shared, reusable package** that provides GitHub Copilot with structured knowledge for developing Cratis-based projects. It consists of five types of artifacts:
-
-- **Instructions** (`.instructions.md`) — rules and constraints loaded automatically based on file context
-- **Skills** (`SKILL.md`) — detailed step-by-step implementation guides invoked on demand
-- **Agents** (`.md` in `agents/`) — specialist personas with defined roles and tools
-- **Prompts** (`.prompt.md`) — quick-invoke slash commands for single-turn tasks
-- **Hooks** (`.md` in `hooks/`) — lifecycle callbacks (pre-commit, agent-stop)
-
-See [Architecture Overview](./architecture.md) for the full picture.
+- Shared behavior is authored in `Cratis/AI`.
+- Product facts remain authoritative in the owning product repository.
+- Consuming repositories own `.cratis/PROJECT.md`, `.cratis/ai.json`, and their
+  minimal harness bootstraps.
+- `Cratis/AI.Distribution` contains bot-generated immutable artifacts only.
+- Repositories pin exact profile versions and update through reviewed pull
+  requests.
+- Improvements flow upstream through issues or pull requests; generated folders
+  are never synchronized bidirectionally.

--- a/Documentation/instructions-vs-skills.md
+++ b/Documentation/instructions-vs-skills.md
@@ -9,7 +9,7 @@ See also: [Instructions](./instructions.md) · [Skills](./skills.md)
 ## The core distinction
 
 | | Instructions | Skills |
-|---|---|---|
+| --- | --- | --- |
 | **Answers** | *What* to do and *when* it applies | *How* to do it, step by step |
 | **Loaded** | Automatically, based on file type | On demand, when explicitly invoked |
 | **Size** | Small and focused | As detailed as needed |
@@ -75,6 +75,7 @@ Full file templates, multi-step scaffolding sequences, and detailed API usage pa
 ### ✅ Correct — Rule in instruction, detail in skill
 
 **`csharp.instructions.md`:**
+
 ```markdown
 ## Commands
 - Records decorated with `[Command]` from `Cratis.Arc.Commands.ModelBound`.
@@ -85,6 +86,7 @@ For step-by-step command creation, invoke the `cratis-command` skill.
 ```
 
 **`skills/cratis-command/SKILL.md`:**
+
 ```markdown
 # Creating a Command
 
@@ -106,6 +108,7 @@ For step-by-step command creation, invoke the `cratis-command` skill.
 ### ❌ Wrong — Detail crammed into instruction
 
 **`csharp.instructions.md`** (too much):
+
 ```markdown
 ## Commands
 
@@ -143,7 +146,7 @@ This keeps instructions at the right level while making the skills discoverable.
 ## Summary
 
 | If you're writing… | Put it in… |
-|---|---|
+| --- | --- |
 | A naming rule | Instruction |
 | A "never do X" constraint | Instruction |
 | A 4-line code example showing a pattern | Instruction |

--- a/Documentation/instructions.md
+++ b/Documentation/instructions.md
@@ -24,7 +24,7 @@ When Copilot works on a file, it automatically loads every instruction file whos
 ### Glob scope examples
 
 | `applyTo` value | Loads when working on |
-|---|---|
+| --- | --- |
 | `"**/*"` | Every file |
 | `"**/*.cs"` | Any C# file |
 | `"**/*.ts,**/*.tsx"` | Any TypeScript file |
@@ -38,6 +38,7 @@ When Copilot works on a file, it automatically loads every instruction file whos
 Instructions should be **concise rules** — not tutorials or step-by-step guides.
 
 ✅ Good instruction content:
+
 - Naming conventions and patterns to follow
 - Hard constraints ("never do X", "always do Y")
 - Structural rules (file layout, namespace conventions)
@@ -45,6 +46,7 @@ Instructions should be **concise rules** — not tutorials or step-by-step guide
 - References to the relevant skill for detailed implementation
 
 ❌ Does NOT belong in instructions:
+
 - Step-by-step implementation walkthroughs
 - Code templates with detailed scaffolding
 - Long lists of "how to" examples
@@ -78,6 +80,7 @@ This guard exists because instruction files are loaded based on file type (e.g. 
 **Rule:** Any instruction file that applies to a specific framework, library, or technology that is not universally present in all Cratis projects MUST include this guard at the top.
 
 Currently guarded files:
+
 - `efcore.instructions.md` — Entity Framework Core
 - `efcore.specs.instructions.md` — Entity Framework Core specs
 - `orleans.instructions.md` — Microsoft Orleans
@@ -87,7 +90,7 @@ Currently guarded files:
 ## Instruction file inventory
 
 | File | `applyTo` | Topic |
-|---|---|---|
+| --- | --- | --- |
 | `copilot-instructions.md` | `"**/*"` (global) | Project philosophy, general rules, development workflow |
 | `csharp.instructions.md` | `"**/*.cs"` | C# formatting, naming, code style, XML docs |
 | `typescript.instructions.md` | `"**/*.ts,**/*.tsx"` | TypeScript type safety, enums, naming, localization |

--- a/Documentation/orchestrator.md
+++ b/Documentation/orchestrator.md
@@ -26,7 +26,7 @@ The Orchestrator does **not** write code or documentation itself. Every concrete
 Use the Orchestrator when your goal spans **more than one type of work**:
 
 | Scenario | Use |
-|---|---|
+| --- | --- |
 | Implement a feature **and** document it | `orchestrator` |
 | Implement multiple independent features in parallel | `orchestrator` |
 | Implement a feature, write specs, review, and document | `orchestrator` |
@@ -43,7 +43,7 @@ If you are unsure, use the Orchestrator — it will route you to the right sub-a
 The Orchestrator coordinates this team of specialists:
 
 | Agent | Role |
-|---|---|
+| --- | --- |
 | `coordinator` | Cross-cutting implementation — backend + frontend + reviews across multiple concerns |
 | `planner` | Vertical slice implementation — sequences backend → build → frontend → specs |
 | `backend-developer` | C# slice files — commands, events, validators, projections, reactors |
@@ -100,6 +100,7 @@ Phase 5: Documentation (references the completed, reviewed implementation)
 ```
 
 **Key rules:**
+
 - Frontend and backend for the **same slice** are never parallel (frontend depends on generated proxies).
 - Independent slices (no shared events) can have their backends run in parallel.
 - Documentation of new features must wait until the implementation is reviewed.
@@ -111,12 +112,13 @@ Phase 5: Documentation (references the completed, reviewed implementation)
 All three agents decompose work and delegate — but at different levels:
 
 | Agent | Scope | Delegates to |
-|---|---|---|
+| --- | --- | --- |
 | `orchestrator` | Any goal — implementation, docs, reviews, refactoring | `coordinator`, `planner`, `code-reviewer`, `security-reviewer`, specialist agents |
 | `coordinator` | Implementation — backend + frontend + reviews | `backend-developer`, `frontend-developer`, `spec-writer`, `code-reviewer` |
 | `planner` | Vertical slices only — one or more slices end-to-end | `backend-developer`, `frontend-developer`, `spec-writer`, `code-reviewer` |
 
 Choose the **most specific** agent that fits the goal:
+
 - Vertical slices only → `planner`
 - Implementation across concerns → `coordinator`
 - Everything else → `orchestrator`
@@ -159,4 +161,5 @@ security-reviewer ┘
 Both reviewers run in parallel. The goal is **not done** until both approve. If either finds blocking issues, the relevant specialist agent is re-engaged to fix them, then the reviewers run again.
 
 Optional quality gate:
+
 - `performance-reviewer` — use when the implementation touches Chronicle projections, MongoDB queries, or compute-intensive React rendering.

--- a/Documentation/skills.md
+++ b/Documentation/skills.md
@@ -1,4 +1,9 @@
-# Skills
+# Repository-local and canonical skills
+
+> **Scope:** The inventory later on this page describes the legacy local corpus
+> and is not the released profile inventory. Canonical public skills live in
+> `skills/`, maintainer skills live in `engineering/`, and generated packages
+> follow [distribution and subscriptions](./ai-distribution-and-subscriptions.md).
 
 Skills are **detailed, step-by-step implementation guides** invoked on demand when a developer needs to perform a specific, reusable workflow. They answer *how* to do something — the exact sequence of steps, patterns, and code templates required to complete a well-defined task.
 
@@ -8,9 +13,14 @@ See also: [Architecture Overview](./architecture.md) · [Instructions vs Skills]
 
 ## How skills work
 
-A skill lives in `.github/skills/<skill-name>/SKILL.md`. It is NOT loaded automatically — it is invoked explicitly when a user asks for that workflow or when an agent determines that skill is needed.
+A local Copilot adapter exposes a legacy skill at
+`.github/skills/<skill-name>/SKILL.md`. Canonical package sources instead live
+under `skills/<skill-name>/SKILL.md` or
+`engineering/skills/<skill-name>/SKILL.md`. A skill is not fully loaded until a
+user invokes it or an agent selects it.
 
 Each skill:
+
 - Has a single, well-defined purpose
 - Provides step-by-step guidance
 - Includes code templates and examples
@@ -21,7 +31,7 @@ Each skill:
 
 ## Skill anatomy
 
-```
+```text
 .github/skills/<skill-name>/
 ├── SKILL.md            ← The skill itself (required)
 ├── references/         ← Supporting documentation (optional)
@@ -61,7 +71,7 @@ A well-formed skill file follows this structure:
 ### Implementation skills
 
 | Skill | When to invoke |
-|---|---|
+| --- | --- |
 | `cratis-command` | Creating a new command with `Handle()`, validator, `CommandDialog`, and React hook |
 | `cratis-readmodel` | Creating a read model from scratch — events, projection, query, TypeScript proxy |
 | `cratis-vertical-slice` | Understanding how vertical slice architecture works in this project |
@@ -78,7 +88,7 @@ A well-formed skill file follows this structure:
 ### Standards and review skills
 
 | Skill | When to invoke |
-|---|---|
+| --- | --- |
 | `cratis-csharp-standards` | Reference for C# coding conventions — formatting, naming, records, nullable handling |
 | `cratis-react-page` | Building a React page with `DataPage`, `CommandDialog`, observable queries |
 | `cratis-specs-csharp` | Writing C# BDD specs — `Establish`/`Because`/`should_` pattern, NSubstitute |
@@ -90,14 +100,14 @@ A well-formed skill file follows this structure:
 ### Documentation skills
 
 | Skill | When to invoke |
-|---|---|
+| --- | --- |
 | `write-documentation` | Writing DocFX documentation following the Diátaxis framework |
 | `write-specs` | Writing BDD integration specs for a command or vertical slice |
 
 ### Meta skills
 
 | Skill | When to invoke |
-|---|---|
+| --- | --- |
 | `skill-creator` | Creating a new skill, improving an existing skill, or running skill evals |
 
 ---
@@ -107,6 +117,7 @@ A well-formed skill file follows this structure:
 Many skills have a `references/` subfolder with supporting documentation pulled from Cratis Chronicle and Arc sources. These are NOT loaded automatically — a skill explicitly reads them during execution when it needs specific API details.
 
 Examples:
+
 - `add-projection/references/CHRONICLE-API.md` — Chronicle projection API reference
 - `cratis-command/references/validation.md` — CommandValidator and FluentValidation patterns
 - `auth-and-identity/references/authentication.md` — IProvideIdentityDetails implementation guide

--- a/Documentation/verify-markdown.sh
+++ b/Documentation/verify-markdown.sh
@@ -27,13 +27,14 @@ echo "Step 1: Running markdownlint..."
 echo "=========================================="
 echo ""
 
-if ! command -v npx &> /dev/null; then
+if ! command -v npx &>/dev/null; then
     echo "Error: npx is not installed. Please install Node.js and npm."
     exit 1
 fi
 
-npx markdownlint-cli2 "Documentation/**/*.md"
-LINT_EXIT_CODE=$?
+LINT_EXIT_CODE=0
+npx markdownlint-cli2 --config Documentation/.markdownlint.json \
+    "Documentation/**/*.md" || LINT_EXIT_CODE=$?
 
 echo ""
 if [ $LINT_EXIT_CODE -eq 0 ]; then
@@ -51,8 +52,10 @@ echo ""
 echo "This may take a few minutes to check all links..."
 echo ""
 
-npx linkinator "Documentation/**/*.md" --markdown --recurse --verbosity error --status-code "403:ok" --timeout 10000 --skip "^(https?:\\/\\/)?(localhost|127\\.0\\.0\\.1)(:\\d+)?(\\/|$)"
-LINK_EXIT_CODE=$?
+LINK_EXIT_CODE=0
+npx linkinator "Documentation/**/*.md" --markdown --recurse \
+    --verbosity error --status-code "403:ok" --timeout 10000 \
+    --skip "^(https?:\\/\\/)?(localhost|127\\.0\\.1)(:\\d+)?(\\/|$)" || LINK_EXIT_CODE=$?
 
 echo ""
 if [ $LINK_EXIT_CODE -eq 0 ]; then

--- a/README.md
+++ b/README.md
@@ -1,76 +1,159 @@
-# Cratis AI — Shared AI Assistant Configuration
+# Cratis AI
 
-Shared AI-assistant configuration for building on the Cratis stack (Chronicle + Arc, .NET/C#, React + Cratis Components). It configures **GitHub Copilot**, **Claude Code**, **Codex**, and **Pi** with the same rules, agents, skills, prompts, and hooks — the "Cratis way" of building software, applied consistently across tools and repositories.
+Cratis AI is the controlled source for shared AI skills, engineering guidance,
+product profiles, and generated multi-harness packages for the Cratis ecosystem.
 
-> This repository is the corpus only — it holds no application or framework source. The delivery machinery that used to live here now has its own homes: **[Stagehand](https://github.com/Cratis/Stagehand)** (the managed control plane) and **[Ensemble](https://github.com/Cratis/Ensemble)** (the governed software factory).
+It serves two separate audiences:
 
-## Single source of truth
+- **Developers building with Cratis** receive passive public product profiles for
+  Fundamentals, Arc, Chronicle, Components, and composed applications.
+- **Cratis maintainers** receive separate engineering profiles for application,
+  framework, client, documentation, Studio, Stagehand, and corpus repositories.
 
-Everything is authored once under **`.ai/`** and surfaced to each tool through adapters — never edit the adapters directly.
+> **Current status:** distribution remains preview/fixture-only. No supported
+> public or engineering profile package has been published. Do not install this
+> mixed source repository as a runtime package.
 
-```
-.ai/                  ← canonical source of truth (edit here)
-├── rules/            ← instruction/rule files (one per topic)
-├── agents/           ← agent definitions
-├── prompts/          ← reusable prompt templates (*.prompt.md)
-├── skills/           ← multi-step skill workflows
-├── hooks/            ← agent lifecycle hooks (+ hooks/scripts/ validator)
-└── workflows/        ← shared CI workflow files
+## The architecture
 
-.github/              ← GitHub Copilot adapters  (copilot-instructions.md, instructions/ → .ai/rules, agents/*.agent.md, prompts/, skills/)
-.claude/              ← Claude Code adapters     (CLAUDE.md, rules/*.md, agents/, commands/*.md, skills/)
-.agents/ + AGENTS.md  ← Codex adapters           (AGENTS.md → general.md; .agents/skills → .ai/skills)
-.pi/                  ← Pi adapters             (agents/, prompts/, skills/, extensions/ bridging the hook scripts)
-```
+| Concern | Owner |
+| --- | --- |
+| Shared AI behavior and profile composition | `Cratis/AI` |
+| Product APIs, versions, and facts | The owning Cratis product repository |
+| Repository-specific context | The consuming repository |
+| Generated immutable packages | `Cratis/AI.Distribution` |
 
-`.github/instructions` is a single folder symlink into `.ai/rules`, so rules are maintained in one place with no per-file adapter to add. (Trade-off: a folder symlink exposes the rules as `<name>.md`, not the `<name>.instructions.md` suffix GitHub Copilot's `applyTo` discovery expects — Claude Code and Codex still read them, and the rules remain available, but Copilot does not auto-attach them by glob.)
+Canonical skill and rule behavior is reviewed here. Generated packages flow
+one way to subscribers. Improvements discovered in product repositories flow
+back through issues or pull requests to this repository; generated folders are
+never synchronized bidirectionally.
 
-### Project-specific instructions — `.agents/PROJECT.md`
+Read [Cratis AI distribution and subscriptions](Documentation/ai-distribution-and-subscriptions.md)
+for the complete source-of-truth, profile, versioning, pinning, Pi, update,
+rollback, and contribution model.
 
-The corpus here is generic and shared. Projects that consume it can drop a `.agents/PROJECT.md` file at their repository root for project-local context — credentials, HTTP headers, environment endpoints. `general.md` instructs every tool to read it when present, and it wins over the shared rules on conflict. It is never propagated from this hub.
+## Repository layout
 
-Each tool has its own conventions, so the adapters differ by surface (rules, agents, prompts/commands, skills, hooks) — see [`.ai/rules/managing-ai-rules.md`](.ai/rules/managing-ai-rules.md) for the per-tool table. Each adapter resolves to its canonical `.ai/` file (a **symlink** or a **path-reference file** — both accepted). `.ai/rules/general.md` is the always-on root (no frontmatter); scoped rules carry `applyTo` (Copilot) and `paths` (Claude) frontmatter.
-
-> **Do not edit anything under `.github/`, `.claude/`, `.agents/`, or root `AGENTS.md`.** They are adapters; edits are lost when the canonical source changes.
-
-## Where to look
-
-- **[`.ai/README.md`](.ai/README.md)** — the authority model, adapter conventions, profiles, and validation (the maintained overview).
-- **[`.ai/rules/managing-ai-rules.md`](.ai/rules/managing-ai-rules.md)** — how to add, update, rename, or remove rules/skills/agents/prompts/hooks.
-- **[`.ai/rules/general.md`](.ai/rules/general.md)** — the project operating manual; its "Where to Look" table indexes every rule.
-- Browse `.ai/rules/`, `.ai/skills/`, `.ai/agents/`, and `.ai/prompts/` directly for the current set — these folders are the inventory (no table here to drift out of date).
-
-## Validation
-
-After changing rules/skills/adapters, run the content-aware validator:
-
-```bash
-.ai/hooks/scripts/validate-ai-setup.sh
+```text
+skills/                 Canonical public skill sources
+engineering/            Canonical Cratis-maintainer skill sources
+.ai/                    Legacy corpus being reconciled into profiles
+catalog/                Sources, targets, authority, evidence, and coverage
+distribution/           Profile, artifact, rollout, and publication contracts
+tooling/                Validation and deterministic generation
+Documentation/          Architecture, contribution, and usage guidance
 ```
 
-It checks frontmatter, adapter integrity (symlink *or* path-reference resolving to the right rule), resolving adapter targets, the Codex adapters, and content-drift guards. Structural/adapter/Codex failures are fatal; drift guards are advisory warnings.
+`.ai/` remains valuable repository-local guidance but is not a publishable
+package tree. Public and engineering artifacts select exact approved files; they
+never package the repository wholesale.
 
-## Recommended VS Code settings
+## Profiles
 
-Add to `.vscode/settings.json` or user settings:
+Public profile plan:
 
-```jsonc
+- `public-fundamentals`
+- `public-arc`
+- `public-chronicle`
+- `public-components`
+- `public-application`
+
+Engineering profile plan includes product-specific framework profiles plus
+application, client, documentation, Studio, Stagehand, and corpus profiles.
+See [`distribution/profile-catalog.json`](distribution/profile-catalog.json).
+
+A consuming repository will pin profiles in project-owned `.cratis/ai.json`:
+
+```json
 {
-    // Load instruction files during code generation
-    "github.copilot.chat.codeGeneration.useInstructionFiles": true,
-    // Record AI contributions in git commits
-    "git.addAICoAuthor": "chatAndAgent",
-    // Safer agent-driven terminal operations
-    "chat.tools.terminal.sandbox.enabled": true,
-    // Let agents verify frontend changes in-browser (enable when working on React)
-    "workbench.browser.enableChatTools": true,
-    // Reduce chat clutter during multi-step builds
-    "chat.tools.terminal.simpleCollapsible": true,
-    // Notify when the agent needs confirmation
-    "chat.notifyWindowOnConfirmation": "always"
+  "schemaVersion": "1.0.0",
+  "channel": "cratis-engineering",
+  "version": "1.0.0",
+  "profiles": ["engineering-framework-chronicle"],
+  "harnesses": ["claude", "codex", "copilot", "pi"],
+  "updatePolicy": "reviewed-pull-request",
+  "projectContext": ".cratis/PROJECT.md"
 }
 ```
 
-## Propagation
+The example is illustrative until the first package is published. Floating
+versions such as `latest` are forbidden.
 
-This repo is the hub that can propagate `.ai/` content to other Cratis repositories. The propagation workflow is managed separately from the corpus content — see `.ai/rules/managing-ai-rules.md` for how it interacts with adapters.
+## Pi
+
+Pi is a first-class distribution target. Released profiles will be ordinary
+versioned Pi packages containing passive skills and references:
+
+```bash
+# User-wide maintainer base
+pi install npm:@cratis/ai-engineering-base@1.0.0
+
+# Exact project profile pin
+pi install -l npm:@cratis/ai-engineering-chronicle@1.0.0
+```
+
+Project installation writes `.pi/settings.json`; after project trust, Pi
+installs missing exact packages automatically. Pinned packages do not float.
+Update and rollback change the exact version through a reviewed pull request.
+
+These commands describe the released workflow and are not available until the
+packages exist. See the [Pi package workflow](Documentation/ai-distribution-and-subscriptions.md#pi-package-workflow).
+
+## Supported output formats
+
+The generator currently produces or models adapters for Agent Skills, Claude
+Code, Codex, GitHub Copilot, Cursor, Gemini CLI, Grok Build, DeepSeek Harness,
+Kiro, Junie, and Pi/npm.
+
+Documentation and release records distinguish:
+
+1. generated;
+2. statically validated;
+3. host-tested and supported.
+
+Adapter generation alone is not a support or marketplace-publication claim.
+
+## Contributing an improvement
+
+Use the **Propose a shared Cratis AI improvement** issue form. Include:
+
+- originating repository;
+- immutable source revision;
+- affected profiles and products;
+- first-party product authority;
+- compatibility and migration impact.
+
+Product repositories do not publish Cratis AI packages or push generated bytes.
+After canonical review, a new immutable release is generated and subscriber
+repositories receive reviewed update pull requests.
+
+## Validation
+
+Run the complete local gate after changing release-relevant content:
+
+```bash
+node tooling/generate-catalog-v2.mjs
+node tooling/generate-human-catalog.mjs
+node tooling/generate-repository-inventory.mjs
+node tooling/validate-catalogs.mjs
+node --test tooling/specs/*.spec.mjs
+.ai/hooks/scripts/validate-ai-setup.sh
+git diff --check
+```
+
+The main workflow runs for canonical skills, engineering content, catalogs,
+distribution contracts, evidence, evaluations, documentation, workflows, and
+tooling.
+
+## Current release blockers
+
+The first narrow public preview still requires:
+
+- owner approval and exact product authority for the Fundamentals concept skill;
+- approval-driven production materialization with immutable provenance;
+- scoped GitHub App credentials for generated pull requests;
+- one real consumer install/update/rollback/uninstall canary;
+- an immutable release channel and published installation instructions.
+
+Until those gates pass, this repository is a source and preview-generation
+system—not a supported installation endpoint.

--- a/catalog/generated/human-catalog/catalog.json
+++ b/catalog/generated/human-catalog/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractVersion": 1,
   "disclaimer": "Catalog inclusion, evaluation evidence, bundle generation, or publication does not grant runtime permission or approval.",
-  "inputDigest": "5efec12307e6ab7d9951862e6819f1ba11bd3357fc4edda367a210ee9274dada",
+  "inputDigest": "a9b6487f3a794a7626aef556853fe4973e7714f638110abf913b2af817431b34",
   "capabilities": [
     {
       "id": "cratis-application-react-specifications",

--- a/catalog/generated/human-catalog/manifest.json
+++ b/catalog/generated/human-catalog/manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "contractVersion": 1,
-  "inputDigest": "5efec12307e6ab7d9951862e6819f1ba11bd3357fc4edda367a210ee9274dada",
+  "inputDigest": "a9b6487f3a794a7626aef556853fe4973e7714f638110abf913b2af817431b34",
   "files": [
     {
       "path": "CATALOG.md",
@@ -11,7 +11,7 @@
     {
       "path": "catalog.json",
       "size": 64765,
-      "sha256": "d300401ebf7e302eb5e5e5597b3e6f3c2b7e3c51ada25b4c0b3225510a99623a"
+      "sha256": "89bec06db9413415db04a2e6b5a7e9f3c1e89a71ecc1d4fbc3f5c00adbe15b96"
     }
   ]
 }

--- a/catalog/v2/artifacts.json
+++ b/catalog/v2/artifacts.json
@@ -193,28 +193,26 @@
       ]
     },
     {
-      "id": "sanitized-public-materializer-fixture",
+      "id": "cratis-fundamentals-concept-preview",
       "audience": "test-fixture",
       "fixtureOnly": true,
       "materializationAllowed": true,
       "runtimeEligible": false,
       "componentInventory": {
         "skills": [
-          "cratis-example"
+          "cratis-fundamentals-concept"
         ],
         "mcp": []
       },
       "exactSourcePaths": [
-        "tooling/fixtures/public-artifact/valid-source/skills/cratis-example/LICENSE",
-        "tooling/fixtures/public-artifact/valid-source/skills/cratis-example/SKILL.md",
-        "tooling/fixtures/public-artifact/valid-source/skills/cratis-example/assets/example.txt",
-        "tooling/fixtures/public-artifact/valid-source/skills/cratis-example/references/guide.md"
+        "skills/cratis-fundamentals-concept/LICENSE",
+        "skills/cratis-fundamentals-concept/SKILL.md"
       ],
       "allowedPathPatterns": [
-        "skills/cratis-example/SKILL.md",
-        "skills/cratis-example/references/**",
-        "skills/cratis-example/assets/**",
-        "skills/cratis-example/LICENSE*"
+        "skills/cratis-fundamentals-concept/SKILL.md",
+        "skills/cratis-fundamentals-concept/references/**",
+        "skills/cratis-fundamentals-concept/assets/**",
+        "skills/cratis-fundamentals-concept/LICENSE*"
       ],
       "forbiddenPathPatterns": [
         "engineering/**",
@@ -233,7 +231,8 @@
       ],
       "requiresApprovedTargets": false,
       "evidenceIds": [
-        "reevaluation-authority"
+        "reevaluation-authority",
+        "public-fundamentals-concept-source-e9d161a"
       ]
     }
   ]

--- a/catalog/v2/evidence.json
+++ b/catalog/v2/evidence.json
@@ -50,14 +50,14 @@
       "immutableRevision": "b795d5307e20f7f7458a67708b4f26975e223796"
     },
     {
-      "id": "public-fundamentals-concept-source-422ec8e",
-      "officialUrl": "https://github.com/Cratis/AI/tree/422ec8eebc198f9c25c28831a94623a3d4432fea/skills/cratis-fundamentals-concept",
+      "id": "public-fundamentals-concept-source-e9d161a",
+      "officialUrl": "https://github.com/Cratis/AI/tree/e9d161a70e25334bb468a33240bcf00f03f87522/skills/cratis-fundamentals-concept",
       "sourceKind": "repository-snapshot",
       "verifiedOn": "2026-08-22",
       "expiresOn": "2027-08-22",
-      "applicableVersion": "422ec8eebc198f9c25c28831a94623a3d4432fea",
+      "applicableVersion": "e9d161a70e25334bb468a33240bcf00f03f87522",
       "confidence": "high",
-      "immutableRevision": "422ec8eebc198f9c25c28831a94623a3d4432fea"
+      "immutableRevision": "e9d161a70e25334bb468a33240bcf00f03f87522"
     },
     {
       "id": "engineering-docs-add-page-source-684d037",

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,14 +1,42 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "f80104c2626f629da81e62a65580f67cd985244718ab53e0aa875dad48b87a89",
+  "indexDigest": "ae8926bd91b01a1ac6e5d4dd1f160d240aa6ed7b9c6d5e5db8e307e453fe0690",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
   "changesSinceBase": [
     {
+      "path": ".ai/README.md",
+      "status": "modified"
+    },
+    {
+      "path": ".ai/agents/coordinator.md",
+      "status": "modified"
+    },
+    {
+      "path": ".ai/agents/orchestrator.md",
+      "status": "modified"
+    },
+    {
+      "path": ".ai/agents/performance-reviewer.md",
+      "status": "modified"
+    },
+    {
+      "path": ".ai/agents/planner.md",
+      "status": "modified"
+    },
+    {
       "path": ".ai/rules/general.md",
       "status": "modified"
+    },
+    {
+      "path": ".ai/rules/managing-ai-rules.md",
+      "status": "modified"
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/shared-ai-improvement.yml",
+      "status": "added"
     },
     {
       "path": ".github/workflows/distribution-canary-rollback.yml",
@@ -25,6 +53,14 @@
     {
       "path": ".github/workflows/engineering-distribution-fixture.yml",
       "status": "added"
+    },
+    {
+      "path": ".github/workflows/propagate-copilot-instructions.yml",
+      "status": "modified"
+    },
+    {
+      "path": ".github/workflows/sync-copilot-instructions.yml",
+      "status": "modified"
     },
     {
       "path": ".github/workflows/verify-ai-corpus.yml",
@@ -85,6 +121,22 @@
     {
       "path": "AI-REPOSITORY-REDESIGN-THIRD-PARTY-SKILLS-EVALUATION.md",
       "status": "added"
+    },
+    {
+      "path": "Documentation/.markdownlint.json",
+      "status": "added"
+    },
+    {
+      "path": "Documentation/agents.md",
+      "status": "modified"
+    },
+    {
+      "path": "Documentation/ai-distribution-and-subscriptions.md",
+      "status": "added"
+    },
+    {
+      "path": "Documentation/architecture.md",
+      "status": "modified"
     },
     {
       "path": "Documentation/capability-catalog-v2.md",
@@ -155,6 +207,34 @@
       "status": "added"
     },
     {
+      "path": "Documentation/examples/ai-subscriptions/chronicle-framework.cratis-ai.json",
+      "status": "added"
+    },
+    {
+      "path": "Documentation/examples/ai-subscriptions/cratis-application.cratis-ai.json",
+      "status": "added"
+    },
+    {
+      "path": "Documentation/examples/ai-subscriptions/pi-settings.json",
+      "status": "added"
+    },
+    {
+      "path": "Documentation/index.md",
+      "status": "modified"
+    },
+    {
+      "path": "Documentation/instructions-vs-skills.md",
+      "status": "modified"
+    },
+    {
+      "path": "Documentation/instructions.md",
+      "status": "modified"
+    },
+    {
+      "path": "Documentation/orchestrator.md",
+      "status": "modified"
+    },
+    {
       "path": "Documentation/phase-0-verification.md",
       "status": "added"
     },
@@ -179,8 +259,20 @@
       "status": "added"
     },
     {
+      "path": "Documentation/skills.md",
+      "status": "modified"
+    },
+    {
       "path": "Documentation/source-evidence-contract.md",
       "status": "added"
+    },
+    {
+      "path": "Documentation/verify-markdown.sh",
+      "status": "modified"
+    },
+    {
+      "path": "README.md",
+      "status": "modified"
     },
     {
       "path": "catalog/ecosystem-versions.json",
@@ -303,6 +395,10 @@
       "status": "added"
     },
     {
+      "path": "distribution/evidence/local-profile-fixture-smoke-2026-08-22.json",
+      "status": "added"
+    },
+    {
       "path": "distribution/evidence/real-documentation-engineering-canary-2026-08-22.json",
       "status": "added"
     },
@@ -320,6 +416,14 @@
     },
     {
       "path": "distribution/npm-stage-contract.json",
+      "status": "added"
+    },
+    {
+      "path": "distribution/profile-catalog.json",
+      "status": "added"
+    },
+    {
+      "path": "distribution/profile-subscription.schema.json",
       "status": "added"
     },
     {
@@ -1819,6 +1923,10 @@
       "status": "added"
     },
     {
+      "path": "tooling/profile-subscription-validation.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/project-context-bootstrap.mjs",
       "status": "added"
     },
@@ -1927,6 +2035,10 @@
       "status": "added"
     },
     {
+      "path": "tooling/specs/profile-subscription.spec.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/specs/project-context-bootstrap.spec.mjs",
       "status": "added"
     },
@@ -1935,7 +2047,15 @@
       "status": "added"
     },
     {
+      "path": "tooling/specs/public-fundamentals-concept.spec.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/specs/source-evidence-contract.spec.mjs",
+      "status": "added"
+    },
+    {
+      "path": "tooling/specs/workflow-safety.spec.mjs",
       "status": "added"
     },
     {
@@ -1951,21 +2071,7 @@
       "status": "added"
     }
   ],
-  "admittedUntracked": [
-    ".github/ISSUE_TEMPLATE/shared-ai-improvement.yml",
-    "Documentation/.markdownlint.json",
-    "Documentation/ai-distribution-and-subscriptions.md",
-    "Documentation/examples/ai-subscriptions/chronicle-framework.cratis-ai.json",
-    "Documentation/examples/ai-subscriptions/cratis-application.cratis-ai.json",
-    "Documentation/examples/ai-subscriptions/pi-settings.json",
-    "distribution/evidence/local-profile-fixture-smoke-2026-08-22.json",
-    "distribution/profile-catalog.json",
-    "distribution/profile-subscription.schema.json",
-    "tooling/profile-subscription-validation.mjs",
-    "tooling/specs/profile-subscription.spec.mjs",
-    "tooling/specs/public-fundamentals-concept.spec.mjs",
-    "tooling/specs/workflow-safety.spec.mjs"
-  ],
+  "admittedUntracked": [],
   "excludedRuntimePrefixes": [
     ".pi/delegate/",
     ".pi/fusion/",

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "50de38f16d5d3440145c66887de5d925f56da5277ded1049323963c9d4d956bf",
+  "indexDigest": "f80104c2626f629da81e62a65580f67cd985244718ab53e0aa875dad48b87a89",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -1951,7 +1951,21 @@
       "status": "added"
     }
   ],
-  "admittedUntracked": [],
+  "admittedUntracked": [
+    ".github/ISSUE_TEMPLATE/shared-ai-improvement.yml",
+    "Documentation/.markdownlint.json",
+    "Documentation/ai-distribution-and-subscriptions.md",
+    "Documentation/examples/ai-subscriptions/chronicle-framework.cratis-ai.json",
+    "Documentation/examples/ai-subscriptions/cratis-application.cratis-ai.json",
+    "Documentation/examples/ai-subscriptions/pi-settings.json",
+    "distribution/evidence/local-profile-fixture-smoke-2026-08-22.json",
+    "distribution/profile-catalog.json",
+    "distribution/profile-subscription.schema.json",
+    "tooling/profile-subscription-validation.mjs",
+    "tooling/specs/profile-subscription.spec.mjs",
+    "tooling/specs/public-fundamentals-concept.spec.mjs",
+    "tooling/specs/workflow-safety.spec.mjs"
+  ],
   "excludedRuntimePrefixes": [
     ".pi/delegate/",
     ".pi/fusion/",
@@ -2546,8 +2560,8 @@
       "evidenceIds": [
         "repo-main-b795d53"
       ],
-      "expectedPathCount": 4,
-      "expectedPathsDigest": "a1fe1a0a7af43bbf195eab58bc0cd86bb6b34f17fa3c86762ec81e34617f4791"
+      "expectedPathCount": 5,
+      "expectedPathsDigest": "e0ad39f4d9537ccb38363e41c462954e371bf617f4d94ea35bad0d64333c67e3"
     },
     {
       "excludePathPatterns": [],
@@ -2707,6 +2721,7 @@
       "excludePathPatterns": [],
       "id": "legacy-documentation",
       "sourcePathPatterns": [
+        "Documentation/.markdownlint.json",
         "Documentation/agents.md",
         "Documentation/architecture.md",
         "Documentation/index.md",
@@ -2731,14 +2746,16 @@
         "repo-main-b795d53",
         "reevaluation-authority"
       ],
-      "expectedPathCount": 8,
-      "expectedPathsDigest": "e2ff4c260b18e7c59146b8a48aadf114d59c06f970a8b473529baa7da667de4f"
+      "expectedPathCount": 9,
+      "expectedPathsDigest": "d0758546d912d30171a35f6070393c261b69cc3c18ac452b9d7cdf6f392431ec"
     },
     {
       "excludePathPatterns": [],
       "id": "redesign-decision-documents",
       "sourcePathPatterns": [
         "AI-REPOSITORY-REDESIGN-*.md",
+        "Documentation/ai-distribution-and-subscriptions.md",
+        "Documentation/examples/ai-subscriptions/**",
         "Documentation/phase-0-verification.md",
         "Documentation/public-product-architecture.md",
         "Documentation/skill-classification-audit.md",
@@ -2762,8 +2779,8 @@
         "workflows-68",
         "reevaluation-authority"
       ],
-      "expectedPathCount": 19,
-      "expectedPathsDigest": "b6184ed056ae917fdea8f3bcdc37d804b0f8c37ab923afec40e65c88d6e10211"
+      "expectedPathCount": 23,
+      "expectedPathsDigest": "8bcfe69caab9977abea3ae57d37bc98ed0f47fa3b9323e3e678b5f0fa26a6760"
     },
     {
       "excludePathPatterns": [],
@@ -3235,8 +3252,8 @@
       "evidenceIds": [
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 15,
-      "expectedPathsDigest": "54d61e538447c58e49227525d6eb5c350db9c81daebb54fec46986b217bfd4c7"
+      "expectedPathCount": 18,
+      "expectedPathsDigest": "08ef0162524356047d9100c699f1503db69c36e4a45fe96b63ef31a90e9f77e5"
     },
     {
       "excludePathPatterns": [],
@@ -3258,8 +3275,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 30,
-      "expectedPathsDigest": "2ecea06af372f03861cb1e52c8e2074216b38838e5bbb632421bab1e8057bada"
+      "expectedPathCount": 31,
+      "expectedPathsDigest": "16105f414ef18bf88bebffaaab9205aa2c08aa1ed70674a0ea13351aca956783"
     },
     {
       "excludePathPatterns": [],
@@ -3282,8 +3299,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 22,
-      "expectedPathsDigest": "7e7e65c53a3e09c9c916ce2c07a73e0ea5670a8f763728e4e35fc04042b87eb2"
+      "expectedPathCount": 25,
+      "expectedPathsDigest": "136d0ecb86b88dc900ea5b606b1f428f336b14f8540bdc99c9de67276c0f32dd"
     },
     {
       "excludePathPatterns": [],

--- a/catalog/v2/sources.json
+++ b/catalog/v2/sources.json
@@ -33,13 +33,13 @@
         "skills/cratis-fundamentals-concept/LICENSE",
         "skills/cratis-fundamentals-concept/SKILL.md"
       ],
-      "sourceRevision": "422ec8eebc198f9c25c28831a94623a3d4432fea",
-      "contentDigest": "426775e9afc2ff0adb0d8adfd7a5fdaa71c74c60726f11272a224707bf1369c6",
+      "sourceRevision": "e9d161a70e25334bb468a33240bcf00f03f87522",
+      "contentDigest": "f7f7c2c110b3ff3f1b5921ad51fffc449a448bb49aaec2626ecc4d391e9d78a1",
       "publicationApproval": false,
       "evidenceIds": [
         "repo-main-b795d53",
         "reevaluation-authority",
-        "public-fundamentals-concept-source-422ec8e"
+        "public-fundamentals-concept-source-e9d161a"
       ]
     },
     {

--- a/distribution/evidence/local-canary-rollback-2026-08-22.json
+++ b/distribution/evidence/local-canary-rollback-2026-08-22.json
@@ -1,11 +1,14 @@
 {
   "schemaVersion": "1.0.0",
   "observedAt": "2026-08-22",
-  "sourceCommit": null,
-  "sourceWorktreeBase": "00828efb80ac93b274c8a3bee7c844fdea19b4fb",
+  "sourceCommit": "e9d161a70e25334bb468a33240bcf00f03f87522",
+  "sourceWorktreeBase": "e9d161a70e25334bb468a33240bcf00f03f87522",
   "state": "FIXTURE_ONLY_ROLLOUT_SIMULATION",
   "candidate": {
-    "artifactId": "sanitized-public-materializer-fixture",
+    "artifactId": "cratis-fundamentals-concept-preview",
+    "sourcePath": "skills/cratis-fundamentals-concept",
+    "manifestSha256": "3bbefa355a20afd48aca800a8c9b9057cd85550a659c687195475c4d99d55a8c",
+    "provenanceSha256": "05512cfdf85418efe524586c61362ee06b1568b13a08db33295cc90e3e035113",
     "status": "PASS",
     "publicationEligible": false,
     "promotionEligible": false

--- a/distribution/evidence/local-engineering-docs-authoring-fixture-2026-08-22.json
+++ b/distribution/evidence/local-engineering-docs-authoring-fixture-2026-08-22.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": "1.0.0",
   "observedAt": "2026-08-22",
-  "sourceCommit": null,
-  "sourceWorktreeBase": "2cfd917d81a026db7aeb50afb7be20b9084e3e3c",
+  "sourceCommit": "f58bcf7f5cc9fc0e11305ada3b5ecb6fa20953e9",
+  "sourceWorktreeBase": "f58bcf7f5cc9fc0e11305ada3b5ecb6fa20953e9",
   "state": "ENGINEERING_FIXTURE_ONLY",
   "targetId": "cratis-engineering-docs-authoring",
   "sourceRevision": "f58bcf7f5cc9fc0e11305ada3b5ecb6fa20953e9",
@@ -12,11 +12,16 @@
     "codex",
     "copilot",
     "cursor",
+    "deepseek",
     "gemini",
+    "grok",
     "junie",
     "kiro",
     "pi"
   ],
+  "manifestSha256": "ada5ef5647151d554851e8627cafed9c19faf186d5a8b407ac20f1f945cfa97b",
+  "provenanceSha256": "0fb2a70dd661702d6e59fabaf18517d423770852c55aa0c4f26fc2ff5bdbfa7d",
+  "sourceContentDigest": "9e9731cdb930999784fd8b244c3df7f0b49b54479d47fd26bc624e1b81e480fa",
   "results": [
     {
       "target": "npm",
@@ -88,6 +93,26 @@
         "removed-state"
       ],
       "status": "PASS_WITH_PROJECT_REGISTRY_WARNING"
+    },
+    {
+      "target": "grok-build",
+      "version": null,
+      "checks": [
+        "direct-skill-install",
+        "canonical-byte-parity",
+        "remove"
+      ],
+      "status": "PASS_DIRECT_LAYOUT_HOST_SMOKE_PENDING"
+    },
+    {
+      "target": "deepseek-harness",
+      "version": null,
+      "checks": [
+        "direct-skill-install",
+        "canonical-byte-parity",
+        "remove"
+      ],
+      "status": "PASS_DIRECT_LAYOUT_HOST_SMOKE_PENDING"
     },
     {
       "target": "cursor",

--- a/distribution/evidence/local-profile-fixture-smoke-2026-08-22.json
+++ b/distribution/evidence/local-profile-fixture-smoke-2026-08-22.json
@@ -1,0 +1,61 @@
+{
+  "schemaVersion": "1.0.0",
+  "verifiedOn": "2026-08-22",
+  "status": "PASS",
+  "sourceCommit": "e9d161a70e25334bb468a33240bcf00f03f87522",
+  "sourceArtifactId": "cratis-fundamentals-concept-preview",
+  "sourcePath": "skills/cratis-fundamentals-concept",
+  "version": "0.0.3-fixture",
+  "generatedTargets": [
+    "canonical",
+    "claude",
+    "codex",
+    "copilot",
+    "cursor",
+    "deepseek",
+    "gemini",
+    "grok",
+    "junie",
+    "kiro",
+    "pi"
+  ],
+  "manifestSha256": "3bbefa355a20afd48aca800a8c9b9057cd85550a659c687195475c4d99d55a8c",
+  "provenanceSha256": "05512cfdf85418efe524586c61362ee06b1568b13a08db33295cc90e3e035113",
+  "provenanceSourceRevision": "e9d161a70e25334bb468a33240bcf00f03f87522",
+  "results": [
+    {
+      "gate": "grok-direct-install-remove",
+      "status": "PASS"
+    },
+    {
+      "gate": "deepseek-harness-direct-install-remove",
+      "status": "PASS"
+    },
+    {
+      "gate": "npm-pack-install-uninstall",
+      "status": "PASS"
+    },
+    {
+      "gate": "pi-install-remove",
+      "status": "PASS"
+    },
+    {
+      "gate": "claude-install-remove",
+      "status": "PASS"
+    },
+    {
+      "gate": "copilot-install-remove",
+      "status": "PASS"
+    },
+    {
+      "gate": "codex-marketplace-add-remove",
+      "status": "PASS"
+    },
+    {
+      "gate": "gemini-link-remove",
+      "status": "PASS"
+    }
+  ],
+  "publicationEligible": false,
+  "promotionEligible": false
+}

--- a/distribution/generated-repository-contract.json
+++ b/distribution/generated-repository-contract.json
@@ -50,8 +50,30 @@
     "enabled": false,
     "requiresApprovedTargets": true,
     "requiresExactSourceCommit": true,
+    "requiresExactSourceDigests": true,
+    "requiresVerifiedSourceContracts": true,
     "requiresBotCredential": true,
-    "requiresProtectedRepository": true
+    "requiresProtectedRepository": true,
+    "releaseTrain": "atomic-semver",
+    "profileCatalog": "distribution/profile-catalog.json",
+    "subscriptionFile": ".cratis/ai.json",
+    "artifactTopology": "one-profile-one-harness-root-asset",
+    "requiredProvenance": [
+      "Cratis/AI commit",
+      "product source revisions",
+      "approved target ids",
+      "profile and package inventory",
+      "content digests",
+      "generator digest",
+      "tested host versions"
+    ],
+    "requiredLifecycleEvidence": [
+      "install",
+      "update",
+      "rollback",
+      "uninstall",
+      "project context preservation"
+    ]
   },
   "publicationEligible": false,
   "promotionEligible": false,

--- a/distribution/profile-catalog.json
+++ b/distribution/profile-catalog.json
@@ -1,0 +1,180 @@
+{
+  "schemaVersion": "1.0.0",
+  "state": "DESIGNED_RELEASES_NOT_YET_PUBLISHED",
+  "sourceRepository": "https://github.com/Cratis/AI",
+  "generatedRepository": "https://github.com/Cratis/AI.Distribution",
+  "versioning": {
+    "strategy": "semver",
+    "releaseTrain": "atomic",
+    "exactPinsRequired": true,
+    "floatingVersionsAllowed": false,
+    "updateMechanism": "reviewed-pull-request"
+  },
+  "authority": {
+    "sharedBehaviorOwner": "Cratis/AI",
+    "productFactOwner": "owning Cratis product repository",
+    "projectContextOwner": "consuming repository",
+    "generatedArtifactOwner": "Cratis/AI.Distribution",
+    "directGeneratedEditsAllowed": false,
+    "automaticReverseSyncAllowed": false
+  },
+  "publicProfiles": [
+    {
+      "id": "public-fundamentals",
+      "packageName": "@cratis/ai-fundamentals",
+      "products": ["fundamentals"],
+      "state": "preview-source-candidate",
+      "availableTargets": ["cratis-fundamentals-concept"],
+      "gapSummary": "Type discovery remains a legacy candidate."
+    },
+    {
+      "id": "public-arc",
+      "packageName": "@cratis/ai-arc",
+      "products": ["arc", "arc-react"],
+      "state": "planned",
+      "availableTargets": [],
+      "gapSummary": "Commands, queries, validation, authorization, generated proxies, and React/MVVM journeys require canonical sources."
+    },
+    {
+      "id": "public-chronicle",
+      "packageName": "@cratis/ai-chronicle",
+      "products": ["chronicle"],
+      "state": "planned",
+      "availableTargets": [],
+      "gapSummary": "Core .NET, compliance, operations, and client-language journeys require canonical sources."
+    },
+    {
+      "id": "public-components",
+      "packageName": "@cratis/ai-components",
+      "products": ["components"],
+      "state": "planned",
+      "availableTargets": [],
+      "gapSummary": "Forms, dialogs, DataPage, tables, and styling journeys require canonical sources."
+    },
+    {
+      "id": "public-application",
+      "packageName": "@cratis/ai-application",
+      "products": ["fundamentals", "arc", "chronicle", "components"],
+      "state": "planned-composition",
+      "composes": [
+        "public-fundamentals",
+        "public-arc",
+        "public-chronicle",
+        "public-components"
+      ],
+      "availableTargets": [],
+      "gapSummary": "The end-to-end application profile becomes publishable only after its component profiles have approved targets."
+    }
+  ],
+  "engineeringProfiles": [
+    {
+      "id": "engineering-base",
+      "packageName": "@cratis/ai-engineering-base",
+      "repositoryKinds": ["application", "framework", "client", "documentation", "corpus"],
+      "products": [],
+      "state": "planned",
+      "gapSummary": "Universal C#/TypeScript/spec/review behavior must be reconciled into a passive profile skill."
+    },
+    {
+      "id": "engineering-application",
+      "packageName": "@cratis/ai-engineering-application",
+      "repositoryKinds": ["application"],
+      "products": ["fundamentals", "arc", "chronicle", "components"],
+      "state": "planned",
+      "composes": ["engineering-base"]
+    },
+    {
+      "id": "engineering-framework-fundamentals",
+      "packageName": "@cratis/ai-engineering-fundamentals",
+      "repositoryKinds": ["framework"],
+      "products": ["fundamentals"],
+      "state": "planned",
+      "composes": ["engineering-base"]
+    },
+    {
+      "id": "engineering-framework-arc",
+      "packageName": "@cratis/ai-engineering-arc",
+      "repositoryKinds": ["framework"],
+      "products": ["arc", "arc-react"],
+      "state": "planned",
+      "composes": ["engineering-base"]
+    },
+    {
+      "id": "engineering-framework-chronicle",
+      "packageName": "@cratis/ai-engineering-chronicle",
+      "repositoryKinds": ["framework"],
+      "products": ["chronicle"],
+      "state": "planned",
+      "composes": ["engineering-base"]
+    },
+    {
+      "id": "engineering-framework-components",
+      "packageName": "@cratis/ai-engineering-components",
+      "repositoryKinds": ["framework"],
+      "products": ["components"],
+      "state": "planned",
+      "composes": ["engineering-base"]
+    },
+    {
+      "id": "engineering-studio",
+      "packageName": "@cratis/ai-engineering-studio",
+      "repositoryKinds": ["application", "framework"],
+      "products": ["studio"],
+      "state": "content-gap",
+      "composes": ["engineering-base"]
+    },
+    {
+      "id": "engineering-stagehand",
+      "packageName": "@cratis/ai-engineering-stagehand",
+      "repositoryKinds": ["framework", "corpus"],
+      "products": ["stagehand"],
+      "state": "content-gap",
+      "composes": ["engineering-base"]
+    },
+    {
+      "id": "engineering-client",
+      "packageName": "@cratis/ai-engineering-clients",
+      "repositoryKinds": ["client"],
+      "products": ["chronicle-clients"],
+      "state": "content-gap",
+      "composes": ["engineering-base"]
+    },
+    {
+      "id": "engineering-documentation",
+      "packageName": "@cratis/ai-engineering-documentation",
+      "repositoryKinds": ["documentation"],
+      "products": ["documentation"],
+      "state": "owner-review-pending",
+      "availableTargets": ["cratis-engineering-docs-authoring"],
+      "composes": ["engineering-base"]
+    },
+    {
+      "id": "engineering-corpus",
+      "packageName": "@cratis/ai-engineering-corpus",
+      "repositoryKinds": ["corpus"],
+      "products": ["ai", "workflows"],
+      "state": "planned",
+      "composes": ["engineering-base"]
+    }
+  ],
+  "subscription": {
+    "projectFile": ".cratis/ai.json",
+    "projectOwned": true,
+    "packageWritesProjectContext": false,
+    "profileSelectionRequired": true,
+    "exactVersionRequired": true
+  },
+  "contributionFlow": {
+    "consumerRepositoriesPublishPackages": false,
+    "consumerRepositoriesPushGeneratedBytes": false,
+    "improvementPath": "source repository issue or pull request to Cratis/AI",
+    "requiredEvidence": [
+      "originating repository",
+      "immutable source revision",
+      "affected profiles and products",
+      "behavior or authority evidence",
+      "migration and compatibility impact"
+    ],
+    "downstreamDelivery": "new immutable release followed by reviewed subscriber update pull requests"
+  }
+}

--- a/distribution/profile-subscription.schema.json
+++ b/distribution/profile-subscription.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Cratis/AI/blob/main/distribution/profile-subscription.schema.json",
+  "title": "Cratis AI profile subscription",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "channel",
+    "version",
+    "profiles",
+    "harnesses",
+    "updatePolicy",
+    "projectContext"
+  ],
+  "oneOf": [
+    {
+      "properties": {
+        "channel": {
+          "const": "public"
+        },
+        "profiles": {
+          "items": {
+            "type": "string",
+            "pattern": "^public-[a-z0-9]+(?:-[a-z0-9]+)*$"
+          }
+        }
+      }
+    },
+    {
+      "properties": {
+        "channel": {
+          "const": "cratis-engineering"
+        },
+        "profiles": {
+          "items": {
+            "type": "string",
+            "pattern": "^engineering-[a-z0-9]+(?:-[a-z0-9]+)*$"
+          }
+        }
+      }
+    }
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "channel": {
+      "enum": ["public", "cratis-engineering"]
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
+    },
+    "profiles": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^(?:public|engineering)-[a-z0-9]+(?:-[a-z0-9]+)*$"
+      }
+    },
+    "harnesses": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "agent-skills",
+          "claude",
+          "codex",
+          "copilot",
+          "cursor",
+          "deepseek-harness",
+          "gemini",
+          "grok",
+          "junie",
+          "kiro",
+          "pi"
+        ]
+      }
+    },
+    "updatePolicy": {
+      "const": "reviewed-pull-request"
+    },
+    "projectContext": {
+      "type": "string",
+      "enum": [".cratis/PROJECT.md", ".agents/PROJECT.md"]
+    },
+    "skillAllowlist": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+      }
+    },
+    "skillDenylist": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+      }
+    }
+  }
+}

--- a/distribution/rollout-policy.json
+++ b/distribution/rollout-policy.json
@@ -11,7 +11,7 @@
   },
   "candidate": {
     "allowedArtifactIds": [
-      "sanitized-public-materializer-fixture"
+      "cratis-fundamentals-concept-preview"
     ],
     "blockedArtifactIds": [
       "planned-passive-public-release"

--- a/skills/cratis-fundamentals-concept/SKILL.md
+++ b/skills/cratis-fundamentals-concept/SKILL.md
@@ -42,7 +42,32 @@ public record <ConceptName>(<UnderlyingType> Value) : ConceptAs<<UnderlyingType>
 }
 ```
 
-## Event-source identity
+## Guid-backed event-source identity
+
+Use this template only when the underlying identity type is `Guid`.
+
+```csharp
+using Cratis.Chronicle.Events;
+
+namespace <NamespaceRoot>.<Feature>;
+
+/// <summary>
+/// Represents the identity of a <description>.
+/// </summary>
+/// <param name="Value">The underlying Guid value.</param>
+public record <ConceptName>(Guid Value) : EventSourceId<Guid>(Value)
+{
+    public static readonly <ConceptName> NotSet = new(Guid.Empty);
+    public static <ConceptName> New() => new(Guid.NewGuid());
+    public static implicit operator <ConceptName>(Guid value) => new(value);
+}
+```
+
+## Non-Guid event-source identity
+
+For string, integer, or other identity primitives, do not call `Guid.NewGuid()`.
+Expose a typed factory only when the domain has a valid way to create that
+primitive.
 
 ```csharp
 using Cratis.Chronicle.Events;
@@ -56,7 +81,6 @@ namespace <NamespaceRoot>.<Feature>;
 public record <ConceptName>(<UnderlyingType> Value) : EventSourceId<<UnderlyingType>>(Value)
 {
     public static readonly <ConceptName> NotSet = new(<emptyValue>);
-    public static <ConceptName> New() => new(Guid.NewGuid());
     public static implicit operator <ConceptName>(<UnderlyingType> value) => new(value);
 }
 ```
@@ -81,7 +105,7 @@ Place the concept with the feature that owns its meaning rather than in a generi
 - The type derives from `ConceptAs<T>` or `EventSourceId<T>` as appropriate.
 - It has a `static readonly NotSet` or semantically equivalent sentinel.
 - It has an implicit conversion from the primitive.
-- A `Guid`-backed identity has a typed `New()` factory.
+- A `Guid`-backed identity has a typed `New()` factory; non-Guid identities use only a domain-valid factory.
 - An identity does not duplicate conversions supplied by `EventSourceId<T>`.
 - The file carries the repository license header.
 - `dotnet build` passes.

--- a/tooling/catalog-validation.mjs
+++ b/tooling/catalog-validation.mjs
@@ -41,6 +41,7 @@ const supportedSchemaKeywords = new Set([
     "pattern",
     "format",
     "minimum",
+    "oneOf",
 ]);
 
 export function validateSchemaVocabulary(schema, path = "$") {
@@ -63,6 +64,15 @@ export function validateSchemaVocabulary(schema, path = "$") {
             }
         } else if (keyword === "items" && value && typeof value === "object") {
             errors.push(...validateSchemaVocabulary(value, `${path}.items`));
+        } else if (keyword === "oneOf" && Array.isArray(value)) {
+            value.forEach((child, index) => {
+                errors.push(
+                    ...validateSchemaVocabulary(
+                        child,
+                        `${path}.oneOf[${index}]`,
+                    ),
+                );
+            });
         }
     }
     return errors;
@@ -140,8 +150,24 @@ function matchesKnownPattern(value, pattern) {
             return /^(\.ai\/skills|skills)\/[a-z0-9]+(?:-[a-z0-9]+)*$/.test(
                 value,
             );
+        case "^[a-f0-9]{40}$":
+            return /^[a-f0-9]{40}$/.test(value);
+        case "^[a-f0-9]{64}$":
+            return /^[a-f0-9]{64}$/.test(value);
+        case "^(?:public|engineering)-[a-z0-9]+(?:-[a-z0-9]+)*$":
+            return /^(?:public|engineering)-[a-z0-9]+(?:-[a-z0-9]+)*$/.test(
+                value,
+            );
+        case "^public-[a-z0-9]+(?:-[a-z0-9]+)*$":
+            return /^public-[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value);
+        case "^engineering-[a-z0-9]+(?:-[a-z0-9]+)*$":
+            return /^engineering-[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value);
+        case "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$":
+            return /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(
+                value,
+            );
         default:
-            return new RegExp(pattern).test(value);
+            return false;
     }
 }
 
@@ -158,6 +184,16 @@ export function validateAgainstSchema(
         if (!referencedSchema)
             return [`${path}: unresolved schema reference ${schema.$ref}`];
         return validateAgainstSchema(value, referencedSchema, rootSchema, path);
+    }
+
+    if (schema.oneOf) {
+        const matchingBranches = schema.oneOf.filter(
+            branch =>
+                validateAgainstSchema(value, branch, rootSchema, path).length ===
+                0,
+        );
+        if (matchingBranches.length !== 1)
+            errors.push(`${path}: expected exactly one matching oneOf branch`);
     }
 
     if (Object.hasOwn(schema, "const") && value !== schema.const) {

--- a/tooling/generate-catalog-v2.mjs
+++ b/tooling/generate-catalog-v2.mjs
@@ -46,8 +46,8 @@ const sourceOverrides = new Map([
         "add-concept",
         {
             sourcePath: "skills/cratis-fundamentals-concept",
-            sourceRevision: "422ec8eebc198f9c25c28831a94623a3d4432fea",
-            evidenceId: "public-fundamentals-concept-source-422ec8e",
+            sourceRevision: "e9d161a70e25334bb468a33240bcf00f03f87522",
+            evidenceId: "public-fundamentals-concept-source-e9d161a",
         },
     ],
     [
@@ -1320,23 +1320,24 @@ writeJson("artifacts.json", {
             ],
         },
         {
-            id: "sanitized-public-materializer-fixture",
+            id: "cratis-fundamentals-concept-preview",
             audience: "test-fixture",
             fixtureOnly: true,
             materializationAllowed: true,
             runtimeEligible: false,
-            componentInventory: { skills: ["cratis-example"], mcp: [] },
+            componentInventory: {
+                skills: ["cratis-fundamentals-concept"],
+                mcp: [],
+            },
             exactSourcePaths: [
-                "tooling/fixtures/public-artifact/valid-source/skills/cratis-example/LICENSE",
-                "tooling/fixtures/public-artifact/valid-source/skills/cratis-example/SKILL.md",
-                "tooling/fixtures/public-artifact/valid-source/skills/cratis-example/assets/example.txt",
-                "tooling/fixtures/public-artifact/valid-source/skills/cratis-example/references/guide.md",
+                "skills/cratis-fundamentals-concept/LICENSE",
+                "skills/cratis-fundamentals-concept/SKILL.md",
             ],
             allowedPathPatterns: [
-                "skills/cratis-example/SKILL.md",
-                "skills/cratis-example/references/**",
-                "skills/cratis-example/assets/**",
-                "skills/cratis-example/LICENSE*",
+                "skills/cratis-fundamentals-concept/SKILL.md",
+                "skills/cratis-fundamentals-concept/references/**",
+                "skills/cratis-fundamentals-concept/assets/**",
+                "skills/cratis-fundamentals-concept/LICENSE*",
             ],
             forbiddenPathPatterns: [
                 "engineering/**",
@@ -1354,7 +1355,10 @@ writeJson("artifacts.json", {
                 ".git/**",
             ],
             requiresApprovedTargets: false,
-            evidenceIds: ["reevaluation-authority"],
+            evidenceIds: [
+                "reevaluation-authority",
+                "public-fundamentals-concept-source-e9d161a",
+            ],
         },
     ],
 });
@@ -1407,15 +1411,15 @@ const evidence = [
         immutableRevision: revision,
     },
     {
-        id: "public-fundamentals-concept-source-422ec8e",
+        id: "public-fundamentals-concept-source-e9d161a",
         officialUrl:
-            "https://github.com/Cratis/AI/tree/422ec8eebc198f9c25c28831a94623a3d4432fea/skills/cratis-fundamentals-concept",
+            "https://github.com/Cratis/AI/tree/e9d161a70e25334bb468a33240bcf00f03f87522/skills/cratis-fundamentals-concept",
         sourceKind: "repository-snapshot",
         verifiedOn: "2026-08-22",
         expiresOn: "2027-08-22",
-        applicableVersion: "422ec8eebc198f9c25c28831a94623a3d4432fea",
+        applicableVersion: "e9d161a70e25334bb468a33240bcf00f03f87522",
         confidence: "high",
-        immutableRevision: "422ec8eebc198f9c25c28831a94623a3d4432fea",
+        immutableRevision: "e9d161a70e25334bb468a33240bcf00f03f87522",
     },
     {
         id: "engineering-docs-add-page-source-684d037",

--- a/tooling/generate-distribution-fixture.mjs
+++ b/tooling/generate-distribution-fixture.mjs
@@ -83,7 +83,13 @@ function manifestFile(root, path) {
     return { path, sha256: sha256(content), size: content.length };
 }
 
-function assertConfiguration(requirements, matrix) {
+function assertConfiguration(
+    requirements,
+    matrix,
+    artifacts,
+    sources,
+    repositoryRoot,
+) {
     if (
         requirements.schemaVersion !== "1.0.0" ||
         matrix.schemaVersion !== "1.0.0"
@@ -128,6 +134,43 @@ function assertConfiguration(requirements, matrix) {
             .some((target) => target.outputRoot !== null)
     )
         throw new Error("Blocked targets must not receive output roots");
+    const artifact = artifacts.find(
+        (candidate) => candidate.id === matrix.canonicalSource.artifactId,
+    );
+    const source = sources.find((candidate) => candidate.id === "add-concept");
+    if (
+        !artifact ||
+        artifact.fixtureOnly !== true ||
+        artifact.materializationAllowed !== true ||
+        artifact.runtimeEligible !== false ||
+        JSON.stringify(artifact.exactSourcePaths) !==
+            JSON.stringify(approvedFiles) ||
+        !source ||
+        source.sourcePath !== "skills/cratis-fundamentals-concept" ||
+        JSON.stringify(source.bundledPaths) !== JSON.stringify(approvedFiles) ||
+        !/^[0-9a-f]{40}$/.test(source.sourceRevision)
+    )
+        throw new Error("Public fixture artifact authority is inconsistent");
+    for (const path of approvedFiles) {
+        const current = readFileSync(join(repositoryRoot, path));
+        let immutable;
+        try {
+            immutable = execFileSync(
+                "git",
+                ["show", `${source.sourceRevision}:${path}`],
+                { cwd: repositoryRoot },
+            );
+        } catch (error) {
+            throw new Error(`Unable to read immutable public source: ${path}`, {
+                cause: error,
+            });
+        }
+        if (!current.equals(immutable))
+            throw new Error(
+                `Public fixture source drifted from revision: ${path}`,
+            );
+    }
+    return { artifact, source };
 }
 
 export function validateDistributionConfiguration(
@@ -140,7 +183,19 @@ export function validateDistributionConfiguration(
         const matrix = readJson(
             join(repositoryRoot, "distribution/artifact-matrix.json"),
         );
-        assertConfiguration(requirements, matrix);
+        const artifacts = readJson(
+            join(repositoryRoot, "catalog/v2/artifacts.json"),
+        ).artifacts;
+        const sources = readJson(
+            join(repositoryRoot, "catalog/v2/sources.json"),
+        ).sources;
+        assertConfiguration(
+            requirements,
+            matrix,
+            artifacts,
+            sources,
+            repositoryRoot,
+        );
         return [];
     } catch (error) {
         return [
@@ -170,7 +225,19 @@ export function generateDistributionFixture({
     );
     const requirements = readJson(requirementsPath);
     const matrix = readJson(matrixPath);
-    assertConfiguration(requirements, matrix);
+    const artifacts = readJson(
+        join(repositoryRoot, "catalog/v2/artifacts.json"),
+    ).artifacts;
+    const sources = readJson(
+        join(repositoryRoot, "catalog/v2/sources.json"),
+    ).sources;
+    const { source } = assertConfiguration(
+        requirements,
+        matrix,
+        artifacts,
+        sources,
+        repositoryRoot,
+    );
 
     mkdirSync(root, { recursive: false });
     try {
@@ -359,7 +426,9 @@ export function generateDistributionFixture({
             state: "FIXTURE_ONLY_NOT_AN_ATTESTATION",
             canonicalRepository: "Cratis/AI",
             sourceArtifactId: matrix.canonicalSource.artifactId,
-            sourceRevision: null,
+            sourceRevision: source.sourceRevision,
+            sourcePath: source.sourcePath,
+            sourceContentDigest: source.contentDigest,
             generator: "tooling/generate-distribution-fixture.mjs",
             version,
             requirementsSha256: sha256(readFileSync(requirementsPath)),

--- a/tooling/generate-engineering-distribution-fixture.mjs
+++ b/tooling/generate-engineering-distribution-fixture.mjs
@@ -92,6 +92,42 @@ function manifestFile(root, path) {
     return { path, sha256: sha256(content), size: content.length };
 }
 
+function validateEngineeringSourceAuthority(repositoryRoot) {
+    const source = readJson(
+        join(repositoryRoot, "catalog/v2/sources.json"),
+    ).sources.find(candidate => candidate.id === "write-documentation");
+    const expectedPaths = approvedFiles.map(path => `engineering/${path}`);
+    if (
+        !source ||
+        source.sourcePath !==
+            "engineering/skills/cratis-engineering-docs-authoring" ||
+        JSON.stringify(source.bundledPaths) !== JSON.stringify(expectedPaths) ||
+        !/^[0-9a-f]{40}$/.test(source.sourceRevision)
+    )
+        throw new Error("Engineering source authority is inconsistent");
+    for (const path of expectedPaths) {
+        const current = readFileSync(join(repositoryRoot, path));
+        let immutable;
+        try {
+            immutable = execFileSync(
+                "git",
+                ["show", `${source.sourceRevision}:${path}`],
+                { cwd: repositoryRoot },
+            );
+        } catch (error) {
+            throw new Error(
+                `Unable to read immutable engineering source: ${path}`,
+                { cause: error },
+            );
+        }
+        if (!current.equals(immutable))
+            throw new Error(
+                `Engineering fixture source drifted from revision: ${path}`,
+            );
+    }
+    return source;
+}
+
 export function validateEngineeringDistributionConfiguration(
     repositoryRoot = defaultRepositoryRoot,
 ) {
@@ -127,6 +163,7 @@ export function validateEngineeringDistributionConfiguration(
         const expectedExactPaths = approvedFiles.map(
             (path) => `engineering/${path}`,
         );
+        validateEngineeringSourceAuthority(repositoryRoot);
         if (
             artifactMatrix.firstPassiveTarget.state !==
                 "REAL_CANARY_PASS_OWNER_REVIEW_PENDING" ||
@@ -186,6 +223,7 @@ export function generateEngineeringDistributionFixture({
         validateEngineeringDistributionConfiguration(repositoryRoot);
     if (configurationErrors.length > 0)
         throw new Error(configurationErrors.join("; "));
+    const source = validateEngineeringSourceAuthority(repositoryRoot);
 
     mkdirSync(root, { recursive: false });
     try {
@@ -382,8 +420,9 @@ export function generateEngineeringDistributionFixture({
             schemaVersion: "1.0.0",
             state: "ENGINEERING_FIXTURE_ONLY_NOT_AN_ATTESTATION",
             canonicalRepository: "Cratis/AI",
-            sourceRevision: "f58bcf7f5cc9fc0e11305ada3b5ecb6fa20953e9",
-            sourcePath: "engineering/skills/cratis-engineering-docs-authoring",
+            sourceRevision: source.sourceRevision,
+            sourcePath: source.sourcePath,
+            sourceContentDigest: source.contentDigest,
             evaluationSummarySha256: sha256(
                 readFileSync(evaluationSummaryPath),
             ),

--- a/tooling/generate-repository-inventory.mjs
+++ b/tooling/generate-repository-inventory.mjs
@@ -96,14 +96,17 @@ const admittedUntracked = gitPaths([
 const unexpectedUntracked = admittedUntracked.filter(
     (path) =>
         !(
+            /^\.github\/ISSUE_TEMPLATE\//.test(path) ||
             path === ".github/workflows/distribution-canary-rollback.yml" ||
             path === ".github/workflows/engineering-distribution-fixture.yml" ||
             path === ".github/workflows/distribution-generated-update.yml" ||
             path === ".github/workflows/distribution-npm-stage.yml" ||
             /^AI-REPOSITORY-REDESIGN-[A-Z0-9-]+\.md$/.test(path) ||
-            /^Documentation\/(?:capability-catalog-v2|phase-0-verification|public-product-architecture|skill-authoring-contract|skill-classification-audit|project-context-bootstrap|redesign-foundation-validation|source-evidence-contract)\.md$/.test(
+            path === "Documentation/.markdownlint.json" ||
+            /^Documentation\/(?:ai-distribution-and-subscriptions|capability-catalog-v2|phase-0-verification|public-product-architecture|skill-authoring-contract|skill-classification-audit|project-context-bootstrap|redesign-foundation-validation|source-evidence-contract)\.md$/.test(
                 path,
             ) ||
+            /^Documentation\/examples\/ai-subscriptions\//.test(path) ||
             /^Documentation\/evidence\/redesign-autonomous-execution-2026-08-20\//.test(
                 path,
             ) ||
@@ -617,6 +620,7 @@ const definitions = [
     {
         id: "legacy-documentation",
         sourcePathPatterns: [
+            "Documentation/.markdownlint.json",
             "Documentation/agents.md",
             "Documentation/architecture.md",
             "Documentation/index.md",
@@ -641,6 +645,8 @@ const definitions = [
         id: "redesign-decision-documents",
         sourcePathPatterns: [
             "AI-REPOSITORY-REDESIGN-*.md",
+            "Documentation/ai-distribution-and-subscriptions.md",
+            "Documentation/examples/ai-subscriptions/**",
             "Documentation/phase-0-verification.md",
             "Documentation/public-product-architecture.md",
             "Documentation/skill-classification-audit.md",

--- a/tooling/profile-subscription-validation.mjs
+++ b/tooling/profile-subscription-validation.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+    validateAgainstSchema,
+    validateSchemaVocabulary,
+} from "./catalog-validation.mjs";
+
+const defaultRepositoryRoot = resolve(
+    fileURLToPath(new URL("..", import.meta.url)),
+);
+
+function readJson(path, errors) {
+    try {
+        return JSON.parse(readFileSync(path, "utf8"));
+    } catch (error) {
+        errors.push(
+            `Unable to parse ${path}: ${error instanceof Error ? error.message : "unknown error"}`,
+        );
+        return null;
+    }
+}
+
+function duplicates(values) {
+    const seen = new Set();
+    return [
+        ...new Set(
+            values.filter((value) => seen.has(value) || !seen.add(value)),
+        ),
+    ];
+}
+
+export function validateProfileSubscriptions(
+    repositoryRoot = defaultRepositoryRoot,
+) {
+    const errors = [];
+    const profilePath = join(
+        repositoryRoot,
+        "distribution/profile-catalog.json",
+    );
+    const schemaPath = join(
+        repositoryRoot,
+        "distribution/profile-subscription.schema.json",
+    );
+    const profileCatalog = readJson(profilePath, errors);
+    const schema = readJson(schemaPath, errors);
+    if (!profileCatalog || !schema) return errors;
+    errors.push(
+        ...validateSchemaVocabulary(schema, "profile-subscription.schema.json"),
+    );
+    if (
+        profileCatalog.schemaVersion !== "1.0.0" ||
+        profileCatalog.state !== "DESIGNED_RELEASES_NOT_YET_PUBLISHED" ||
+        profileCatalog.versioning?.strategy !== "semver" ||
+        profileCatalog.versioning?.releaseTrain !== "atomic" ||
+        profileCatalog.versioning?.exactPinsRequired !== true ||
+        profileCatalog.versioning?.floatingVersionsAllowed !== false ||
+        profileCatalog.authority?.sharedBehaviorOwner !== "Cratis/AI" ||
+        profileCatalog.authority?.productFactOwner !==
+            "owning Cratis product repository" ||
+        profileCatalog.authority?.projectContextOwner !==
+            "consuming repository" ||
+        profileCatalog.authority?.directGeneratedEditsAllowed !== false ||
+        profileCatalog.authority?.automaticReverseSyncAllowed !== false
+    )
+        errors.push("Profile catalog authority or versioning contract changed");
+    const profiles = [
+        ...profileCatalog.publicProfiles,
+        ...profileCatalog.engineeringProfiles,
+    ];
+    const profileIds = profiles.map((profile) => profile.id);
+    const packageNames = profiles.map((profile) => profile.packageName);
+    if (duplicates(profileIds).length)
+        errors.push("Profile catalog contains duplicate profile ids");
+    if (duplicates(packageNames).length)
+        errors.push("Profile catalog contains duplicate package names");
+    const knownProfiles = new Set(profileIds);
+    for (const profile of profiles)
+        for (const dependency of profile.composes ?? [])
+            if (!knownProfiles.has(dependency))
+                errors.push(
+                    `${profile.id}: unknown composed profile ${dependency}`,
+                );
+    if (
+        profileCatalog.subscription?.projectFile !== ".cratis/ai.json" ||
+        profileCatalog.subscription?.projectOwned !== true ||
+        profileCatalog.subscription?.packageWritesProjectContext !== false ||
+        profileCatalog.subscription?.profileSelectionRequired !== true ||
+        profileCatalog.subscription?.exactVersionRequired !== true ||
+        profileCatalog.contributionFlow?.consumerRepositoriesPublishPackages !==
+            false ||
+        profileCatalog.contributionFlow
+            ?.consumerRepositoriesPushGeneratedBytes !== false
+    )
+        errors.push("Profile subscription or contribution boundary changed");
+
+    const examples = [
+        [
+            "Documentation/examples/ai-subscriptions/chronicle-framework.cratis-ai.json",
+            "cratis-engineering",
+        ],
+        [
+            "Documentation/examples/ai-subscriptions/cratis-application.cratis-ai.json",
+            "public",
+        ],
+    ];
+    const parsedExamples = new Map();
+    for (const [relativePath, expectedChannel] of examples) {
+        const example = readJson(join(repositoryRoot, relativePath), errors);
+        if (!example) continue;
+        parsedExamples.set(relativePath, example);
+        errors.push(
+            ...validateAgainstSchema(example, schema, schema, relativePath),
+        );
+        if (example.channel !== expectedChannel)
+            errors.push(`${relativePath}: unexpected channel`);
+        const allowedProfiles = new Set(
+            (expectedChannel === "public"
+                ? profileCatalog.publicProfiles
+                : profileCatalog.engineeringProfiles
+            ).map((profile) => profile.id),
+        );
+        for (const profile of example.profiles)
+            if (!allowedProfiles.has(profile))
+                errors.push(`${relativePath}: unknown profile ${profile}`);
+        const overlap = (example.skillAllowlist ?? []).filter((skill) =>
+            (example.skillDenylist ?? []).includes(skill),
+        );
+        if (overlap.length)
+            errors.push(
+                `${relativePath}: skill allowlist and denylist overlap`,
+            );
+    }
+    const piSettingsPath =
+        "Documentation/examples/ai-subscriptions/pi-settings.json";
+    const piSettings = readJson(join(repositoryRoot, piSettingsPath), errors);
+    const chronicleSubscription = parsedExamples.get(
+        "Documentation/examples/ai-subscriptions/chronicle-framework.cratis-ai.json",
+    );
+    if (
+        !piSettings ||
+        !chronicleSubscription ||
+        JSON.stringify(piSettings.packages) !==
+            JSON.stringify([
+                `npm:@cratis/ai-engineering-chronicle@${chronicleSubscription.version}`,
+            ]) ||
+        piSettings.enableSkillCommands !== true ||
+        Object.hasOwn(piSettings, "extensions")
+    )
+        errors.push("Pi profile settings example changed");
+    return [...new Set(errors)].sort();
+}
+
+function main() {
+    const errors = validateProfileSubscriptions();
+    if (errors.length) {
+        process.stderr.write(
+            `Profile subscription validation failed with ${errors.length} error(s):\n`,
+        );
+        for (const error of errors) process.stderr.write(`- ${error}\n`);
+        process.exitCode = 1;
+    } else {
+        process.stdout.write(
+            "Profile subscription validation passed: 16 profiles and 2 examples.\n",
+        );
+    }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/tooling/specs/catalog-v2-validation.spec.mjs
+++ b/tooling/specs/catalog-v2-validation.spec.mjs
@@ -212,7 +212,7 @@ test("first useful public skill is bound to immutable canonical source", () => {
     assert.equal(source.sourcePath, "skills/cratis-fundamentals-concept");
     assert.equal(
         source.sourceRevision,
-        "422ec8eebc198f9c25c28831a94623a3d4432fea",
+        "e9d161a70e25334bb468a33240bcf00f03f87522",
     );
     assert.deepEqual(source.bundledPaths, [
         "skills/cratis-fundamentals-concept/LICENSE",
@@ -220,7 +220,7 @@ test("first useful public skill is bound to immutable canonical source", () => {
     ]);
     assert(
         source.evidenceIds.includes(
-            "public-fundamentals-concept-source-422ec8e",
+            "public-fundamentals-concept-source-e9d161a",
         ),
     );
     assert.deepEqual(target.sourceSkillIds, ["add-concept"]);
@@ -694,10 +694,10 @@ test("unknown properties fail the closed catalog v2 schema", () => {
 
 test("unsupported JSON Schema vocabulary fails explicitly", () => {
     const unsupported = clone(schema);
-    unsupported.$defs.target.oneOf = [];
+    unsupported.$defs.target.allOf = [];
     assert(
         validateSchemaVocabulary(unsupported).some((error) =>
-            error.includes("unsupported JSON Schema keyword oneOf"),
+            error.includes("unsupported JSON Schema keyword allOf"),
         ),
     );
 });

--- a/tooling/specs/distribution-fixture.spec.mjs
+++ b/tooling/specs/distribution-fixture.spec.mjs
@@ -73,6 +73,12 @@ test("distribution requirements and artifact matrix stay authority bounded", () 
             "distribution/evidence/local-fixture-smoke-2026-08-22.json",
         ),
     );
+    const currentProfileEvidence = readJson(
+        join(
+            repositoryRoot,
+            "distribution/evidence/local-profile-fixture-smoke-2026-08-22.json",
+        ),
+    );
     const verified = requirements.requirements
         .filter((item) => item.status.startsWith("VERIFIED"))
         .map((item) => item.id);
@@ -124,6 +130,26 @@ test("distribution requirements and artifact matrix stay authority bounded", () 
             result.status.startsWith("PASS"),
         ),
     );
+    assert.equal(currentProfileEvidence.status, "PASS");
+    assert.equal(
+        currentProfileEvidence.sourceCommit,
+        "e9d161a70e25334bb468a33240bcf00f03f87522",
+    );
+    assert.equal(
+        currentProfileEvidence.sourceArtifactId,
+        "cratis-fundamentals-concept-preview",
+    );
+    assert.equal(
+        currentProfileEvidence.provenanceSourceRevision,
+        currentProfileEvidence.sourceCommit,
+    );
+    assert(
+        currentProfileEvidence.results.every(
+            (result) => result.status === "PASS",
+        ),
+    );
+    assert.equal(currentProfileEvidence.publicationEligible, false);
+    assert.equal(currentProfileEvidence.promotionEligible, false);
 });
 
 test("distribution fixture generation is deterministic across native adapters", () => {
@@ -159,6 +185,29 @@ test("distribution fixture generation is deterministic across native adapters", 
             "kiro",
             "pi",
         ]);
+    });
+});
+
+test("fixture provenance binds the authorized immutable public source", () => {
+    withTemporaryDirectory((root) => {
+        const stage = join(root, "stage");
+        generateDistributionFixture({ repositoryRoot, outputRoot: stage });
+        const provenance = readJson(join(stage, "provenance.json"));
+        assert.equal(
+            provenance.sourceArtifactId,
+            "cratis-fundamentals-concept-preview",
+        );
+        assert.equal(
+            provenance.sourceRevision,
+            "e9d161a70e25334bb468a33240bcf00f03f87522",
+        );
+        assert.equal(
+            provenance.sourcePath,
+            "skills/cratis-fundamentals-concept",
+        );
+        assert.match(provenance.sourceContentDigest, /^[0-9a-f]{64}$/);
+        assert.equal(provenance.publicationEligible, false);
+        assert.equal(provenance.promotionEligible, false);
     });
 });
 

--- a/tooling/specs/distribution-rollout.spec.mjs
+++ b/tooling/specs/distribution-rollout.spec.mjs
@@ -51,15 +51,34 @@ test("rollout policy keeps production promotion and retirement blocked", () => {
             "NO_PRODUCTION_ROLLBACK_EVIDENCE",
         ),
     );
+    const evidence = JSON.parse(
+        readFileSync(
+            join(
+                repositoryRoot,
+                "distribution/evidence/local-canary-rollback-2026-08-22.json",
+            ),
+            "utf8",
+        ),
+    );
+    assert.equal(
+        evidence.sourceCommit,
+        "e9d161a70e25334bb468a33240bcf00f03f87522",
+    );
+    assert.equal(
+        evidence.candidate.artifactId,
+        "cratis-fundamentals-concept-preview",
+    );
+    assert.match(evidence.candidate.manifestSha256, /^[0-9a-f]{64}$/);
+    assert.match(evidence.candidate.provenanceSha256, /^[0-9a-f]{64}$/);
 });
 
-test("candidate staging allows only the authorized sanitized fixture", () => {
+test("candidate staging allows only the authorized Fundamentals preview", () => {
     withTemporaryDirectory((root) => {
         const stage = join(root, "stage");
         const recordPath = join(root, "candidate.json");
         const record = stageDistributionCandidate({
             repositoryRoot,
-            artifactId: "sanitized-public-materializer-fixture",
+            artifactId: "cratis-fundamentals-concept-preview",
             outputRoot: stage,
             candidateRecordPath: recordPath,
         });

--- a/tooling/specs/engineering-distribution-fixture.spec.mjs
+++ b/tooling/specs/engineering-distribution-fixture.spec.mjs
@@ -95,6 +95,14 @@ test("engineering fixture evidence remains local and non-promoting", () => {
     );
     assert.equal(evidence.state, "ENGINEERING_FIXTURE_ONLY");
     assert.equal(evidence.targetId, "cratis-engineering-docs-authoring");
+    assert.equal(
+        evidence.sourceCommit,
+        "f58bcf7f5cc9fc0e11305ada3b5ecb6fa20953e9",
+    );
+    assert.equal(evidence.sourceCommit, evidence.sourceRevision);
+    assert.match(evidence.manifestSha256, /^[0-9a-f]{64}$/);
+    assert.match(evidence.provenanceSha256, /^[0-9a-f]{64}$/);
+    assert.match(evidence.sourceContentDigest, /^[0-9a-f]{64}$/);
     assert(
         evidence.results.every((result) => result.status.startsWith("PASS")),
     );
@@ -146,6 +154,16 @@ test("engineering fixture generation is deterministic and non-installable", () =
             validateEngineeringDistributionFixture(firstRoot),
             first,
         );
+        const provenance = readJson(join(firstRoot, "provenance.json"));
+        assert.equal(
+            provenance.sourceRevision,
+            "f58bcf7f5cc9fc0e11305ada3b5ecb6fa20953e9",
+        );
+        assert.equal(
+            provenance.sourcePath,
+            "engineering/skills/cratis-engineering-docs-authoring",
+        );
+        assert.match(provenance.sourceContentDigest, /^[0-9a-f]{64}$/);
     });
 });
 

--- a/tooling/specs/generated-distribution-repository.spec.mjs
+++ b/tooling/specs/generated-distribution-repository.spec.mjs
@@ -81,6 +81,32 @@ test("generated repository contract keeps remote authority and production blocke
         "ABSENT_PENDING_PR_RELEASE_BOT",
     );
     assert.equal(contract.productionMaterialization.enabled, false);
+    assert.equal(
+        contract.productionMaterialization.artifactTopology,
+        "one-profile-one-harness-root-asset",
+    );
+    assert.equal(
+        contract.productionMaterialization.profileCatalog,
+        "distribution/profile-catalog.json",
+    );
+    assert.equal(
+        contract.productionMaterialization.subscriptionFile,
+        ".cratis/ai.json",
+    );
+    assert.equal(
+        contract.productionMaterialization.requiresVerifiedSourceContracts,
+        true,
+    );
+    assert.deepEqual(
+        contract.productionMaterialization.requiredLifecycleEvidence,
+        [
+            "install",
+            "update",
+            "rollback",
+            "uninstall",
+            "project context preservation",
+        ],
+    );
     assert.equal(contract.publicationEligible, false);
     assert.equal(contract.promotionEligible, false);
     assert.equal(contract.legacyRetirementEligible, false);

--- a/tooling/specs/profile-subscription.spec.mjs
+++ b/tooling/specs/profile-subscription.spec.mjs
@@ -1,0 +1,146 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert from "node:assert/strict";
+import {
+    cpSync,
+    mkdtempSync,
+    mkdirSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { validateProfileSubscriptions } from "../profile-subscription-validation.mjs";
+
+const repositoryRoot = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    "../..",
+);
+const profileFiles = [
+    "distribution/profile-catalog.json",
+    "distribution/profile-subscription.schema.json",
+    "Documentation/examples/ai-subscriptions/chronicle-framework.cratis-ai.json",
+    "Documentation/examples/ai-subscriptions/cratis-application.cratis-ai.json",
+    "Documentation/examples/ai-subscriptions/pi-settings.json",
+];
+
+function withFixture(callback) {
+    const root = mkdtempSync(join(tmpdir(), "cratis-ai-profiles-"));
+    try {
+        for (const path of profileFiles) {
+            const destination = join(root, path);
+            mkdirSync(dirname(destination), { recursive: true });
+            cpSync(join(repositoryRoot, path), destination);
+        }
+        return callback(root);
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+}
+
+function readJson(path) {
+    return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function writeJson(path, value) {
+    writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+test("profile catalog and project subscriptions pass", () => {
+    assert.deepEqual(validateProfileSubscriptions(repositoryRoot), []);
+    const catalog = readJson(
+        join(repositoryRoot, "distribution/profile-catalog.json"),
+    );
+    assert.equal(catalog.publicProfiles.length, 5);
+    assert.equal(catalog.engineeringProfiles.length, 11);
+    assert.equal(catalog.versioning.exactPinsRequired, true);
+    assert.equal(catalog.authority.automaticReverseSyncAllowed, false);
+});
+
+test("profile subscription rejects floating versions and unknown profiles", () => {
+    withFixture((root) => {
+        const path = join(
+            root,
+            "Documentation/examples/ai-subscriptions/chronicle-framework.cratis-ai.json",
+        );
+        const example = readJson(path);
+        example.version = "latest";
+        example.profiles = ["engineering-framework-unknown"];
+        writeJson(path, example);
+        const errors = validateProfileSubscriptions(root);
+        assert(errors.some((error) => error.includes("version")));
+        assert(
+            errors.some((error) =>
+                error.includes("unknown profile engineering-framework-unknown"),
+            ),
+        );
+    });
+});
+
+test("subscription schema enforces exact SemVer pins", () => {
+    withFixture(root => {
+        const path = join(
+            root,
+            "Documentation/examples/ai-subscriptions/cratis-application.cratis-ai.json",
+        );
+        const example = readJson(path);
+        example.version = "01.0.0";
+        writeJson(path, example);
+        assert(
+            validateProfileSubscriptions(root).some(error =>
+                error.includes("version"),
+            ),
+        );
+        example.version = "1.2.3-preview.1+build.7";
+        writeJson(path, example);
+        assert.deepEqual(validateProfileSubscriptions(root), []);
+    });
+});
+
+test("subscription schema rejects cross-audience profiles", () => {
+    withFixture(root => {
+        const path = join(
+            root,
+            "Documentation/examples/ai-subscriptions/cratis-application.cratis-ai.json",
+        );
+        const example = readJson(path);
+        example.profiles = ["engineering-framework-chronicle"];
+        writeJson(path, example);
+        const errors = validateProfileSubscriptions(root);
+        assert(
+            errors.some(error =>
+                error.includes("expected exactly one matching oneOf branch"),
+            ),
+        );
+        assert(
+            errors.some(error =>
+                error.includes("unknown profile engineering-framework-chronicle"),
+            ),
+        );
+    });
+});
+
+test("profile catalog rejects unknown composition and authority drift", () => {
+    withFixture((root) => {
+        const path = join(root, "distribution/profile-catalog.json");
+        const catalog = readJson(path);
+        catalog.authority.automaticReverseSyncAllowed = true;
+        catalog.engineeringProfiles[0].composes = ["engineering-missing"];
+        writeJson(path, catalog);
+        const errors = validateProfileSubscriptions(root);
+        assert(
+            errors.includes(
+                "Profile catalog authority or versioning contract changed",
+            ),
+        );
+        assert(
+            errors.includes(
+                "engineering-base: unknown composed profile engineering-missing",
+            ),
+        );
+    });
+});

--- a/tooling/specs/public-fundamentals-concept.spec.mjs
+++ b/tooling/specs/public-fundamentals-concept.spec.mjs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const skill = readFileSync(
+    "skills/cratis-fundamentals-concept/SKILL.md",
+    "utf8",
+);
+
+test("Fundamentals concept skill is passive canonical Agent Skills content", () => {
+    assert.match(
+        skill,
+        /^---\nname: cratis-fundamentals-concept\ndescription: .+\nlicense: MIT\n---/,
+    );
+    assert.equal(skill.includes("scripts/"), false);
+    assert.equal(skill.includes("allowed-tools:"), false);
+    assert.equal(skill.includes(".ai/"), false);
+    assert.equal(skill.includes("../"), false);
+});
+
+test("Guid and non-Guid event-source identity templates stay type-correct", () => {
+    const guidSection = skill
+        .split("## Guid-backed event-source identity")[1]
+        .split("## Non-Guid event-source identity")[0];
+    const nonGuidSection = skill
+        .split("## Non-Guid event-source identity")[1]
+        .split("## Sentinel values")[0];
+    assert(guidSection.includes("EventSourceId<Guid>"));
+    assert(guidSection.includes("Guid.NewGuid()"));
+    const nonGuidTemplate = /```csharp\n([\s\S]*?)```/.exec(
+        nonGuidSection,
+    )?.[1];
+    assert(nonGuidTemplate?.includes("EventSourceId<<UnderlyingType>>"));
+    assert.equal(nonGuidTemplate?.includes("Guid.NewGuid()"), false);
+    assert(nonGuidSection.includes("domain has a valid way to create"));
+});
+
+test("concept guidance preserves value identity placement and verification boundaries", () => {
+    for (const required of [
+        "ConceptAs<T>",
+        "EventSourceId<T>",
+        "Do not use `ConceptAs<Guid>` for an event-source identity",
+        "Do not introduce a top-level `Features/` wrapper",
+        "`dotnet build` passes",
+    ])
+        assert(skill.includes(required), required);
+});

--- a/tooling/specs/workflow-safety.spec.mjs
+++ b/tooling/specs/workflow-safety.spec.mjs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const verification = readFileSync(
+    ".github/workflows/verify-ai-corpus.yml",
+    "utf8",
+);
+
+test("verification workflow covers every release-relevant source", () => {
+    for (const path of [
+        ".ai/**",
+        ".agents/**",
+        ".github/ISSUE_TEMPLATE/**",
+        ".github/workflows/**",
+        "AGENTS.md",
+        "README.md",
+        "Documentation/**",
+        "catalog/**",
+        "distribution/**",
+        "engineering/**",
+        "evals/**",
+        "evidence/**",
+        "pilots/**",
+        "skills/**",
+        "tooling/**",
+    ]) {
+        const occurrences = verification.split(`- "${path}"`).length - 1;
+        assert.equal(occurrences, 2, path);
+    }
+});
+
+test("legacy propagation workflows are inert and inherit no secrets", () => {
+    for (const path of [
+        ".github/workflows/propagate-copilot-instructions.yml",
+        ".github/workflows/sync-copilot-instructions.yml",
+    ]) {
+        const workflow = readFileSync(path, "utf8");
+        assert(workflow.includes("Retired -"));
+        assert(workflow.includes("workflow_dispatch"));
+        assert.equal(workflow.includes("uses: Cratis/Workflows/"), false);
+        assert.equal(workflow.includes("secrets: inherit"), false);
+        assert.equal(workflow.includes("push:"), false);
+    }
+});

--- a/tooling/stage-distribution-candidate.mjs
+++ b/tooling/stage-distribution-candidate.mjs
@@ -14,7 +14,7 @@ import {
 const defaultRepositoryRoot = resolve(
     fileURLToPath(new URL("..", import.meta.url)),
 );
-const fixtureArtifactId = "sanitized-public-materializer-fixture";
+const fixtureArtifactId = "cratis-fundamentals-concept-preview";
 
 function sha256(content) {
     return createHash("sha256").update(content).digest("hex");

--- a/tooling/validate-catalogs.mjs
+++ b/tooling/validate-catalogs.mjs
@@ -11,6 +11,7 @@ import { validateDistributionConfiguration } from "./generate-distribution-fixtu
 import { validateEngineeringDocsAuthoring } from "./engineering-docs-authoring-validation.mjs";
 import { validateEngineeringDistributionConfiguration } from "./generate-engineering-distribution-fixture.mjs";
 import { validateEngineeringDocsCompanions } from "./engineering-docs-companions-validation.mjs";
+import { validateProfileSubscriptions } from "./profile-subscription-validation.mjs";
 
 const errors = [
     ...validateCatalogs(),
@@ -22,6 +23,7 @@ const errors = [
     ...validateEngineeringDocsAuthoring(),
     ...validateEngineeringDistributionConfiguration(),
     ...validateEngineeringDocsCompanions(),
+    ...validateProfileSubscriptions(),
 ];
 if (errors.length > 0) {
     process.stderr.write(
@@ -31,6 +33,6 @@ if (errors.length > 0) {
     process.exitCode = 1;
 } else {
     process.stdout.write(
-        "Catalog validation passed: 3 legacy catalogs, 13 v2 catalogs, and 4 schemas are valid.\n",
+        "Catalog validation passed: legacy, v2, source-evidence, distribution-profile, and evaluation contracts are valid.\n",
     );
 }


### PR DESCRIPTION
# Summary

Establishes the long-term Cratis AI source-of-truth, profile subscription, Pi, versioning, update, rollback and upstream-contribution architecture, while fixing the concrete release and corpus defects found by the fresh readiness review.

## Architecture

- Add five public and eleven product/repository-specific Cratis engineering profiles (#165)
- Add project-owned `.cratis/ai.json` exact SemVer subscriptions and validation (#165)
- Document Pi global/project packages, trust, exact pins, filters, updates and rollback (#165)
- Define one canonical upstream contribution point and one-way generated delivery (#165)
- Add a shared-improvement issue form and retire broad propagation/reverse sync (#165)

## Hardening

- Correct Guid versus non-Guid EventSourceId templates (#148)
- Align preview artifact authorization, rollout, bytes and immutable provenance (#148)
- Bind engineering fixture provenance to immutable source bytes (#154)
- Cover all release-relevant paths in CI (#126)
- Fix stale planner Features paths, AutoMap guidance and instruction links (#126)
- Repair markdown verification and rewrite README/docs around the actual architecture (#126)

## Current gates

No target or profile becomes approved, runtime-enabled, published or promoted. Production materialization, owner approval, credentials, per-harness release assets and a real public consumer canary remain separate explicit gates.
