### PR TITLE
Record authoritative post-168 delivery checkpoint

### DIFF
--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
@@ -1931,3 +1931,99 @@ later protected publication unit archives or publishes each harness root and
 runs exact remote lifecycle commands. Production code now exists; organizational
 approval, credentials, release-asset publication, and the real public canary
 remain blockers.
+
+## 51. Authoritative post-#168 delivery checkpoint — 2026-08-23
+
+This section supersedes stale unchecked historical ledger items for current
+execution state.
+
+### Repository state
+
+- canonical remote main: `ee905994f6a6278b72241a07e31c54bec84f1b41`;
+- worktree: `/Volumes/sourcecode/repos/cratis/AI-review-pilot`;
+- intentional checkpoint branch: `chore/post-168-authoritative-checkpoint`;
+- divergence from `origin/main`: `0/0` when reconciled;
+- open `Cratis/AI` pull requests: none;
+- primary `/Volumes/sourcecode/repos/cratis/AI` worktree remains on historical
+  local `main` at `b795d5307e20f7f7458a67708b4f26975e223796` and must not be reset;
+- one inherited unstaged diff in
+  `tooling/passive-profile-adapters.mjs` is formatter-only. It belongs to the
+  merged production materializer and will be preserved deliberately, not
+  discarded.
+
+Hosted main verification passed for materializer merge `0675633` at
+`https://github.com/Cratis/AI/actions/runs/32609491793` and for Pi documentation
+merge `ee90599` at
+`https://github.com/Cratis/AI/actions/runs/32609687681`.
+
+### Current statistics
+
+| Area | Current count/state |
+| --- | --- |
+| Skill source identities | 43 total: 35 public, 8 Cratis engineering |
+| Canonical sources | 1 public, 3 engineering |
+| Legacy `.ai/skills` sources | 39 remain to reconcile; none were deleted |
+| Targets | 43 candidate, 0 approved, 0 runtime-enabled |
+| Classified targets | 3 |
+| Security-accepted targets | 0 |
+| Bundles | 6 draft, 0 publishable |
+| Profiles | 5 public + 11 engineering, 0 approved |
+| Materializable artifacts | 2 fixture/preview artifacts only |
+| Runtime-eligible artifacts | 0 |
+| Supported published packages | 0 |
+
+The 39 legacy sources are useful migration inputs, not package bytes. The next
+release candidate remains `public-fundamentals` with exactly
+`cratis-fundamentals-concept`, pending AI#148 and AI#165. The next internal
+candidate remains `engineering-documentation` with docs-authoring only, pending
+AI#154; add/edit companions remain excluded.
+
+### Distribution and credentials
+
+- `Cratis/AI.Distribution` is public, initialized, secret-scanned,
+  push-protected, and has protected `main` with one required approval;
+- it still contains fixture-only generated state and is not an installation
+  target;
+- no repository or protected-environment distribution App secrets are present;
+- update-bot state is `WORKFLOW_READY_CREDENTIALS_MISSING`;
+- npm is not authenticated locally, package ownership is unconfirmed, and
+  trusted publishing is disabled;
+- publication, promotion, production canary, and legacy retirement remain
+  false.
+
+### Live external blockers
+
+- AI#148 — first public target/source approval; assigned to `einari` and
+  `woksin`;
+- AI#165 — profile owners and source authority; assigned to both;
+- AI#154 — internal docs-authoring owner approval; assigned to both;
+- Workflows#72 — repository-scoped distribution App; assigned to both;
+- Workflows#70 — npm ownership/trusted publishing; assigned to both;
+- Workflows#71 — real public consumer lifecycle canary; assigned to both;
+- AI#147 — reviewed marketplace submissions; now assigned to both;
+- Stagehand#39 was closed `NOT_PLANNED` with no implementation evidence. The
+  subscriber-update control-plane owner is therefore unresolved and must not be
+  represented as implemented.
+
+Deferred/non-critical state remains: companion corrective evaluation is outside
+the first release; Cursor/Kiro/Junie are structurally validated but await real
+host lifecycle evidence; DeepSeek Harness remains preview and must be
+reverified before stable support.
+
+### Verification and exact resume actions
+
+Last fresh local evidence before #167/#168 merge was 260/260 specs, clean corpus
+validation, clean Markdown lint/links, and clean LSP/multi-runner diagnostics.
+Current main must be rerun after preserving the formatting diff.
+
+Resume in this order:
+
+1. commit this checkpoint plus the formatter-only diff on the intentional branch;
+2. run the complete main verification suite and merge the checkpoint PR;
+3. verify AI#148/AI#165 for approval; do not self-grant it;
+4. if still blocked, make the smallest useful release immediately executable by
+   producing deterministic local per-harness release-asset staging from the
+   preview without calling it approved or publishable;
+5. resolve subscriber-update ownership after Stagehand#39 closure;
+6. proceed to protected App/npm/canary/publication only when the corresponding
+   external gates are actually satisfied.

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
@@ -2001,9 +2001,10 @@ AI#154; add/edit companions remain excluded.
 - Workflows#70 — npm ownership/trusted publishing; assigned to both;
 - Workflows#71 — real public consumer lifecycle canary; assigned to both;
 - AI#147 — reviewed marketplace submissions; now assigned to both;
