### PR TITLE
Add approval-driven profile materialization

### DIFF
--- a/.github/workflows/distribution-approved-profile-release.yml
+++ b/.github/workflows/distribution-approved-profile-release.yml
@@ -1,0 +1,123 @@
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+name: Prepare Approved Profile Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: Approved profile release operation
+        required: true
+        default: verify
+        type: choice
+        options:
+          - verify
+          - create-generated-pr
+      profile:
+        description: Approved profile id
+        required: true
+        type: string
+      version:
+        description: Exact SemVer release candidate version
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: approved-profile-${{ inputs.profile }}-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out complete immutable history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      - name: Validate catalogs and approved release plan
+        env:
+          PROFILE: ${{ inputs.profile }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          node tooling/validate-catalogs.mjs
+          node tooling/generate-approved-profile-release.mjs \
+            "$RUNNER_TEMP/approved-profile" "$PROFILE" "$VERSION"
+          test "$(node -p "require('$RUNNER_TEMP/approved-profile/release-manifest.json').publicationEligible")" = "false"
+          test "$(node -p "require('$RUNNER_TEMP/approved-profile/release-manifest.json').promotionEligible")" = "false"
+          node --test tooling/specs/approved-profile-release.spec.mjs
+
+  create-generated-pr:
+    if: inputs.operation == 'create-generated-pr'
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: distribution-canary
+    steps:
+      - name: Check out complete immutable history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      - name: Create repository-scoped GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AI_DISTRIBUTION_APP_ID }}
+          private-key: ${{ secrets.AI_DISTRIBUTION_APP_PRIVATE_KEY }}
+          owner: Cratis
+          repositories: AI.Distribution
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Regenerate and open protected distribution pull request
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PROFILE: ${{ inputs.profile }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          node tooling/generate-approved-profile-release.mjs \
+            "$RUNNER_TEMP/approved-profile" "$PROFILE" "$VERSION"
+          gh auth setup-git
+          gh repo clone Cratis/AI.Distribution "$RUNNER_TEMP/AI.Distribution"
+          version_slug="${VERSION//./-}"
+          branch="generated/${PROFILE}-${version_slug}-${GITHUB_SHA:0:12}"
+          destination="$RUNNER_TEMP/AI.Distribution/profiles/$PROFILE/$VERSION"
+          git -C "$RUNNER_TEMP/AI.Distribution" checkout -b "$branch"
+          test ! -e "$destination"
+          mkdir -p "$destination"
+          rsync -a --delete --exclude=.git \
+            "$RUNNER_TEMP/approved-profile/" "$destination/"
+          git -C "$RUNNER_TEMP/AI.Distribution" config \
+            user.name "cratis-distribution-release-bot"
+          git -C "$RUNNER_TEMP/AI.Distribution" config \
+            user.email "release-bot@invalid.example"
+          git -C "$RUNNER_TEMP/AI.Distribution" add -A
+          git -C "$RUNNER_TEMP/AI.Distribution" commit \
+            --message "Generate $PROFILE release candidate $VERSION"
+          git -C "$RUNNER_TEMP/AI.Distribution" push origin "$branch"
+          gh pr create \
+            --repo Cratis/AI.Distribution \
+            --base main \
+            --head "$branch" \
+            --title "Generate $PROFILE release candidate $VERSION" \
+            --body "Generated from Cratis/AI@$GITHUB_SHA. Publication and promotion remain separate protected gates."

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
@@ -1899,3 +1899,35 @@ Immediate review findings corrected in this unit include:
 Production materialization, per-harness root release assets, product-owner
 approval, bot credentials, npm authority, and a real public consumer canary
 remain explicit blockers. No profile is represented as published.
+
+## 50. Approval-driven profile materialization — 2026-08-23
+
+The production release path now has a concrete fail-closed implementation:
+
+- `tooling/generate-approved-profile-release.mjs` resolves one profile and exact
+  SemVer against approved/runtime targets, accepted security, complete passing
+  evaluations, verified distribution source contracts, active authoring
+  contracts, source publication approval, and an enabled planned artifact;
+- immutable skill bytes are read with `git show` from each source revision and
+  recomputed against the catalog content digest;
+- `tooling/passive-profile-adapters.mjs` emits one install root per profile and
+  harness for Agent Skills, Claude, Codex, Copilot, Cursor, Gemini, Grok,
+  DeepSeek Harness, Kiro, Junie, and Pi;
+- profile adapter inputs are path/content/frontmatter validated, passive-only,
+  byte-parity checked, deterministically inventoried, and produce a non-private
+  Pi package with no scripts or dependencies;
+- release candidate provenance records AI commit, profile, artifact, target
+  approvals, immutable source revisions, and content digests; checksums and a
+  release manifest bind every generated file;
+- `.github/workflows/distribution-approved-profile-release.yml` verifies the
+  plan and can open only a protected, bot-authored `AI.Distribution` pull
+  request using repository-scoped App credentials; publication and promotion
+  remain separate;
+- current catalogs correctly reject generation because no profile/target/source
+  contract/artifact is approved and runtime-enabled.
+
+The generated repository stores immutable profile/version/harness roots. A
+later protected publication unit archives or publishes each harness root and
+runs exact remote lifecycle commands. Production code now exists; organizational
+approval, credentials, release-asset publication, and the real public canary
+remain blockers.

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
@@ -619,7 +619,9 @@ Evidence and exact next actions are in
   AutoMap, path, README, and documentation guidance.
 - [x] Reconcile the public preview artifact identity and bind fixture provenance
   to immutable source revision/digest.
-- [ ] Implement approval-driven production materialization and per-profile,
-  per-harness root release assets after AI#148 and profile-owner issue #165.
+- [x] Implement fail-closed approval-driven production materialization and
+  per-profile, per-harness install roots; current catalogs reject generation.
+- [ ] Enable one approved profile after AI#148 and profile-owner issue #165,
+  then package and host immutable per-harness release assets.
 - [ ] Run the first real public consumer lifecycle canary and publish only a
   narrowly labeled Fundamentals/Chronicle C# preview.

--- a/Documentation/ai-distribution-and-subscriptions.md
+++ b/Documentation/ai-distribution-and-subscriptions.md
@@ -5,9 +5,11 @@ profiles, immutable releases, and reviewed downstream updates. It does not use
 folder propagation or automatic two-way synchronization.
 
 > **Current availability:** the architecture and fixture generation exist, but
-> no supported profile package has been published yet. Commands containing
-> `1.0.0` below show the intended released workflow; do not run them until that
-> version exists in the selected channel.
+> no supported profile package has been published yet. The approval-driven
+> materializer exists but fails closed while profiles, targets, source contracts,
+> and release artifacts remain unapproved. Commands containing `1.0.0` below
+> show the intended released workflow; do not run them until that version exists
+> in the selected channel.
 
 ## Authority model
 
@@ -242,6 +244,38 @@ The same approved skill bytes are wrapped idiomatically for each host:
 Release documentation distinguishes **generated**, **statically validated**, and
 **host-tested and supported**. A generated wrapper is not automatically a
 public marketplace listing.
+
+### Released host examples
+
+Each release publishes a separate root for the selected profile and host. After
+reviewing and extracting the immutable host asset, native commands operate on
+that root. Representative examples are:
+
+```text
+# Claude Code interactive commands
+/plugin marketplace add <extracted-claude-root>
+/plugin install engineering-framework-chronicle@cratis
+
+# Codex
+codex plugin marketplace add <extracted-codex-root>
+
+# GitHub Copilot CLI
+copilot plugin marketplace add <extracted-copilot-root>
+copilot plugin install engineering-framework-chronicle@cratis
+
+# Gemini CLI local verification before remote publication
+gemini extensions link <extracted-gemini-root>
+
+# Grok Build project skills
+cp -R <extracted-grok-root>/.grok/skills .grok/
+
+# DeepSeek Harness project skills
+cp -R <extracted-deepseek-root>/.dsh/skills .dsh/
+```
+
+The final release page replaces placeholders with immutable URLs, checksums,
+tested host versions, update commands, and uninstall commands. Do not point a
+host at the multi-profile generated repository root.
 
 ## Versioning and release train
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ tooling.
 The first narrow public preview still requires:
 
 - owner approval and exact product authority for the Fundamentals concept skill;
-- approval-driven production materialization with immutable provenance;
+- enabling and exercising the approval-driven production materializer after target approval;
 - scoped GitHub App credentials for generated pull requests;
 - one real consumer install/update/rollback/uninstall canary;
 - an immutable release channel and published installation instructions.

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "ae8926bd91b01a1ac6e5d4dd1f160d240aa6ed7b9c6d5e5db8e307e453fe0690",
+  "indexDigest": "ef4147c5223eeef8407d8f3758a4643a49c1c1793dd92f73327016a1e7ea41eb",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -2071,7 +2071,12 @@
       "status": "added"
     }
   ],
