### PR TITLE
Correct Pi skill filtering guidance

### DIFF
--- a/Documentation/ai-distribution-and-subscriptions.md
+++ b/Documentation/ai-distribution-and-subscriptions.md
@@ -113,18 +113,19 @@ The schema is
 Exact versions are mandatory. `latest`, branches, and floating ranges are not
 valid subscriptions.
 
-The repository-scoped update App discovers subscriptions from committed
-`.cratis/ai.json` files in repositories where it is installed. A new release
-opens a normal pull request changing the subscription and host-native lock or
-settings files. It never merges automatically, pushes generated corpus folders,
-or receives broad organization write access.
+Stagehand owns the subscriber update controller tracked internally as
+`Cratis/Stagehand#39`. Its repository-scoped App discovers committed `.cratis/ai.json` files only in
+repositories where it is explicitly installed. A new release opens a normal
+pull request changing the subscription and host-native lock or settings files.
+It never merges automatically, pushes generated corpus folders, or receives
+broad organization write access.
 
 ## Pi package workflow
 
 Pi is a first-class host, not a copied adapter directory. Pi packages can load
 skills from npm or Git and can be installed globally or into project settings.
-See the official [Pi package documentation](https://pi.dev/docs) and package
-gallery at [pi.dev/packages](https://pi.dev/packages). Because Pi packages and
+See the official [Pi package reference](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/packages.md)
+and package gallery at [pi.dev/packages](https://pi.dev/packages). Because Pi packages and
 skills can execute or instruct powerful actions, Cratis public and base profile
 packages remain passive and are reviewed before publication.
 
@@ -175,8 +176,8 @@ package filter object:
     {
       "source": "npm:@cratis/ai-chronicle@1.0.0",
       "skills": [
-        "cratis-chronicle-projection",
-        "cratis-chronicle-read-model"
+        "skills/cratis-chronicle-projection",
+        "skills/cratis-chronicle-read-model"
       ],
       "extensions": []
     }

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "08aea5cb51746b9c1495e4ff3942185e388b51863c39e1ddb44998f1b5c9f03f",
+  "indexDigest": "3d6bc8baa5adb6748a8466dfd6b07a8fd74b1fbe8d3c1845ec56273c6ed728fc",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],


### PR DESCRIPTION
# Summary

Corrects the Pi package filtering example against the official Pi package reference and identifies Stagehand as the internal subscriber update controller.

## Changed

- Use package-root-relative `skills/<name>` Pi filter paths (#165)
- Link the official Pi package reference and pi.dev package gallery (#165)
- Record Stagehand as the subscriber update controller without linking a private issue from public documentation (#165)