-- Stagehand#39 was closed `NOT_PLANNED` with no implementation evidence. The
-  subscriber-update control-plane owner is therefore unresolved and must not be
-  represented as implemented.
+- Stagehand#39 was closed `NOT_PLANNED` with no implementation evidence;
+- Workflows#73 now owns the subscriber update PR controller follow-up, consistent
+  with Workflows ownership of fleet distribution, canaries, pins, and rollback.
+  It is assigned to `einari` and `woksin` and remains unimplemented.
 
 Deferred/non-critical state remains: companion corrective evaluation is outside
 the first release; Cursor/Kiro/Junie are structurally validated but await real
@@ -2012,9 +2013,10 @@ reverified before stable support.
 
 ### Verification and exact resume actions
 
-Last fresh local evidence before #167/#168 merge was 260/260 specs, clean corpus
-validation, clean Markdown lint/links, and clean LSP/multi-runner diagnostics.
-Current main must be rerun after preserving the formatting diff.
+Fresh post-reconciliation evidence is 260/260 specs, deterministic catalog and
+inventory generation, clean catalog/profile/source/evaluation validation, clean
+corpus validation, 17 Markdown files lint-clean, 25 links passing, and clean
+diff. This includes the preserved formatter-only materializer change.
 
 Resume in this order:
 

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
@@ -625,3 +625,35 @@ Evidence and exact next actions are in
   then package and host immutable per-harness release assets.
 - [ ] Run the first real public consumer lifecycle canary and publish only a
   narrowly labeled Fundamentals/Chronicle C# preview.