-  "admittedUntracked": [],
+  "admittedUntracked": [
+    ".github/workflows/distribution-approved-profile-release.yml",
+    "tooling/generate-approved-profile-release.mjs",
+    "tooling/passive-profile-adapters.mjs",
+    "tooling/specs/approved-profile-release.spec.mjs"
+  ],
   "excludedRuntimePrefixes": [
     ".pi/delegate/",
     ".pi/fusion/",
@@ -2621,6 +2626,7 @@
       "excludePathPatterns": [],
       "id": "repository-validation-workflow",
       "sourcePathPatterns": [
+        ".github/workflows/distribution-approved-profile-release.yml",
         ".github/workflows/distribution-canary-rollback.yml",
         ".github/workflows/engineering-distribution-fixture.yml",
         ".github/workflows/distribution-generated-update.yml",
@@ -2643,8 +2649,8 @@
         "repo-main-b795d53",
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 5,
-      "expectedPathsDigest": "5c7d3ee554ebb50633a8139a841a107e6cfc027018c5fa10b4d2ef056d6f35bf"
+      "expectedPathCount": 6,
+      "expectedPathsDigest": "6e7604e8543c6f011bf0852a2b81f6d416a83ce2fcab42dbc47d4aa324d184ae"
     },
     {
       "excludePathPatterns": [],
@@ -3381,8 +3387,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 31,
-      "expectedPathsDigest": "16105f414ef18bf88bebffaaab9205aa2c08aa1ed70674a0ea13351aca956783"
+      "expectedPathCount": 33,
+      "expectedPathsDigest": "ade37b2c91e8e2421f43e484961a158e4c5d2a109a57e9865e7f66010e2952de"
     },
     {
       "excludePathPatterns": [],
@@ -3405,8 +3411,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 25,
-      "expectedPathsDigest": "136d0ecb86b88dc900ea5b606b1f428f336b14f8540bdc99c9de67276c0f32dd"
+      "expectedPathCount": 26,
+      "expectedPathsDigest": "f46889a4a04eaadb9235545a1402d44de3127378458e0a864e929bde8d426a7d"
     },
     {
       "excludePathPatterns": [],

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "ef4147c5223eeef8407d8f3758a4643a49c1c1793dd92f73327016a1e7ea41eb",
+  "indexDigest": "08aea5cb51746b9c1495e4ff3942185e388b51863c39e1ddb44998f1b5c9f03f",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -36,6 +36,10 @@
     },
     {
       "path": ".github/ISSUE_TEMPLATE/shared-ai-improvement.yml",
+      "status": "added"
+    },
+    {
+      "path": ".github/workflows/distribution-approved-profile-release.yml",
       "status": "added"
     },
     {
@@ -1883,6 +1887,10 @@
       "status": "added"
     },
     {
+      "path": "tooling/generate-approved-profile-release.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/generate-catalog-v2.mjs",
       "status": "added"
     },
@@ -1923,6 +1931,10 @@
       "status": "added"
     },
     {
+      "path": "tooling/passive-profile-adapters.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/profile-subscription-validation.mjs",
       "status": "added"
     },
@@ -1956,6 +1968,10 @@
     },
     {
       "path": "tooling/source-evidence-loader.mjs",
+      "status": "added"
+    },
+    {
+      "path": "tooling/specs/approved-profile-release.spec.mjs",
       "status": "added"
     },
     {
@@ -2071,12 +2087,7 @@
       "status": "added"
     }
   ],