+
+### 2026-08-23 — Authoritative post-#168 delivery state
+
+Historical unchecked items above describe their original checkpoints and are
+not automatically current blockers. Current state and exact evidence are in
+handover section 51.
+
+- [x] Reconcile current `origin/main` at `ee905994`, worktrees, open PRs,
+  divergence, local formatting diff, live issues, credentials, profiles,
+  artifacts, and release statistics.
+- [x] Preserve all 43 legacy skill sources: 35 public and 8 engineering; record
+  that 39 remain migration inputs while 4 have canonical replacements.
+- [x] Merge profile subscriptions, first-class Pi guidance, one-way contribution,
+  broad-sync retirement, and release hardening through AI#166.
+- [x] Merge fail-closed approval-driven profile materialization and per-harness
+  install roots through AI#167.
+- [x] Merge corrected official Pi filter paths through AI#168.
+- [ ] Preserve the inherited formatter-only materializer diff and this
+  checkpoint in one small no-release PR; rerun all current-main gates.
+- [ ] Obtain AI#148 and AI#165 approval for the one-skill
+  `public-fundamentals` preview; never infer approval.
+- [ ] If approval is still absent, generate deterministic local immutable
+  per-harness release assets from the explicitly non-publishable preview so the
+  owner/canary step is executable immediately when approved.
+- [ ] Reassign subscriber-update control-plane ownership: Stagehand#39 closed
+  `NOT_PLANNED`, so no production subscriber controller currently exists.
+- [ ] Provision Workflows#72 App credentials, Workflows#70 npm trust, and run
+  Workflows#71 only after exact approvals exist.
+- [ ] Submit AI#147 marketplaces only for hosts with honest lifecycle evidence;
+  keep Cursor/Kiro/Junie structural and DeepSeek preview labels until reverified.
+- [ ] Keep companion corrective evaluation, broad legacy migration, publication,
+  promotion, and retirement off the first-release critical path.

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
@@ -649,8 +649,11 @@ handover section 51.
 - [ ] If approval is still absent, generate deterministic local immutable
   per-harness release assets from the explicitly non-publishable preview so the
   owner/canary step is executable immediately when approved.
-- [ ] Reassign subscriber-update control-plane ownership: Stagehand#39 closed
-  `NOT_PLANNED`, so no production subscriber controller currently exists.
+- [x] Reassign subscriber-update control-plane ownership after Stagehand#39
+  closed `NOT_PLANNED`: Workflows#73 now tracks the controller and manual App
+  scope decision.
+- [ ] Implement and canary the Workflows#73 subscriber update PR controller; no
+  production subscriber controller currently exists.
 - [ ] Provision Workflows#72 App credentials, Workflows#70 npm trust, and run
   Workflows#71 only after exact approvals exist.
 - [ ] Submit AI#147 marketplaces only for hosts with honest lifecycle evidence;

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "c6902e7eafccb1fbaf026001b25dbdea30de323e3ce7f77ae4e78e20cd2121ac",
+  "indexDigest": "f14c553816becff49833abe86fb717c9f510b18c5df10f506d266150c554952e",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "3d6bc8baa5adb6748a8466dfd6b07a8fd74b1fbe8d3c1845ec56273c6ed728fc",
+  "indexDigest": "c6902e7eafccb1fbaf026001b25dbdea30de323e3ce7f77ae4e78e20cd2121ac",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/tooling/passive-profile-adapters.mjs
+++ b/tooling/passive-profile-adapters.mjs
@@ -64,13 +64,12 @@ export function readSkillFrontmatter(content, skillName) {
         if (!line.trim()) continue;
         const match = /^([A-Za-z][A-Za-z0-9-]*):\s*(\S.*)$/.exec(line);
         if (!match || properties.has(match[1]))
-            throw new Error(`Profile skill frontmatter is invalid: ${skillName}`);
+            throw new Error(
+                `Profile skill frontmatter is invalid: ${skillName}`,
+            );
         properties.set(match[1], match[2]);
     }
-    if (
-        properties.get("name") !== skillName ||
-        !properties.get("description")
-    )
+    if (properties.get("name") !== skillName || !properties.get("description"))
         throw new Error(
             `Profile skill frontmatter name or description is invalid: ${skillName}`,
         );


### PR DESCRIPTION
# Summary

Records the authoritative post-#168 delivery checkpoint before the next release unit.

## Reconciled state

- Current main, worktrees, divergence and open PRs (#126)
- 43 source / 43 target / 16 profile statistics (#126)
- Approved versus blocked artifacts and profiles (#165)
- Live App/npm/canary/marketplace credential gates (#126)
- First public and engineering candidates (#148, #154)
- Subscriber update ownership moved from closed Stagehand#39 to Workflows#73 (#165)
- Exact resume actions and fresh 260/260 verification evidence (#126)
- Preserves the formatter-only materializer change observed after #168

No approval, runtime, publication, promotion or retirement state changes.