-  "admittedUntracked": [
-    ".github/workflows/distribution-approved-profile-release.yml",
-    "tooling/generate-approved-profile-release.mjs",
-    "tooling/passive-profile-adapters.mjs",
-    "tooling/specs/approved-profile-release.spec.mjs"
-  ],
+  "admittedUntracked": [],
   "excludedRuntimePrefixes": [
     ".pi/delegate/",
     ".pi/fusion/",

--- a/tooling/catalog-validation.mjs
+++ b/tooling/catalog-validation.mjs
@@ -188,9 +188,9 @@ export function validateAgainstSchema(
 
     if (schema.oneOf) {
         const matchingBranches = schema.oneOf.filter(
-            branch =>
-                validateAgainstSchema(value, branch, rootSchema, path).length ===
-                0,
+            (branch) =>
+                validateAgainstSchema(value, branch, rootSchema, path)
+                    .length === 0,
         );
         if (matchingBranches.length !== 1)
             errors.push(`${path}: expected exactly one matching oneOf branch`);

--- a/tooling/generate-approved-profile-release.mjs
+++ b/tooling/generate-approved-profile-release.mjs
@@ -1,0 +1,416 @@
+#!/usr/bin/env node
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+    existsSync,
+    readFileSync,
+    readdirSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+    generatePassiveProfileAdapters,
+    readSkillFrontmatter,
+} from "./passive-profile-adapters.mjs";
+
+const defaultRepositoryRoot = resolve(
+    fileURLToPath(new URL("..", import.meta.url)),
+);
+
+function sha256(content) {
+    return createHash("sha256").update(content).digest("hex");
+}
+
+function readJson(path) {
+    try {
+        return JSON.parse(readFileSync(path, "utf8"));
+    } catch (error) {
+        throw new Error(`Unable to parse release input: ${path}`, {
+            cause: error,
+        });
+    }
+}
+
+function writeJson(path, value) {
+    writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, { flag: "wx" });
+}
+
+function walkFiles(root, current = root) {
+    return readdirSync(current, { withFileTypes: true }).flatMap((entry) => {
+        const path = join(current, entry.name);
+        if (entry.isDirectory()) return walkFiles(root, path);
+        if (!entry.isFile())
+            throw new Error(
+                `Approved release contains a special file: ${path}`,
+            );
+        return [relative(root, path).replaceAll("\\", "/")];
+    });
+}
+
+function exactSemVer(version) {
+    return /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(
+        version,
+    );
+}
+
+export function buildApprovedProfileReleasePlan({
+    profileId,
+    version,
+    profileCatalog,
+    targets,
+    sources,
+    sourceContracts,
+    authoringContracts,
+    artifacts,
+}) {
+    const blockers = [];
+    if (!exactSemVer(version)) blockers.push("VERSION_NOT_EXACT_SEMVER");
+    const publicProfile = profileCatalog.publicProfiles.find(
+        (profile) => profile.id === profileId,
+    );
+    const engineeringProfile = profileCatalog.engineeringProfiles.find(
+        (profile) => profile.id === profileId,
+    );
+    const profile = publicProfile ?? engineeringProfile;
+    if (!profile) blockers.push("UNKNOWN_PROFILE");
+    if (profile && profile.state !== "approved")
+        blockers.push("PROFILE_NOT_APPROVED");
+    const targetIds = profile?.availableTargets ?? [];
+    if (targetIds.length === 0) blockers.push("PROFILE_HAS_NO_TARGETS");
+    const selectedTargets = targetIds
+        .map((id) => targets.find((target) => target.id === id))
+        .filter(Boolean);
+    if (selectedTargets.length !== targetIds.length)
+        blockers.push("PROFILE_TARGET_MISSING");
+    const audience = publicProfile ? "public" : "cratis-engineering";
+    const sourceById = new Map(sources.map((source) => [source.id, source]));
+    const sourceContractById = new Map(
+        sourceContracts.map((contract) => [contract.id, contract]),
+    );
+    const authoringContractById = new Map(
+        authoringContracts.map((contract) => [contract.id, contract]),
+    );
+    const selectedSources = [];
+    for (const target of selectedTargets) {
+        if (target.audience !== audience)
+            blockers.push(`${target.id}:TARGET_AUDIENCE_MISMATCH`);
+        if (
+            target.capabilityKind === "unclassified" ||
+            target.invocation === "unclassified" ||
+            target.trust?.assessmentState !== "assessed" ||
+            target.dependencyClassificationState !== "classified" ||
+            target.sourceContractState !== "classified" ||
+            target.authoringContractState !== "classified" ||
+            [
+                target.architectures,
+                target.personas,
+                target.surfaces,
+                target.repositoryProfiles,
+            ].some((dimension) => dimension?.state === "unclassified")
+        )
+            blockers.push(`${target.id}:TARGET_CLASSIFICATION_INCOMPLETE`);
+        if (
+            target.approval?.state !== "approved" ||
+            target.includeInRuntime !== true ||
+            target.lifecycle !== "approved"
+        )
+            blockers.push(`${target.id}:TARGET_NOT_RUNTIME_APPROVED`);
+        if (
+            !target.approval?.reviewer ||
+            !target.approval?.approvedOn ||
+            !target.approval?.sourceRevision ||
+            !target.approval?.contentDigest ||
+            (target.approval?.evidenceIds?.length ?? 0) === 0
+        )
+            blockers.push(`${target.id}:APPROVAL_EVIDENCE_INCOMPLETE`);
+        if (
+            target.security?.disposition !== "accepted" ||
+            target.security.evidenceIds.length === 0
+        )
+            blockers.push(`${target.id}:SECURITY_NOT_ACCEPTED`);
+        const evaluationEntries = Object.entries(target.evaluations ?? {});
+        if (
+            JSON.stringify(evaluationEntries.map(([name]) => name).sort()) !==
+            JSON.stringify(
+                [
+                    "behavior",
+                    "collision",
+                    "negativeTrigger",
+                    "positiveTrigger",
+                ].sort(),
+            )
+        )
+            blockers.push(`${target.id}:EVALUATION_SET_INCOMPLETE`);
+        for (const [, evaluation] of evaluationEntries)
+            if (
+                evaluation.status !== "passing" ||
+                evaluation.evidenceIds.length === 0
+            )
+                blockers.push(`${target.id}:EVALUATION_NOT_PASSING`);
+        if ((target.sourceContractIds?.length ?? 0) === 0)
+            blockers.push(`${target.id}:SOURCE_CONTRACTS_MISSING`);
+        for (const id of target.sourceContractIds ?? []) {
+            const contract = sourceContractById.get(id);
+            if (
+                !contract ||
+                contract.verificationState !== "verified" ||
+                contract.distributionInputAllowed !== true
+            )
+                blockers.push(`${target.id}:SOURCE_CONTRACT_NOT_VERIFIED`);
+        }
+        if (
+            (target.authoringContractIds?.length ?? 0) === 0 ||
+            !target.authoringContractIds.includes("cratis-skill-clean-room-v1")
+        )
+            blockers.push(`${target.id}:AUTHORING_CONTRACTS_MISSING`);
+        for (const id of target.authoringContractIds ?? []) {
+            const contract = authoringContractById.get(id);
+            if (!contract || contract.state !== "active")
+                blockers.push(`${target.id}:AUTHORING_CONTRACT_NOT_ACTIVE`);
+        }
+        if (target.sourceSkillIds.length !== 1) {
+            blockers.push(`${target.id}:COMPOSED_SOURCE_NOT_SUPPORTED`);
+            continue;
+        }
+        const source = sourceById.get(target.sourceSkillIds[0]);
+        if (
+            !source ||
+            !/^[0-9a-f]{40}$/.test(source.sourceRevision) ||
+            !/^[0-9a-f]{64}$/.test(source.contentDigest)
+        ) {
+            blockers.push(`${target.id}:SOURCE_PROVENANCE_INVALID`);
+            continue;
+        }
+        if (source.audience !== audience)
+            blockers.push(`${target.id}:SOURCE_AUDIENCE_MISMATCH`);
+        if (
+            target.approval.sourceRevision !== source.sourceRevision ||
+            target.approval.contentDigest !== source.contentDigest
+        )
+            blockers.push(`${target.id}:APPROVAL_SOURCE_BINDING_MISMATCH`);
+        selectedSources.push({ target, source });
+    }
+    const artifactId =
+        audience === "public"
+            ? "planned-passive-public-release"
+            : "planned-passive-engineering-release";
+    const artifact = artifacts.find((candidate) => candidate.id === artifactId);
+    if (
+        !artifact ||
+        artifact.materializationAllowed !== true ||
+        artifact.runtimeEligible !== true ||
+        artifact.requiresApprovedTargets !== true
+    )
+        blockers.push("ARTIFACT_NOT_RUNTIME_ENABLED");
+    if (
+        artifact &&
+        targetIds.some(
+            (targetId) =>
+                !artifact.componentInventory.skills.includes(targetId),
+        )
+    )
+        blockers.push("PROFILE_TARGET_NOT_IN_ARTIFACT");
+    return {
+        schemaVersion: "1.0.0",
+        state:
+            blockers.length === 0 ? "READY_FOR_BOT_MATERIALIZATION" : "BLOCKED",
+        profileId,
+        packageName: profile?.packageName ?? null,
+        audience,
+        version,
+        artifactId,
+        targetIds,
+        selectedSources,
+        blockers: [...new Set(blockers)].sort(),
+        publicationEligible: false,
+        promotionEligible: false,
+    };
+}
+
+function readRepositoryInputs(repositoryRoot) {
+    return {
+        profileCatalog: readJson(
+            join(repositoryRoot, "distribution/profile-catalog.json"),
+        ),
+        targets: readJson(join(repositoryRoot, "catalog/v2/targets.json"))
+            .targets,
+        sources: readJson(join(repositoryRoot, "catalog/v2/sources.json"))
+            .sources,
+        sourceContracts: readJson(
+            join(repositoryRoot, "catalog/v2/source-contracts.json"),
+        ).contracts,
+        authoringContracts: readJson(
+            join(repositoryRoot, "catalog/v2/authoring-contracts.json"),
+        ).contracts,
+        artifacts: readJson(join(repositoryRoot, "catalog/v2/artifacts.json"))
+            .artifacts,
+    };
+}
+
+function immutableSkill(repositoryRoot, target, source) {
+    const prefix = `${source.sourcePath}/`;
+    const files = source.bundledPaths.map((path) => {
+        if (!path.startsWith(prefix))
+            throw new Error(`${source.id}: bundled path escaped source root`);
+        const relativePath = path.slice(prefix.length);
+        const content = execFileSync(
+            "git",
+            ["show", `${source.sourceRevision}:${path}`],
+            { cwd: repositoryRoot },
+        );
+        return { path: relativePath, content };
+    });
+    const digest = createHash("sha256");
+    for (const [index, path] of source.bundledPaths.entries()) {
+        digest.update(path);
+        digest.update("\0");
+        digest.update(files[index].content);
+        digest.update("\0");
+    }
+    if (digest.digest("hex") !== source.contentDigest)
+        throw new Error(`${source.id}: immutable source digest mismatch`);
+    const skillFile = files.find((file) => file.path === "SKILL.md");
+    if (!skillFile)
+        throw new Error(`${source.id}: immutable source has no SKILL.md`);
+    readSkillFrontmatter(skillFile.content, target.id);
+    return { name: target.id, files };
+}
+
+export function generateApprovedProfileRelease({
+    repositoryRoot = defaultRepositoryRoot,
+    outputRoot,
+    profileId,
+    version,
+} = {}) {
+    if (!outputRoot || !profileId || !version)
+        throw new Error("outputRoot, profileId, and version are required");
+    const inputs = readRepositoryInputs(repositoryRoot);
+    const plan = buildApprovedProfileReleasePlan({
+        profileId,
+        version,
+        ...inputs,
+    });
+    if (plan.state !== "READY_FOR_BOT_MATERIALIZATION")
+        throw new Error(
+            `Approved profile release is blocked: ${plan.blockers.join(", ")}`,
+        );
+    const root = resolve(outputRoot);
+    if (existsSync(root))
+        throw new Error(`Approved release output must not exist: ${root}`);
+    const skills = plan.selectedSources.map(({ target, source }) =>
+        immutableSkill(repositoryRoot, target, source),
+    );
+    try {
+        const adapterManifest = generatePassiveProfileAdapters({
+            outputRoot: root,
+            version,
+            profileId,
+            packageName: plan.packageName,
+            description: `Cratis AI profile ${profileId}`,
+            skills,
+        });
+        const sourceCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+            cwd: repositoryRoot,
+            encoding: "utf8",
+        }).trim();
+        const generatorPaths = [
+            "tooling/generate-approved-profile-release.mjs",
+            "tooling/passive-profile-adapters.mjs",
+        ];
+        const generatorHash = createHash("sha256");
+        for (const path of generatorPaths) {
+            generatorHash.update(path);
+            generatorHash.update("\0");
+            generatorHash.update(readFileSync(join(repositoryRoot, path)));
+            generatorHash.update("\0");
+        }
+        writeJson(join(root, "provenance.json"), {
+            schemaVersion: "1.0.0",
+            state: "APPROVED_PROFILE_RELEASE_PROVENANCE",
+            sourceRepository: "https://github.com/Cratis/AI",
+            sourceCommit,
+            generatorPaths,
+            generatorDigest: generatorHash.digest("hex"),
+            testedHostVersions: {
+                state: "pending-canary",
+                versions: {},
+            },
+            profileId,
+            version,
+            artifactId: plan.artifactId,
+            targets: plan.selectedSources.map(({ target, source }) => ({
+                targetId: target.id,
+                sourceId: source.id,
+                sourcePath: source.sourcePath,
+                sourceRevision: source.sourceRevision,
+                contentDigest: source.contentDigest,
+                approval: target.approval,
+            })),
+            publicationEligible: false,
+            promotionEligible: false,
+        });
+        const payloadFiles = walkFiles(root)
+            .sort()
+            .map((path) => {
+                const content = readFileSync(join(root, path));
+                return { path, size: content.length, sha256: sha256(content) };
+            });
+        const releaseManifest = {
+            schemaVersion: "1.0.0",
+            state: "APPROVED_PROFILE_RELEASE_CANDIDATE",
+            profileId,
+            packageName: plan.packageName,
+            audience: plan.audience,
+            version,
+            artifactId: plan.artifactId,
+            targetIds: plan.targetIds,
+            harnessRoots: adapterManifest.roots,
+            files: payloadFiles,
+            checksumFile: "SHA256SUMS",
+            publicationEligible: false,
+            promotionEligible: false,
+        };
+        writeJson(join(root, "release-manifest.json"), releaseManifest);
+        const checksumPaths = walkFiles(root).sort();
+        writeFileSync(
+            join(root, "SHA256SUMS"),
+            `${checksumPaths
+                .map(
+                    (path) =>
+                        `${sha256(readFileSync(join(root, path)))}  ${path}`,
+                )
+                .join("\n")}\n`,
+            { flag: "wx" },
+        );
+        return releaseManifest;
+    } catch (error) {
+        if (existsSync(root)) rmSync(root, { recursive: true, force: true });
+        throw error;
+    }
+}
+
+function main() {
+    const [outputRoot, profileId, version] = process.argv.slice(2);
+    if (!outputRoot || !profileId || !version) {
+        process.stderr.write(
+            "Usage: node tooling/generate-approved-profile-release.mjs <output> <profile-id> <exact-version>\n",
+        );
+        process.exitCode = 1;
+        return;
+    }
+    const manifest = generateApprovedProfileRelease({
+        outputRoot,
+        profileId,
+        version,
+    });
+    process.stdout.write(
+        `Generated approved profile release ${manifest.profileId}@${manifest.version}.\n`,
+    );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/tooling/generate-engineering-distribution-fixture.mjs
+++ b/tooling/generate-engineering-distribution-fixture.mjs
@@ -95,8 +95,8 @@ function manifestFile(root, path) {
 function validateEngineeringSourceAuthority(repositoryRoot) {
     const source = readJson(
         join(repositoryRoot, "catalog/v2/sources.json"),
-    ).sources.find(candidate => candidate.id === "write-documentation");
-    const expectedPaths = approvedFiles.map(path => `engineering/${path}`);
+    ).sources.find((candidate) => candidate.id === "write-documentation");
+    const expectedPaths = approvedFiles.map((path) => `engineering/${path}`);
     if (
         !source ||
         source.sourcePath !==

--- a/tooling/generate-repository-inventory.mjs
+++ b/tooling/generate-repository-inventory.mjs
@@ -97,6 +97,8 @@ const unexpectedUntracked = admittedUntracked.filter(
     (path) =>
         !(
             /^\.github\/ISSUE_TEMPLATE\//.test(path) ||
+            path ===
+                ".github/workflows/distribution-approved-profile-release.yml" ||
             path === ".github/workflows/distribution-canary-rollback.yml" ||
             path === ".github/workflows/engineering-distribution-fixture.yml" ||
             path === ".github/workflows/distribution-generated-update.yml" ||
@@ -473,6 +475,7 @@ const definitions = [
     {
         id: "repository-validation-workflow",
         sourcePathPatterns: [
+            ".github/workflows/distribution-approved-profile-release.yml",
             ".github/workflows/distribution-canary-rollback.yml",
             ".github/workflows/engineering-distribution-fixture.yml",
             ".github/workflows/distribution-generated-update.yml",

--- a/tooling/passive-profile-adapters.mjs
+++ b/tooling/passive-profile-adapters.mjs
@@ -1,0 +1,336 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { createHash } from "node:crypto";
+import {
+    existsSync,
+    mkdirSync,
+    readFileSync,
+    readdirSync,
+    writeFileSync,
+} from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import {
+    assertSafeContent,
+    validatePayloadPath,
+} from "./public-artifact-materializer.mjs";
+
+export const passiveHarnesses = [
+    "agent-skills",
+    "claude",
+    "codex",
+    "copilot",
+    "cursor",
+    "deepseek",
+    "gemini",
+    "grok",
+    "junie",
+    "kiro",
+    "pi",
+];
+
+function sha256(content) {
+    return createHash("sha256").update(content).digest("hex");
+}
+
+function writeExclusive(path, content) {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, content, { flag: "wx" });
+}
+
+function writeJson(path, value) {
+    writeExclusive(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function walkFiles(root, current = root) {
+    return readdirSync(current, { withFileTypes: true }).flatMap((entry) => {
+        const path = join(current, entry.name);
+        if (entry.isDirectory()) return walkFiles(root, path);
+        if (!entry.isFile())
+            throw new Error(`Profile adapter contains a special file: ${path}`);
+        return [relative(root, path).replaceAll("\\", "/")];
+    });
+}
+
+export function readSkillFrontmatter(content, skillName) {
+    const text = content.toString("utf8");
+    if (!text.startsWith("---\n"))
+        throw new Error(`Profile skill frontmatter is missing: ${skillName}`);
+    const closing = text.indexOf("\n---\n", 4);
+    if (closing < 0)
+        throw new Error(`Profile skill frontmatter is unclosed: ${skillName}`);
+    const properties = new Map();
+    for (const line of text.slice(4, closing).split("\n")) {
+        if (!line.trim()) continue;
+        const match = /^([A-Za-z][A-Za-z0-9-]*):\s*(\S.*)$/.exec(line);
+        if (!match || properties.has(match[1]))
+            throw new Error(`Profile skill frontmatter is invalid: ${skillName}`);
+        properties.set(match[1], match[2]);
+    }
+    if (
+        properties.get("name") !== skillName ||
+        !properties.get("description")
+    )
+        throw new Error(
+            `Profile skill frontmatter name or description is invalid: ${skillName}`,
+        );
+    return properties;
+}
+
+function copySkills(skills, root) {
+    for (const skill of skills)
+        for (const file of skill.files)
+            writeExclusive(
+                join(root, "skills", skill.name, file.path),
+                file.content,
+            );
+}
+
+function assertInputs({ version, profileId, packageName, skills }) {
+    if (
+        !/^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(
+            version,
+        )
+    )
+        throw new Error("Profile release version must be exact SemVer");
+    if (!/^(?:public|engineering)-[a-z0-9]+(?:-[a-z0-9]+)*$/.test(profileId))
+        throw new Error("Profile id is invalid");
+    if (!/^@cratis\/[a-z0-9]+(?:-[a-z0-9]+)*$/.test(packageName))
+        throw new Error("Profile package name is invalid");
+    if (!Array.isArray(skills) || skills.length === 0)
+        throw new Error("Profile release requires at least one skill");
+    const names = new Set();
+    for (const skill of skills) {
+        if (
+            !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(skill.name) ||
+            names.has(skill.name) ||
+            !Array.isArray(skill.files) ||
+            !skill.files.some((file) => file.path === "SKILL.md")
+        )
+            throw new Error(`Profile skill input is invalid: ${skill.name}`);
+        names.add(skill.name);
+        const filePaths = new Set();
+        const collisionKeys = new Set();
+        for (const file of skill.files) {
+            if (
+                !/^(?:SKILL\.md|LICENSE[^/]*|references\/[A-Za-z0-9._/-]+|assets\/[A-Za-z0-9._/-]+)$/.test(
+                    file.path,
+                ) ||
+                file.path.split("/").includes("..") ||
+                !Buffer.isBuffer(file.content) ||
+                filePaths.has(file.path) ||
+                collisionKeys.has(file.path.normalize("NFC").toLowerCase())
+            )
+                throw new Error(
+                    `Profile skill file is invalid: ${skill.name}/${file.path}`,
+                );
+            filePaths.add(file.path);
+            collisionKeys.add(file.path.normalize("NFC").toLowerCase());
+            const payloadPath = `skills/${skill.name}/${file.path}`;
+            validatePayloadPath(payloadPath);
+            assertSafeContent(payloadPath, file.content);
+        }
+        readSkillFrontmatter(
+            skill.files.find((file) => file.path === "SKILL.md").content,
+            skill.name,
+        );
+    }
+}
+
+export function generatePassiveProfileAdapters({
+    outputRoot,
+    version,
+    profileId,
+    packageName,
+    description,
+    skills,
+}) {
+    assertInputs({ version, profileId, packageName, skills });
+    const root = resolve(outputRoot);
+    if (existsSync(root))
+        throw new Error(`Profile adapter output must not exist: ${root}`);
+    mkdirSync(root, { recursive: false });
+    const harnessRoot = (harness) => join(root, "harnesses", harness);
+
+    copySkills(skills, harnessRoot("agent-skills"));
+
+    const claudeRoot = harnessRoot("claude");
+    copySkills(skills, join(claudeRoot, `plugins/${profileId}`));
+    writeJson(join(claudeRoot, ".claude-plugin/marketplace.json"), {
+        name: "cratis",
+        owner: { name: "Cratis" },
+        metadata: { description, version },
+        plugins: [
+            {
+                name: profileId,
+                description,
+                version,
+                source: `./plugins/${profileId}`,
+                strict: true,
+            },
+        ],
+    });
+    writeJson(
+        join(claudeRoot, `plugins/${profileId}/.claude-plugin/plugin.json`),
+        {
+            name: profileId,
+            version,
+            description,
+            author: { name: "Cratis" },
+        },
+    );
+
+    const codexRoot = harnessRoot("codex");
+    copySkills(skills, join(codexRoot, `plugins/${profileId}`));
+    writeJson(join(codexRoot, ".agents/plugins/marketplace.json"), {
+        name: "cratis",
+        interface: { displayName: "Cratis" },
+        plugins: [
+            {
+                name: profileId,
+                source: {
+                    source: "local",
+                    path: `./plugins/${profileId}`,
+                },
+                policy: {
+                    installation: "AVAILABLE",
+                    authentication: "ON_INSTALL",
+                },
+                category: "Developer Tools",
+            },
+        ],
+    });
+    writeJson(
+        join(codexRoot, `plugins/${profileId}/.codex-plugin/plugin.json`),
+        { name: profileId, version, description, skills: "./skills/" },
+    );
+
+    const copilotRoot = harnessRoot("copilot");
+    copySkills(skills, join(copilotRoot, `plugins/${profileId}`));
+    writeJson(join(copilotRoot, ".github/plugin/marketplace.json"), {
+        name: "cratis",
+        owner: { name: "Cratis" },
+        metadata: { description, version },
+        plugins: [
+            {
+                name: profileId,
+                description,
+                version,
+                source: `./plugins/${profileId}`,
+                strict: true,
+            },
+        ],
+    });
+    writeJson(join(copilotRoot, `plugins/${profileId}/plugin.json`), {
+        name: profileId,
+        version,
+        description,
+        skills: "skills/",
+    });
+
+    const cursorRoot = harnessRoot("cursor");
+    copySkills(skills, join(cursorRoot, `plugins/${profileId}`));
+    writeJson(join(cursorRoot, ".cursor-plugin/marketplace.json"), {
+        name: "cratis",
+        owner: { name: "Cratis" },
+        metadata: { description, version },
+        plugins: [
+            {
+                name: profileId,
+                description,
+                version,
+                source: `./plugins/${profileId}`,
+            },
+        ],
+    });
+    writeJson(
+        join(cursorRoot, `plugins/${profileId}/.cursor-plugin/plugin.json`),
+        { name: profileId, version, description, skills: "./skills/" },
+    );
+
+    const directRoots = {
+        deepseek: ".dsh",
+        gemini: ".",
+        grok: ".grok",
+        kiro: ".",
+    };
+    for (const [harness, destination] of Object.entries(directRoots))
+        copySkills(skills, join(harnessRoot(harness), destination));
+    writeJson(join(harnessRoot("gemini"), "gemini-extension.json"), {
+        name: profileId,
+        version,
+        description,
+    });
+    writeJson(join(harnessRoot("kiro"), "plugin.json"), {
+        $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+        name: profileId,
+        version,
+        description,
+        author: { name: "Cratis" },
+        license: "MIT",
+    });
+
+    const junieRoot = join(harnessRoot("junie"), `extensions/${profileId}`);
+    copySkills(skills, junieRoot);
+    writeJson(join(junieRoot, "extension.json"), {
+        name: profileId,
+        description,
+    });
+
+    const piRoot = harnessRoot("pi");
+    copySkills(skills, piRoot);
+    writeJson(join(piRoot, "package.json"), {
+        name: packageName,
+        version,
+        description,
+        private: false,
+        license: "MIT",
+        files: ["skills"],
+        keywords: ["pi-package", "cratis"],
+        pi: { skills: ["./skills"] },
+    });
+
+    const canonicalFiles = new Map();
+    for (const skill of skills)
+        for (const file of skill.files)
+            canonicalFiles.set(
+                `skills/${skill.name}/${file.path}`,
+                sha256(file.content),
+            );
+    for (const harness of passiveHarnesses) {
+        const harnessPath = harnessRoot(harness);
+        const files = walkFiles(harnessPath).sort();
+        const skillFiles = files.filter(
+            (path) => path.includes("/skills/") || path.startsWith("skills/"),
+        );
+        for (const [canonicalPath, digest] of canonicalFiles) {
+            const suffix = canonicalPath;
+            const matches = skillFiles.filter((path) => path.endsWith(suffix));
+            if (matches.length !== 1)
+                throw new Error(
+                    `${harness}: expected one copy of ${canonicalPath}, found ${matches.length}`,
+                );
+            if (sha256(readFileSync(join(harnessPath, matches[0]))) !== digest)
+                throw new Error(`${harness}: canonical byte parity failed`);
+        }
+    }
+    return {
+        harnesses: passiveHarnesses,
+        roots: Object.fromEntries(
+            passiveHarnesses.map((harness) => [
+                harness,
+                `harnesses/${harness}`,
+            ]),
+        ),
+        files: walkFiles(root)
+            .sort()
+            .map((path) => {
+                const content = readFileSync(join(root, path));
+                return {
+                    path,
+                    size: content.length,
+                    sha256: sha256(content),
+                };
+            }),
+    };
+}

--- a/tooling/profile-subscription-validation.mjs
+++ b/tooling/profile-subscription-validation.mjs
@@ -79,12 +79,30 @@ export function validateProfileSubscriptions(
     if (duplicates(packageNames).length)
         errors.push("Profile catalog contains duplicate package names");
     const knownProfiles = new Set(profileIds);
-    for (const profile of profiles)
+    const allowedProfileStates = new Set([
+        "approved",
+        "content-gap",
+        "owner-review-pending",
+        "planned",
+        "planned-composition",
+        "preview-source-candidate",
+    ]);
+    for (const profile of profiles) {
+        if (!allowedProfileStates.has(profile.state))
+            errors.push(
+                `${profile.id}: unknown profile state ${profile.state}`,
+            );
+        if (
+            profile.state === "approved" &&
+            (profile.availableTargets?.length ?? 0) === 0
+        )
+            errors.push(`${profile.id}: approved profile has no targets`);
         for (const dependency of profile.composes ?? [])
             if (!knownProfiles.has(dependency))
                 errors.push(
                     `${profile.id}: unknown composed profile ${dependency}`,
                 );
+    }
     if (
         profileCatalog.subscription?.projectFile !== ".cratis/ai.json" ||
         profileCatalog.subscription?.projectOwned !== true ||

--- a/tooling/specs/approved-profile-release.spec.mjs
+++ b/tooling/specs/approved-profile-release.spec.mjs
@@ -1,0 +1,343 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+    buildApprovedProfileReleasePlan,
+    generateApprovedProfileRelease,
+} from "../generate-approved-profile-release.mjs";
+import {
+    generatePassiveProfileAdapters,
+    passiveHarnesses,
+} from "../passive-profile-adapters.mjs";
+
+function readJson(path) {
+    return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function clone(value) {
+    return structuredClone(value);
+}
+
+function withTemporaryDirectory(callback) {
+    const root = mkdtempSync(join(tmpdir(), "cratis-approved-release-"));
+    try {
+        return callback(root);
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+}
+
+function repositoryInputs() {
+    return {
+        profileCatalog: readJson("distribution/profile-catalog.json"),
+        targets: readJson("catalog/v2/targets.json").targets,
+        sources: readJson("catalog/v2/sources.json").sources,
+        sourceContracts: readJson("catalog/v2/source-contracts.json").contracts,
+        authoringContracts: readJson("catalog/v2/authoring-contracts.json")
+            .contracts,
+        artifacts: readJson("catalog/v2/artifacts.json").artifacts,
+    };
+}
+
+test("current catalogs fail closed before approved materialization", () => {
+    const plan = buildApprovedProfileReleasePlan({
+        profileId: "public-fundamentals",
+        version: "1.0.0-preview.1",
+        ...repositoryInputs(),
+    });
+    assert.equal(plan.state, "BLOCKED");
+    assert(plan.blockers.includes("PROFILE_NOT_APPROVED"));
+    assert(
+        plan.blockers.includes(
+            "cratis-fundamentals-concept:TARGET_NOT_RUNTIME_APPROVED",
+        ),
+    );
+    assert(plan.blockers.includes("ARTIFACT_NOT_RUNTIME_ENABLED"));
+    withTemporaryDirectory((root) => {
+        const outputRoot = join(root, "release");
+        assert.throws(
+            () =>
+                generateApprovedProfileRelease({
+                    outputRoot,
+                    profileId: "public-fundamentals",
+                    version: "1.0.0-preview.1",
+                }),
+            /Approved profile release is blocked/,
+        );
+        assert.equal(existsSync(outputRoot), false);
+    });
+});
+
+test("approved plan requires every authority security and evidence gate", () => {
+    const inputs = clone(repositoryInputs());
+    const profile = inputs.profileCatalog.publicProfiles.find(
+        (candidate) => candidate.id === "public-fundamentals",
+    );
+    profile.state = "approved";
+    const target = inputs.targets.find(
+        (candidate) => candidate.id === "cratis-fundamentals-concept",
+    );
+    target.approval = {
+        state: "approved",
+        sourceRevision: "e9d161a70e25334bb468a33240bcf00f03f87522",
+        contentDigest:
+            "f7f7c2c110b3ff3f1b5921ad51fffc449a448bb49aaec2626ecc4d391e9d78a1",
+        reviewer: "fundamentals-owner",
+        approvedOn: "2026-08-23",
+        securityEvidenceId: "security-evidence",
+        behaviorEvidenceId: "behavior-evidence",
+        portabilityEvidenceId: "portability-evidence",
+        evidenceIds: ["approval-evidence"],
+    };
+    target.includeInRuntime = true;
+    target.lifecycle = "approved";
+    target.capabilityKind = "journey";
+    target.invocation = "both";
+    target.trust.assessmentState = "assessed";
+    target.dependencyClassificationState = "classified";
+    target.sourceContractState = "classified";
+    target.authoringContractState = "classified";
+    for (const dimension of [
+        target.architectures,
+        target.personas,
+        target.surfaces,
+        target.repositoryProfiles,
+    ])
+        dimension.state = "applicable";
+    target.security = {
+        ...target.security,
+        disposition: "accepted",
+        evidenceIds: ["security-evidence"],
+    };
+    for (const evaluation of Object.values(target.evaluations)) {
+        evaluation.status = "passing";
+        evaluation.evidenceIds = ["behavior-evidence"];
+    }
+    target.sourceContractIds = ["verified-fundamentals-source"];
+    target.authoringContractIds = ["cratis-skill-clean-room-v1"];
+    inputs.sourceContracts.push({
+        id: "verified-fundamentals-source",
+        verificationState: "verified",
+        distributionInputAllowed: true,
+    });
+    const artifact = inputs.artifacts.find(
+        (candidate) => candidate.id === "planned-passive-public-release",
+    );
+    artifact.materializationAllowed = true;
+    artifact.runtimeEligible = true;
+    const plan = buildApprovedProfileReleasePlan({
+        profileId: profile.id,
+        version: "1.0.0-preview.1+build.7",
+        ...inputs,
+    });
+    assert.equal(plan.state, "READY_FOR_BOT_MATERIALIZATION");
+    assert.deepEqual(plan.blockers, []);
+    assert.deepEqual(plan.targetIds, ["cratis-fundamentals-concept"]);
+    assert.equal(plan.packageName, "@cratis/ai-fundamentals");
+    assert.equal(plan.publicationEligible, false);
+    assert.equal(plan.promotionEligible, false);
+
+    const source = inputs.sources.find(
+        (candidate) => candidate.id === "add-concept",
+    );
+    target.approval.contentDigest = "0".repeat(64);
+    assert(
+        buildApprovedProfileReleasePlan({
+            profileId: profile.id,
+            version: "1.0.0",
+            ...inputs,
+        }).blockers.includes(
+            "cratis-fundamentals-concept:APPROVAL_SOURCE_BINDING_MISMATCH",
+        ),
+    );
+    target.approval.contentDigest = source.contentDigest;
+    source.audience = "cratis-engineering";
+    assert(
+        buildApprovedProfileReleasePlan({
+            profileId: profile.id,
+            version: "1.0.0",
+            ...inputs,
+        }).blockers.includes(
+            "cratis-fundamentals-concept:SOURCE_AUDIENCE_MISMATCH",
+        ),
+    );
+    source.audience = "public";
+    target.evaluations = {};
+    target.sourceContractIds = [];
+    target.authoringContractIds = [];
+    target.approval.evidenceIds = [];
+    const incompletePlan = buildApprovedProfileReleasePlan({
+        profileId: profile.id,
+        version: "1.0.0",
+        ...inputs,
+    });
+    for (const blocker of [
+        "cratis-fundamentals-concept:APPROVAL_EVIDENCE_INCOMPLETE",
+        "cratis-fundamentals-concept:EVALUATION_SET_INCOMPLETE",
+        "cratis-fundamentals-concept:SOURCE_CONTRACTS_MISSING",
+        "cratis-fundamentals-concept:AUTHORING_CONTRACTS_MISSING",
+    ])
+        assert(incompletePlan.blockers.includes(blocker), blocker);
+});
+
+test("passive adapter materializer rejects unsafe or mismatched skill input", () => {
+    withTemporaryDirectory((root) => {
+        const base = {
+            version: "1.0.0",
+            profileId: "public-example",
+            packageName: "@cratis/ai-example",
+            description: "Example",
+        };
+        assert.throws(
+            () =>
+                generatePassiveProfileAdapters({
+                    ...base,
+                    outputRoot: join(root, "traversal"),
+                    skills: [
+                        {
+                            name: "cratis-example",
+                            files: [
+                                {
+                                    path: "SKILL.md",
+                                    content: Buffer.from(
+                                        "---\nname: different-name\ndescription: Wrong.\n---\n",
+                                    ),
+                                },
+                                {
+                                    path: "references/../escape.md",
+                                    content: Buffer.from("escape\n"),
+                                },
+                            ],
+                        },
+                    ],
+                }),
+            /invalid|does not match/,
+        );
+        assert.equal(existsSync(join(root, "traversal")), false);
+        const validHeader =
+            "---\nname: cratis-example\ndescription: Example.\n---\n";
+        assert.throws(
+            () =>
+                generatePassiveProfileAdapters({
+                    ...base,
+                    outputRoot: join(root, "case-collision"),
+                    skills: [
+                        {
+                            name: "cratis-example",
+                            files: [
+                                {
+                                    path: "SKILL.md",
+                                    content: Buffer.from(validHeader),
+                                },
+                                {
+                                    path: "references/Guide.md",
+                                    content: Buffer.from("Guide\n"),
+                                },
+                                {
+                                    path: "references/guide.md",
+                                    content: Buffer.from("guide\n"),
+                                },
+                            ],
+                        },
+                    ],
+                }),
+            /invalid/,
+        );
+        assert.throws(
+            () =>
+                generatePassiveProfileAdapters({
+                    ...base,
+                    outputRoot: join(root, "malformed-frontmatter"),
+                    skills: [
+                        {
+                            name: "cratis-example",
+                            files: [
+                                {
+                                    path: "SKILL.md",
+                                    content: Buffer.from(
+                                        "---\ndescription: Missing name.\n---\n\nname: cratis-example\n",
+                                    ),
+                                },
+                            ],
+                        },
+                    ],
+                }),
+            /frontmatter name or description is invalid/,
+        );
+    });
+});
+
+test("release provenance binds generators and checksums the final manifest", () => {
+    const generator = readFileSync(
+        "tooling/generate-approved-profile-release.mjs",
+        "utf8",
+    );
+    assert(generator.includes("generatorDigest"));
+    assert(generator.includes("testedHostVersions"));
+    assert(generator.includes('state: "pending-canary"'));
+    assert(
+        generator.indexOf(
+            'writeJson(join(root, "release-manifest.json"), releaseManifest)',
+        ) < generator.indexOf('join(root, "SHA256SUMS")'),
+    );
+});
+
+test("passive adapter materializer emits one install root per harness", () => {
+    withTemporaryDirectory((root) => {
+        const outputRoot = join(root, "release");
+        const skillBytes = Buffer.from(
+            "---\nname: cratis-example\ndescription: Example passive skill.\n---\n\n# Example\n",
+        );
+        const manifest = generatePassiveProfileAdapters({
+            outputRoot,
+            version: "1.2.3-preview.1",
+            profileId: "public-example",
+            packageName: "@cratis/ai-example",
+            description: "Cratis example profile",
+            skills: [
+                {
+                    name: "cratis-example",
+                    files: [
+                        { path: "SKILL.md", content: skillBytes },
+                        { path: "LICENSE", content: Buffer.from("MIT\n") },
+                    ],
+                },
+            ],
+        });
+        assert.deepEqual(manifest.harnesses, passiveHarnesses);
+        for (const harness of passiveHarnesses)
+            assert.equal(manifest.roots[harness], `harnesses/${harness}`);
+        const piPackage = readJson(
+            join(outputRoot, "harnesses/pi/package.json"),
+        );
+        assert.equal(piPackage.name, "@cratis/ai-example");
+        assert.equal(piPackage.version, "1.2.3-preview.1");
+        assert.equal(piPackage.private, false);
+        assert.deepEqual(piPackage.pi, { skills: ["./skills"] });
+        assert.equal(piPackage.scripts, undefined);
+        assert.equal(piPackage.dependencies, undefined);
+        assert.equal(
+            readFileSync(
+                join(
+                    outputRoot,
+                    "harnesses/grok/.grok/skills/cratis-example/SKILL.md",
+                ),
+            ).equals(skillBytes),
+            true,
+        );
+        assert.equal(
+            readFileSync(
+                join(
+                    outputRoot,
+                    "harnesses/deepseek/.dsh/skills/cratis-example/SKILL.md",
+                ),
+            ).equals(skillBytes),
+            true,
+        );
+    });
+});

--- a/tooling/specs/profile-subscription.spec.mjs
+++ b/tooling/specs/profile-subscription.spec.mjs
@@ -82,7 +82,7 @@ test("profile subscription rejects floating versions and unknown profiles", () =
 });
 
 test("subscription schema enforces exact SemVer pins", () => {
-    withFixture(root => {
+    withFixture((root) => {
         const path = join(
             root,
             "Documentation/examples/ai-subscriptions/cratis-application.cratis-ai.json",
@@ -91,7 +91,7 @@ test("subscription schema enforces exact SemVer pins", () => {
         example.version = "01.0.0";
         writeJson(path, example);
         assert(
-            validateProfileSubscriptions(root).some(error =>
+            validateProfileSubscriptions(root).some((error) =>
                 error.includes("version"),
             ),
         );
@@ -102,7 +102,7 @@ test("subscription schema enforces exact SemVer pins", () => {
 });
 
 test("subscription schema rejects cross-audience profiles", () => {
-    withFixture(root => {
+    withFixture((root) => {
         const path = join(
             root,
             "Documentation/examples/ai-subscriptions/cratis-application.cratis-ai.json",
@@ -112,13 +112,15 @@ test("subscription schema rejects cross-audience profiles", () => {
         writeJson(path, example);
         const errors = validateProfileSubscriptions(root);
         assert(
-            errors.some(error =>
+            errors.some((error) =>
                 error.includes("expected exactly one matching oneOf branch"),
             ),
         );
         assert(
-            errors.some(error =>
-                error.includes("unknown profile engineering-framework-chronicle"),
+            errors.some((error) =>
+                error.includes(
+                    "unknown profile engineering-framework-chronicle",
+                ),
             ),
         );
     });

--- a/tooling/specs/workflow-safety.spec.mjs
+++ b/tooling/specs/workflow-safety.spec.mjs
@@ -33,6 +33,33 @@ test("verification workflow covers every release-relevant source", () => {
     }
 });
 
+test("approved profile workflow is bot-scoped and keeps publication separate", () => {
+    const workflow = readFileSync(
+        ".github/workflows/distribution-approved-profile-release.yml",
+        "utf8",
+    );
+    for (const required of [
+        "generate-approved-profile-release.mjs",
+        "fetch-depth: 0",
+        "environment: distribution-canary",
+        "repositories: AI.Distribution",
+        "permission-contents: write",
+        "permission-pull-requests: write",
+        'test ! -e "$destination"',
+        "Publication and promotion remain separate protected gates",
+    ])
+        assert(workflow.includes(required), required);
+    for (const forbidden of [
+        "force push",
+        "--force",
+        "npm publish",
+        "gh release create",
+        "git tag",
+        "secrets: inherit",
+    ])
+        assert.equal(workflow.includes(forbidden), false, forbidden);
+});
+
 test("legacy propagation workflows are inert and inherit no secrets", () => {
     for (const path of [
         ".github/workflows/propagate-copilot-instructions.yml",


### PR DESCRIPTION
# Summary

Implements the fail-closed production materialization path for approved Cratis AI profiles and emits one root-native artifact tree per supported harness.

## Changed

- Resolve release readiness against approved profile/target lifecycle, audience, complete classification, security, evaluation, source/authoring contracts and artifact gates (#165)
- Bind target approval to exact source revision and digest (#148)
- Materialize immutable Git bytes and recompute catalog content digests (#148)
- Generate root-native Agent Skills, Claude, Codex, Copilot, Cursor, Gemini, Grok, DeepSeek Harness, Kiro, Junie and Pi layouts (#165)
- Validate passive paths/content/frontmatter, case collisions, secrets and canonical byte parity (#165)
- Emit generator/source/approval provenance, release manifest and checksums (#165)
- Add protected repository-scoped App workflow for bot-authored AI.Distribution PRs (#72)

## Current state

Current catalogs intentionally fail closed because no profile, target, source contract or production artifact is approved/runtime-enabled. Publication, tags, promotion and marketplace submission remain separate gates.
