### PR TITLE
Package Fundamentals approval-pending preview assets

### DIFF
--- a/.github/workflows/distribution-fundamentals-preview-assets.yml
+++ b/.github/workflows/distribution-fundamentals-preview-assets.yml
@@ -1,0 +1,58 @@
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+name: Package Fundamentals Preview Assets
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact non-production SemVer preview version
+        required: true
+        default: 0.1.0-preview.1
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fundamentals-preview-${{ inputs.version }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  package-preview:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out complete immutable history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      - name: Generate and verify approval-pending preview assets
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          node tooling/validate-catalogs.mjs
+          node tooling/package-fundamentals-preview-assets.mjs \
+            "$RUNNER_TEMP/fundamentals-preview-assets" "$VERSION"
+          test "$(node -p "require('$RUNNER_TEMP/fundamentals-preview-assets/preview-assets.json').state")" = "PREVIEW_ASSETS_APPROVAL_PENDING"
+          test "$(node -p "require('$RUNNER_TEMP/fundamentals-preview-assets/preview-assets.json').approvalEligible")" = "false"
+          test "$(node -p "require('$RUNNER_TEMP/fundamentals-preview-assets/preview-assets.json').publicationEligible")" = "false"
+          test "$(node -p "require('$RUNNER_TEMP/fundamentals-preview-assets/preview-assets.json').promotionEligible")" = "false"
+          node --test tooling/specs/fundamentals-preview-assets.spec.mjs
+
+      - name: Upload short-lived review assets
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v7.0.1
+        with:
+          name: fundamentals-${{ inputs.version }}-approval-pending
+          path: ${{ runner.temp }}/fundamentals-preview-assets
+          if-no-files-found: error
+          retention-days: 7

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
@@ -2029,3 +2029,50 @@ Resume in this order:
 5. resolve subscriber-update ownership after Stagehand#39 closure;
 6. proceed to protected App/npm/canary/publication only when the corresponding
    external gates are actually satisfied.
+
+## 52. Approval-pending Fundamentals preview assets — 2026-08-23
+
+AI#148 and AI#165 still contain no owner approval. Rather than add generic
+validation or wait idly, the first public candidate is now staged into usable,
+short-lived review assets without crossing that authority boundary.
+
+`tooling/package-fundamentals-preview-assets.mjs`:
+
+- accepts only the exact `public-fundamentals` /
+  `cratis-fundamentals-concept-preview` candidate relationship;
+- requires target/source/profile/artifact state to remain candidate,
+  non-runtime, fixture-only, and non-publishable;
+- reads exact source bytes from immutable revision
+  `e9d161a70e25334bb468a33240bcf00f03f87522` and verifies catalog digest
+  `f7f7c2c110b3ff3f1b5921ad51fffc449a448bb49aaec2626ecc4d391e9d78a1`;
+- generates one root-native deterministic `tar.gz` per passive harness and one
+  npm-compatible Pi `.tgz` for Agent Skills, Claude, Codex, Copilot, Cursor,
+  DeepSeek Harness, Gemini, Grok, Junie, Kiro, and Pi;
+- emits `preview-assets.json`, passive `preview-sbom.json`, and `SHA256SUMS`;
+- records `PREVIEW_ASSETS_APPROVAL_PENDING` with approval, supported
+  installation, publication, and promotion all false;
+- validates tar checksums/paths, archive byte parity, deterministic generation,
+  Pi npm install/update/rollback/uninstall, extracted Pi install/list/remove,
+  and project context/subscription/settings preservation.
+
+Local evidence at
+`distribution/evidence/local-fundamentals-preview-assets-2026-08-23.json`
+records 11 assets from review-corrected implementation commit
+`9f4f8dc7cd0ede084c1d024fb6f83ad237614355`, generator digest
+`3044c0d473b5d2fcda9734547b9246c8d24f5eab9ac361453a7d5f5ea86bc867`,
+zero SBOM dependencies/executables, and all focused gates passing.
+
+The single bounded review found three high preview-boundary defects. Corrections
+now require the fixed source revision/digest, reject stable/non-preview versions,
+set the Pi package `private: true`, and mark Codex installation
+`NOT_AVAILABLE`. The read-only **Package Fundamentals Preview Assets** workflow
+verifies and uploads the corrected artifacts for seven days. It has no secrets,
+write/OIDC, publish, release, push, approval, or promotion authority. Non-Pi harness assets
+have archive byte parity only in this unit; existing fixture host evidence
+remains separate and exact archive install evidence is still required before a
+support claim.
+
+The bounded approval request on AI#148 and first-profile request on AI#165 now
+name exact revision/digest and a copy-ready approve/reject response. Workflows#73
+tracks the downstream subscriber-update controller after Stagehand#39 closed
+`NOT_PLANNED`.

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
@@ -646,9 +646,10 @@ handover section 51.
   checkpoint in one small no-release PR; rerun all current-main gates.
 - [ ] Obtain AI#148 and AI#165 approval for the one-skill
   `public-fundamentals` preview; never infer approval.
-- [ ] If approval is still absent, generate deterministic local immutable
-  per-harness release assets from the explicitly non-publishable preview so the
-  owner/canary step is executable immediately when approved.
+- [x] With approval still absent, generate deterministic local immutable
+  per-harness review assets from the explicitly non-publishable Fundamentals
+  preview, including Pi npm lifecycle, passive SBOM, checksums, provenance, and
+  a read-only seven-day workflow.
 - [x] Reassign subscriber-update control-plane ownership after Stagehand#39
   closed `NOT_PLANNED`: Workflows#73 now tracks the controller and manual App
   scope decision.

--- a/Documentation/ai-distribution-and-subscriptions.md
+++ b/Documentation/ai-distribution-and-subscriptions.md
@@ -278,6 +278,27 @@ The final release page replaces placeholders with immutable URLs, checksums,
 tested host versions, update commands, and uninstall commands. Do not point a
 host at the multi-profile generated repository root.
 
+### Approval-pending Fundamentals review assets
+
+While target approval remains open, maintainers can generate deterministic,
+short-lived review assets without granting installation or publication status:
+
+```bash
+node tooling/package-fundamentals-preview-assets.mjs \
+  /tmp/fundamentals-preview 0.1.0-preview.1
+```
+
+The output contains one root-native `tar.gz` asset per harness, an npm-compatible
+Pi `.tgz`, `preview-assets.json`, `preview-sbom.json`, and `SHA256SUMS`. It binds
+the exact immutable concept source revision and digest. The manifest state is
+`PREVIEW_ASSETS_APPROVAL_PENDING`; approval, supported installation,
+publication, and promotion are all false.
+
+The read-only **Package Fundamentals Preview Assets** workflow produces the same
+assets with seven-day retention for owner review and disposable canaries. These
+assets must not be published, installed as a supported release, or submitted to
+a marketplace.
+
 ## Versioning and release train
 
 All profile packages use SemVer and one atomic release train. A release changes

--- a/Documentation/ai-distribution-and-subscriptions.md
+++ b/Documentation/ai-distribution-and-subscriptions.md
@@ -289,7 +289,9 @@ node tooling/package-fundamentals-preview-assets.mjs \
 ```
 
 The output contains one root-native `tar.gz` asset per harness, an npm-compatible
-Pi `.tgz`, `preview-assets.json`, `preview-sbom.json`, and `SHA256SUMS`. It binds
+but npm-private Pi `.tgz`, `preview-assets.json`, `preview-sbom.json`, and
+`SHA256SUMS`. Stable/non-preview versions are rejected, and the Codex preview
+metadata marks installation `NOT_AVAILABLE`. It binds
 the exact immutable concept source revision and digest. The manifest state is
 `PREVIEW_ASSETS_APPROVAL_PENDING`; approval, supported installation,
 publication, and promotion are all false.

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "c4dae4db5d3df3eb4af2423418592d2c444e86268dbc9924a1f7a9058ad03867",
+  "indexDigest": "60fecc3e8d335d6fc73aa9d58cf5d4512693d1df8e1c8b1eae57a268a4836e65",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -396,6 +396,10 @@
     },
     {
       "path": "distribution/evidence/local-fixture-smoke-2026-08-22.json",
+      "status": "added"
+    },
+    {
+      "path": "distribution/evidence/local-fundamentals-preview-assets-2026-08-23.json",
       "status": "added"
     },
     {
@@ -2099,9 +2103,7 @@
       "status": "added"
     }
   ],
-  "admittedUntracked": [
-    "distribution/evidence/local-fundamentals-preview-assets-2026-08-23.json"
-  ],
+  "admittedUntracked": [],
   "excludedRuntimePrefixes": [
     ".pi/delegate/",
     ".pi/fusion/",

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -2087,7 +2087,11 @@
       "status": "added"
     }
   ],
-  "admittedUntracked": [],
+  "admittedUntracked": [
+    ".github/workflows/distribution-fundamentals-preview-assets.yml",
+    "tooling/package-fundamentals-preview-assets.mjs",
+    "tooling/specs/fundamentals-preview-assets.spec.mjs"
+  ],
   "excludedRuntimePrefixes": [
     ".pi/delegate/",
     ".pi/fusion/",
@@ -2638,6 +2642,7 @@
       "id": "repository-validation-workflow",
       "sourcePathPatterns": [
         ".github/workflows/distribution-approved-profile-release.yml",
+        ".github/workflows/distribution-fundamentals-preview-assets.yml",
         ".github/workflows/distribution-canary-rollback.yml",
         ".github/workflows/engineering-distribution-fixture.yml",
         ".github/workflows/distribution-generated-update.yml",
@@ -2660,8 +2665,8 @@
         "repo-main-b795d53",
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 6,
-      "expectedPathsDigest": "6e7604e8543c6f011bf0852a2b81f6d416a83ce2fcab42dbc47d4aa324d184ae"
+      "expectedPathCount": 7,
+      "expectedPathsDigest": "5a65e77aea979995ff0ef0fe6cb46700b304da3082d03a2a742765855956c82d"
     },
     {
       "excludePathPatterns": [],
@@ -3398,8 +3403,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 33,
-      "expectedPathsDigest": "ade37b2c91e8e2421f43e484961a158e4c5d2a109a57e9865e7f66010e2952de"
+      "expectedPathCount": 34,
+      "expectedPathsDigest": "6facafe4362c2224d7689cf7a2bb63c7099affb12a0ca84435c48ee9c140fef6"
     },
     {
       "excludePathPatterns": [],
@@ -3422,8 +3427,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 26,
-      "expectedPathsDigest": "f46889a4a04eaadb9235545a1402d44de3127378458e0a864e929bde8d426a7d"
+      "expectedPathCount": 27,
+      "expectedPathsDigest": "cdd1e58ce361586db8c6c0bd849e31460e22a3c894480cf4c81ed5052e6e2c83"
     },
     {
       "excludePathPatterns": [],

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "f14c553816becff49833abe86fb717c9f510b18c5df10f506d266150c554952e",
+  "indexDigest": "c4dae4db5d3df3eb4af2423418592d2c444e86268dbc9924a1f7a9058ad03867",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -44,6 +44,10 @@
     },
     {
       "path": ".github/workflows/distribution-canary-rollback.yml",
+      "status": "added"
+    },
+    {
+      "path": ".github/workflows/distribution-fundamentals-preview-assets.yml",
       "status": "added"
     },
     {
@@ -1931,6 +1935,10 @@
       "status": "added"
     },
     {
+      "path": "tooling/package-fundamentals-preview-assets.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/passive-profile-adapters.mjs",
       "status": "added"
     },
@@ -2039,6 +2047,10 @@
       "status": "added"
     },
     {
+      "path": "tooling/specs/fundamentals-preview-assets.spec.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/specs/generated-distribution-repository.spec.mjs",
       "status": "added"
     },
@@ -2088,9 +2100,7 @@
     }
   ],
   "admittedUntracked": [
-    ".github/workflows/distribution-fundamentals-preview-assets.yml",
-    "tooling/package-fundamentals-preview-assets.mjs",
-    "tooling/specs/fundamentals-preview-assets.spec.mjs"
+    "distribution/evidence/local-fundamentals-preview-assets-2026-08-23.json"
   ],
   "excludedRuntimePrefixes": [
     ".pi/delegate/",
@@ -3380,8 +3390,8 @@
       "evidenceIds": [
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 18,
-      "expectedPathsDigest": "08ef0162524356047d9100c699f1503db69c36e4a45fe96b63ef31a90e9f77e5"
+      "expectedPathCount": 19,
+      "expectedPathsDigest": "716837082abc6966269bb8d3ba526e1b6585e991ba6731e72a09cd2243047974"
     },
     {
       "excludePathPatterns": [],

--- a/distribution/evidence/local-fundamentals-preview-assets-2026-08-23.json
+++ b/distribution/evidence/local-fundamentals-preview-assets-2026-08-23.json
@@ -1,0 +1,150 @@
+{
+  "schemaVersion": "1.0.0",
+  "observedAt": "2026-08-23",
+  "state": "PREVIEW_ASSET_STAGING_PASS_APPROVAL_PENDING",
+  "sourceCommit": "9f4f8dc7cd0ede084c1d024fb6f83ad237614355",
+  "profileId": "public-fundamentals",
+  "artifactId": "cratis-fundamentals-concept-preview",
+  "targetId": "cratis-fundamentals-concept",
+  "sourceRevision": "e9d161a70e25334bb468a33240bcf00f03f87522",
+  "sourceContentDigest": "f7f7c2c110b3ff3f1b5921ad51fffc449a448bb49aaec2626ecc4d391e9d78a1",
+  "generatorDigest": "3044c0d473b5d2fcda9734547b9246c8d24f5eab9ac361453a7d5f5ea86bc867",
+  "version": "0.1.0-preview.1",
+  "assets": [
+    {
+      "harness": "agent-skills",
+      "filename": "cratis-ai-public-fundamentals-0.1.0-preview.1-agent-skills.tar.gz",
+      "format": "tar+gzip",
+      "root": "harnesses/agent-skills",
+      "size": 1466,
+      "sha256": "fa9b62b52b3729db604691c771c34391694732bc96697e05e0fbe81ad04ec1e9"
+    },
+    {
+      "harness": "claude",
+      "filename": "cratis-ai-public-fundamentals-0.1.0-preview.1-claude.tar.gz",
+      "format": "tar+gzip",
+      "root": "harnesses/claude",
+      "size": 1681,
+      "sha256": "fa401fad6e8fd6a5edfc7fdd2906201b7492757d37f790766096ff905b238b7e"
+    },
+    {
+      "harness": "codex",
+      "filename": "cratis-ai-public-fundamentals-0.1.0-preview.1-codex.tar.gz",
+      "format": "tar+gzip",
+      "root": "harnesses/codex",
+      "size": 1733,
+      "sha256": "0006437f9e33566eb0b54d9266bb4b6b45dff7f1af84de8cb7c2c135de59ac39"
+    },
+    {
+      "harness": "copilot",
+      "filename": "cratis-ai-public-fundamentals-0.1.0-preview.1-copilot.tar.gz",
+      "format": "tar+gzip",
+      "root": "harnesses/copilot",
+      "size": 1678,
+      "sha256": "c145e18361d0dbfdc81d6e6fcfebe45e5e737f337fcb9663a335b70fd2e95a99"
+    },
+    {
+      "harness": "cursor",
+      "filename": "cratis-ai-public-fundamentals-0.1.0-preview.1-cursor.tar.gz",
+      "format": "tar+gzip",
+      "root": "harnesses/cursor",
+      "size": 1676,
+      "sha256": "3067dbee96ef99c9c7c45ae7691143deb0dba8ea58dc9b984fc603fe8cabade6"
+    },
+    {
+      "harness": "deepseek",
+      "filename": "cratis-ai-public-fundamentals-0.1.0-preview.1-deepseek.tar.gz",
+      "format": "tar+gzip",
+      "root": "harnesses/deepseek",
+      "size": 1469,
+      "sha256": "21961141eb29956da8d100f62df434e0c59c928ae0950170ffed46d640d64b15"
+    },
+    {
+      "harness": "gemini",
+      "filename": "cratis-ai-public-fundamentals-0.1.0-preview.1-gemini.tar.gz",
+      "format": "tar+gzip",
+      "root": "harnesses/gemini",
+      "size": 1548,
+      "sha256": "3951199628b5bb59a5d8298a025aa2f45b97ad63d2b56ea96e3dac1c9fd76f3c"
+    },
+    {
+      "harness": "grok",
+      "filename": "cratis-ai-public-fundamentals-0.1.0-preview.1-grok.tar.gz",
+      "format": "tar+gzip",
+      "root": "harnesses/grok",
+      "size": 1471,
+      "sha256": "dea385bef4dfc59442b177328d3cd33bfe59436dd1260750aada76cda2cb2021"
+    },
+    {
+      "harness": "junie",
+      "filename": "cratis-ai-public-fundamentals-0.1.0-preview.1-junie.tar.gz",
+      "format": "tar+gzip",
+      "root": "harnesses/junie",
+      "size": 1539,
+      "sha256": "9d85b4607e7498270271ff30cd515d390317124c3f6921e3efaad0bef146ad0f"
+    },
+    {
+      "harness": "kiro",
+      "filename": "cratis-ai-public-fundamentals-0.1.0-preview.1-kiro.tar.gz",
+      "format": "tar+gzip",
+      "root": "harnesses/kiro",
+      "size": 1608,
+      "sha256": "9c682bec96622eb6e720d5cbeb77518e4268f700fd44407d8d5993a5ca30a551"
+    },
+    {
+      "harness": "pi",
+      "filename": "cratis-ai-public-fundamentals-0.1.0-preview.1-pi.tgz",
+      "format": "tar+gzip",
+      "root": "harnesses/pi",
+      "size": 1626,
+      "sha256": "62bb0660ea2169bd0cd8f9d8b642402e4d3ba0950719afbf48edb150f1c52275"
+    }
+  ],
+  "assetManifestSha256": "f9ad0461c8c75f68d1ba196f3a2dcf7efc739348f6a231de13f3bea2ed48e1ea",
+  "sbomSha256": "c0f14f3301fdf29e864c400356d1a05c2bb507102b5aef4b0dd0c0443b4826a6",
+  "checksumsSha256": "5b70b978c5c731de7edc27e752ec04bf0dcf28592239956a1fc60e488497d813",
+  "sbom": {
+    "format": "cratis-passive-profile-sbom-v1",
+    "dependencies": 0,
+    "executableComponents": 0
+  },
+  "results": [
+    {
+      "gate": "fixed-revision-digest-and-preview-version-boundary",
+      "status": "PASS"
+    },
+    {
+      "gate": "deterministic-generation-and-archive-byte-parity",
+      "opportunities": 11,
+      "status": "PASS"
+    },
+    {
+      "gate": "pi-npm-private-install-update-rollback-uninstall-context-preservation",
+      "version": "10.9.2",
+      "status": "PASS"
+    },
+    {
+      "gate": "pi-extracted-package-install-list-remove",
+      "version": "0.84.2",
+      "status": "PASS"
+    },
+    {
+      "gate": "codex-preview-installation-not-available",
+      "status": "PASS"
+    },
+    {
+      "gate": "passive-sbom-no-dependencies-or-executables",
+      "status": "PASS"
+    }
+  ],
+  "limitations": [
+    "Approval-pending review evidence only; no target/profile/source contract approval is inferred.",
+    "Claude, Codex, Copilot, Cursor, Gemini, Grok, DeepSeek Harness, Kiro, and Junie archives have deterministic byte-parity verification but were not installed from these archives in this run.",
+    "The Pi package is npm-private and assets are not a supported installation endpoint, release, npm publication, or marketplace submission.",
+    "Real public consumer canary remains pending Workflows#71."
+  ],
+  "approvalEligible": false,
+  "installationSupported": false,
+  "publicationEligible": false,
+  "promotionEligible": false
+}

--- a/tooling/generate-repository-inventory.mjs
+++ b/tooling/generate-repository-inventory.mjs
@@ -99,6 +99,8 @@ const unexpectedUntracked = admittedUntracked.filter(
             /^\.github\/ISSUE_TEMPLATE\//.test(path) ||
             path ===
                 ".github/workflows/distribution-approved-profile-release.yml" ||
+            path ===
+                ".github/workflows/distribution-fundamentals-preview-assets.yml" ||
             path === ".github/workflows/distribution-canary-rollback.yml" ||
             path === ".github/workflows/engineering-distribution-fixture.yml" ||
             path === ".github/workflows/distribution-generated-update.yml" ||
@@ -476,6 +478,7 @@ const definitions = [
         id: "repository-validation-workflow",
         sourcePathPatterns: [
             ".github/workflows/distribution-approved-profile-release.yml",
+            ".github/workflows/distribution-fundamentals-preview-assets.yml",
             ".github/workflows/distribution-canary-rollback.yml",
             ".github/workflows/engineering-distribution-fixture.yml",
             ".github/workflows/distribution-generated-update.yml",

--- a/tooling/package-fundamentals-preview-assets.mjs
+++ b/tooling/package-fundamentals-preview-assets.mjs
@@ -14,7 +14,7 @@ import {
     writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, join, relative, resolve } from "node:path";
+import { join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { gunzipSync, gzipSync } from "node:zlib";
 import {
@@ -30,6 +30,10 @@ const targetId = "cratis-fundamentals-concept";
 const sourceId = "add-concept";
 const artifactId = "cratis-fundamentals-concept-preview";
 const packageName = "@cratis/ai-fundamentals";
+const requiredSourceRevision =
+    "e9d161a70e25334bb468a33240bcf00f03f87522";
+const requiredSourceContentDigest =
+    "f7f7c2c110b3ff3f1b5921ad51fffc449a448bb49aaec2626ecc4d391e9d78a1";
 
 function sha256(content) {
     return createHash("sha256").update(content).digest("hex");
@@ -50,7 +54,7 @@ function writeJson(path, value) {
 }
 
 function walkFiles(root, current = root) {
-    return readdirSync(current, { withFileTypes: true }).flatMap(entry => {
+    return readdirSync(current, { withFileTypes: true }).flatMap((entry) => {
         const path = join(current, entry.name);
         if (entry.isDirectory()) return walkFiles(root, path);
         if (!entry.isFile())
@@ -69,7 +73,11 @@ function writeOctal(header, offset, length, value) {
 
 function splitTarPath(path) {
     if (Buffer.byteLength(path) <= 100) return { name: path, prefix: "" };
-    for (let index = path.lastIndexOf("/"); index > 0; index = path.lastIndexOf("/", index - 1)) {
+    for (
+        let index = path.lastIndexOf("/");
+        index > 0;
+        index = path.lastIndexOf("/", index - 1)
+    ) {
         const prefix = path.slice(0, index);
         const name = path.slice(index + 1);
         if (Buffer.byteLength(name) <= 100 && Buffer.byteLength(prefix) <= 155)
@@ -127,7 +135,7 @@ export function readTarGzip(content) {
     let offset = 0;
     while (offset + 512 <= tar.length) {
         const header = tar.subarray(offset, offset + 512);
-        if (header.every(byte => byte === 0)) break;
+        if (header.every((byte) => byte === 0)) break;
         const expectedChecksum = parseOctal(header.subarray(148, 156));
         const checksumHeader = Buffer.from(header);
         checksumHeader.fill(0x20, 148, 156);
@@ -179,21 +187,32 @@ function loadPreviewAuthority(repositoryRoot) {
     const profiles = readJson(
         join(repositoryRoot, "distribution/profile-catalog.json"),
     );
-    const profile = profiles.publicProfiles.find(candidate => candidate.id === profileId);
-    const targets = readJson(join(repositoryRoot, "catalog/v2/targets.json")).targets;
-    const target = targets.find(candidate => candidate.id === targetId);
-    const sources = readJson(join(repositoryRoot, "catalog/v2/sources.json")).sources;
-    const source = sources.find(candidate => candidate.id === sourceId);
-    const artifacts = readJson(join(repositoryRoot, "catalog/v2/artifacts.json")).artifacts;
-    const artifact = artifacts.find(candidate => candidate.id === artifactId);
+    const profile = profiles.publicProfiles.find(
+        (candidate) => candidate.id === profileId,
+    );
+    const targets = readJson(
+        join(repositoryRoot, "catalog/v2/targets.json"),
+    ).targets;
+    const target = targets.find((candidate) => candidate.id === targetId);
+    const sources = readJson(
+        join(repositoryRoot, "catalog/v2/sources.json"),
+    ).sources;
+    const source = sources.find((candidate) => candidate.id === sourceId);
+    const artifacts = readJson(
+        join(repositoryRoot, "catalog/v2/artifacts.json"),
+    ).artifacts;
+    const artifact = artifacts.find((candidate) => candidate.id === artifactId);
     if (
         profile?.state !== "preview-source-candidate" ||
-        JSON.stringify(profile.availableTargets) !== JSON.stringify([targetId]) ||
+        JSON.stringify(profile.availableTargets) !==
+            JSON.stringify([targetId]) ||
         target?.approval?.state !== "candidate" ||
         target.includeInRuntime !== false ||
         target.sourceSkillIds.length !== 1 ||
         target.sourceSkillIds[0] !== sourceId ||
         source?.audience !== "public" ||
+        source.sourceRevision !== requiredSourceRevision ||
+        source.contentDigest !== requiredSourceContentDigest ||
         source.publicationApproval !== false ||
         artifact?.fixtureOnly !== true ||
         artifact.materializationAllowed !== true ||
@@ -205,7 +224,7 @@ function loadPreviewAuthority(repositoryRoot) {
     )
         throw new Error("Fundamentals preview authority changed");
     const contents = new Map(
-        source.bundledPaths.map(path => [
+        source.bundledPaths.map((path) => [
             path,
             execFileSync("git", ["show", `${source.sourceRevision}:${path}`], {
                 cwd: repositoryRoot,
@@ -222,7 +241,7 @@ function loadPreviewAuthority(repositoryRoot) {
         artifact,
         skill: {
             name: targetId,
-            files: source.bundledPaths.map(path => ({
+            files: source.bundledPaths.map((path) => ({
                 path: path.slice(prefix.length),
                 content: contents.get(path),
             })),
@@ -236,6 +255,10 @@ export function packageFundamentalsPreviewAssets({
     version = "0.1.0-preview.1",
 } = {}) {
     if (!outputRoot) throw new Error("outputRoot is required");
+    if (!/^0\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-preview\.(0|[1-9][0-9]*)$/.test(version))
+        throw new Error(
+            "Preview asset version must match 0.MINOR.PATCH-preview.N",
+        );
     const root = resolve(outputRoot);
     if (existsSync(root))
         throw new Error(`Preview asset output must not exist: ${root}`);
@@ -253,6 +276,8 @@ export function packageFundamentalsPreviewAssets({
             packageName,
             description: "Cratis Fundamentals concept preview",
             skills: [authority.skill],
+            codexInstallationPolicy: "NOT_AVAILABLE",
+            piPrivate: true,
         });
         const assets = [];
         for (const harness of passiveHarnesses) {
@@ -267,9 +292,9 @@ export function packageFundamentalsPreviewAssets({
                 const archivePath = pathPrefix ? `${pathPrefix}/${path}` : path;
                 if (
                     !archiveFiles.has(archivePath) ||
-                    !archiveFiles.get(archivePath).equals(
-                        readFileSync(join(harnessRoot, path)),
-                    )
+                    !archiveFiles
+                        .get(archivePath)
+                        .equals(readFileSync(join(harnessRoot, path)))
                 )
                     throw new Error(`${harness}: archive byte parity failed`);
             }
@@ -339,7 +364,7 @@ export function packageFundamentalsPreviewAssets({
             ],
             dependencies: [],
             executableComponents: [],
-            assets: assets.map(asset => ({
+            assets: assets.map((asset) => ({
                 harness: asset.harness,
                 filename: asset.filename,
                 sha256: asset.sha256,
@@ -350,7 +375,7 @@ export function packageFundamentalsPreviewAssets({
             join(root, "SHA256SUMS"),
             `${checksumPaths
                 .map(
-                    path =>
+                    (path) =>
                         `${sha256(readFileSync(join(root, path)))}  ${path}`,
                 )
                 .join("\n")}\n`,

--- a/tooling/package-fundamentals-preview-assets.mjs
+++ b/tooling/package-fundamentals-preview-assets.mjs
@@ -30,8 +30,7 @@ const targetId = "cratis-fundamentals-concept";
 const sourceId = "add-concept";
 const artifactId = "cratis-fundamentals-concept-preview";
 const packageName = "@cratis/ai-fundamentals";
-const requiredSourceRevision =
-    "e9d161a70e25334bb468a33240bcf00f03f87522";
+const requiredSourceRevision = "e9d161a70e25334bb468a33240bcf00f03f87522";
 const requiredSourceContentDigest =
     "f7f7c2c110b3ff3f1b5921ad51fffc449a448bb49aaec2626ecc4d391e9d78a1";
 
@@ -255,7 +254,11 @@ export function packageFundamentalsPreviewAssets({
     version = "0.1.0-preview.1",
 } = {}) {
     if (!outputRoot) throw new Error("outputRoot is required");
-    if (!/^0\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-preview\.(0|[1-9][0-9]*)$/.test(version))
+    if (
+        !/^0\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-preview\.(0|[1-9][0-9]*)$/.test(
+            version,
+        )
+    )
         throw new Error(
             "Preview asset version must match 0.MINOR.PATCH-preview.N",
         );

--- a/tooling/package-fundamentals-preview-assets.mjs
+++ b/tooling/package-fundamentals-preview-assets.mjs
@@ -1,0 +1,386 @@
+#!/usr/bin/env node
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    readdirSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { gunzipSync, gzipSync } from "node:zlib";
+import {
+    generatePassiveProfileAdapters,
+    passiveHarnesses,
+} from "./passive-profile-adapters.mjs";
+
+const defaultRepositoryRoot = resolve(
+    fileURLToPath(new URL("..", import.meta.url)),
+);
+const profileId = "public-fundamentals";
+const targetId = "cratis-fundamentals-concept";
+const sourceId = "add-concept";
+const artifactId = "cratis-fundamentals-concept-preview";
+const packageName = "@cratis/ai-fundamentals";
+
+function sha256(content) {
+    return createHash("sha256").update(content).digest("hex");
+}
+
+function readJson(path) {
+    try {
+        return JSON.parse(readFileSync(path, "utf8"));
+    } catch (error) {
+        throw new Error(`Unable to parse preview input: ${path}`, {
+            cause: error,
+        });
+    }
+}
+
+function writeJson(path, value) {
+    writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, { flag: "wx" });
+}
+
+function walkFiles(root, current = root) {
+    return readdirSync(current, { withFileTypes: true }).flatMap(entry => {
+        const path = join(current, entry.name);
+        if (entry.isDirectory()) return walkFiles(root, path);
+        if (!entry.isFile())
+            throw new Error(`Preview asset contains a special file: ${path}`);
+        return [relative(root, path).replaceAll("\\", "/")];
+    });
+}
+
+function writeOctal(header, offset, length, value) {
+    const encoded = value.toString(8).padStart(length - 1, "0");
+    if (encoded.length >= length)
+        throw new Error(`Tar numeric value exceeds field size: ${value}`);
+    header.write(encoded, offset, length - 1, "ascii");
+    header[offset + length - 1] = 0;
+}
+
+function splitTarPath(path) {
+    if (Buffer.byteLength(path) <= 100) return { name: path, prefix: "" };
+    for (let index = path.lastIndexOf("/"); index > 0; index = path.lastIndexOf("/", index - 1)) {
+        const prefix = path.slice(0, index);
+        const name = path.slice(index + 1);
+        if (Buffer.byteLength(name) <= 100 && Buffer.byteLength(prefix) <= 155)
+            return { name, prefix };
+    }
+    throw new Error(`Tar path is too long: ${path}`);
+}
+
+function tarHeader(path, size) {
+    const header = Buffer.alloc(512, 0);
+    const { name, prefix } = splitTarPath(path);
+    header.write(name, 0, 100, "utf8");
+    writeOctal(header, 100, 8, 0o644);
+    writeOctal(header, 108, 8, 0);
+    writeOctal(header, 116, 8, 0);
+    writeOctal(header, 124, 12, size);
+    writeOctal(header, 136, 12, 0);
+    header.fill(0x20, 148, 156);
+    header.write("0", 156, 1, "ascii");
+    header.write("ustar\0", 257, 6, "ascii");
+    header.write("00", 263, 2, "ascii");
+    header.write("Cratis", 265, 32, "ascii");
+    header.write("Cratis", 297, 32, "ascii");
+    if (prefix) header.write(prefix, 345, 155, "utf8");
+    const checksum = header.reduce((sum, byte) => sum + byte, 0);
+    const encodedChecksum = checksum.toString(8).padStart(6, "0");
+    header.write(encodedChecksum, 148, 6, "ascii");
+    header[154] = 0;
+    header[155] = 0x20;
+    return header;
+}
+
+function createTarGzip(root, paths, pathPrefix = "") {
+    const chunks = [];
+    for (const path of paths) {
+        const content = readFileSync(join(root, path));
+        const archivePath = pathPrefix ? `${pathPrefix}/${path}` : path;
+        chunks.push(tarHeader(archivePath, content.length), content);
+        const remainder = content.length % 512;
+        if (remainder) chunks.push(Buffer.alloc(512 - remainder, 0));
+    }
+    chunks.push(Buffer.alloc(1024, 0));
+    return gzipSync(Buffer.concat(chunks), { level: 9, mtime: 0 });
+}
+
+function parseOctal(buffer) {
+    const value = buffer.toString("ascii").replaceAll("\0", "").trim();
+    if (!/^[0-7]*$/.test(value)) throw new Error("Tar field is not octal");
+    return value ? Number.parseInt(value, 8) : 0;
+}
+
+export function readTarGzip(content) {
+    const tar = gunzipSync(content);
+    const files = new Map();
+    let offset = 0;
+    while (offset + 512 <= tar.length) {
+        const header = tar.subarray(offset, offset + 512);
+        if (header.every(byte => byte === 0)) break;
+        const expectedChecksum = parseOctal(header.subarray(148, 156));
+        const checksumHeader = Buffer.from(header);
+        checksumHeader.fill(0x20, 148, 156);
+        const actualChecksum = checksumHeader.reduce(
+            (sum, byte) => sum + byte,
+            0,
+        );
+        if (actualChecksum !== expectedChecksum)
+            throw new Error("Tar header checksum mismatch");
+        const name = header
+            .subarray(0, 100)
+            .toString("utf8")
+            .replace(/\0.*$/u, "");
+        const prefix = header
+            .subarray(345, 500)
+            .toString("utf8")
+            .replace(/\0.*$/u, "");
+        const path = prefix ? `${prefix}/${name}` : name;
+        if (
+            !path ||
+            path.startsWith("/") ||
+            path.split("/").includes("..") ||
+            files.has(path) ||
+            header.subarray(156, 157).toString("ascii") !== "0"
+        )
+            throw new Error(`Unsafe tar entry: ${path}`);
+        const size = parseOctal(header.subarray(124, 136));
+        const start = offset + 512;
+        const end = start + size;
+        if (end > tar.length) throw new Error(`Truncated tar entry: ${path}`);
+        files.set(path, Buffer.from(tar.subarray(start, end)));
+        offset = start + Math.ceil(size / 512) * 512;
+    }
+    return files;
+}
+
+function sourceDigest(paths, contents) {
+    const hash = createHash("sha256");
+    for (const path of paths) {
+        hash.update(path);
+        hash.update("\0");
+        hash.update(contents.get(path));
+        hash.update("\0");
+    }
+    return hash.digest("hex");
+}
+
+function loadPreviewAuthority(repositoryRoot) {
+    const profiles = readJson(
+        join(repositoryRoot, "distribution/profile-catalog.json"),
+    );
+    const profile = profiles.publicProfiles.find(candidate => candidate.id === profileId);
+    const targets = readJson(join(repositoryRoot, "catalog/v2/targets.json")).targets;
+    const target = targets.find(candidate => candidate.id === targetId);
+    const sources = readJson(join(repositoryRoot, "catalog/v2/sources.json")).sources;
+    const source = sources.find(candidate => candidate.id === sourceId);
+    const artifacts = readJson(join(repositoryRoot, "catalog/v2/artifacts.json")).artifacts;
+    const artifact = artifacts.find(candidate => candidate.id === artifactId);
+    if (
+        profile?.state !== "preview-source-candidate" ||
+        JSON.stringify(profile.availableTargets) !== JSON.stringify([targetId]) ||
+        target?.approval?.state !== "candidate" ||
+        target.includeInRuntime !== false ||
+        target.sourceSkillIds.length !== 1 ||
+        target.sourceSkillIds[0] !== sourceId ||
+        source?.audience !== "public" ||
+        source.publicationApproval !== false ||
+        artifact?.fixtureOnly !== true ||
+        artifact.materializationAllowed !== true ||
+        artifact.runtimeEligible !== false ||
+        JSON.stringify(artifact.componentInventory.skills) !==
+            JSON.stringify([targetId]) ||
+        JSON.stringify(artifact.exactSourcePaths) !==
+            JSON.stringify(source.bundledPaths)
+    )
+        throw new Error("Fundamentals preview authority changed");
+    const contents = new Map(
+        source.bundledPaths.map(path => [
+            path,
+            execFileSync("git", ["show", `${source.sourceRevision}:${path}`], {
+                cwd: repositoryRoot,
+            }),
+        ]),
+    );
+    if (sourceDigest(source.bundledPaths, contents) !== source.contentDigest)
+        throw new Error("Fundamentals preview immutable source digest changed");
+    const prefix = `${source.sourcePath}/`;
+    return {
+        profile,
+        target,
+        source,
+        artifact,
+        skill: {
+            name: targetId,
+            files: source.bundledPaths.map(path => ({
+                path: path.slice(prefix.length),
+                content: contents.get(path),
+            })),
+        },
+    };
+}
+
+export function packageFundamentalsPreviewAssets({
+    repositoryRoot = defaultRepositoryRoot,
+    outputRoot,
+    version = "0.1.0-preview.1",
+} = {}) {
+    if (!outputRoot) throw new Error("outputRoot is required");
+    const root = resolve(outputRoot);
+    if (existsSync(root))
+        throw new Error(`Preview asset output must not exist: ${root}`);
+    const authority = loadPreviewAuthority(repositoryRoot);
+    const temporaryRoot = mkdtempSync(
+        join(tmpdir(), "cratis-fundamentals-preview-"),
+    );
+    const stageRoot = join(temporaryRoot, "stage");
+    mkdirSync(root, { recursive: false });
+    try {
+        const adapterManifest = generatePassiveProfileAdapters({
+            outputRoot: stageRoot,
+            version,
+            profileId,
+            packageName,
+            description: "Cratis Fundamentals concept preview",
+            skills: [authority.skill],
+        });
+        const assets = [];
+        for (const harness of passiveHarnesses) {
+            const harnessRoot = join(stageRoot, adapterManifest.roots[harness]);
+            const paths = walkFiles(harnessRoot).sort();
+            const extension = harness === "pi" ? "tgz" : "tar.gz";
+            const filename = `cratis-ai-${profileId}-${version}-${harness}.${extension}`;
+            const pathPrefix = harness === "pi" ? "package" : "";
+            const content = createTarGzip(harnessRoot, paths, pathPrefix);
+            const archiveFiles = readTarGzip(content);
+            for (const path of paths) {
+                const archivePath = pathPrefix ? `${pathPrefix}/${path}` : path;
+                if (
+                    !archiveFiles.has(archivePath) ||
+                    !archiveFiles.get(archivePath).equals(
+                        readFileSync(join(harnessRoot, path)),
+                    )
+                )
+                    throw new Error(`${harness}: archive byte parity failed`);
+            }
+            writeFileSync(join(root, filename), content, { flag: "wx" });
+            assets.push({
+                harness,
+                filename,
+                format: "tar+gzip",
+                root: adapterManifest.roots[harness],
+                size: content.length,
+                sha256: sha256(content),
+            });
+        }
+        const sourceCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+            cwd: repositoryRoot,
+            encoding: "utf8",
+        }).trim();
+        const generatorPaths = [
+            "tooling/package-fundamentals-preview-assets.mjs",
+            "tooling/passive-profile-adapters.mjs",
+        ];
+        const generatorHash = createHash("sha256");
+        for (const path of generatorPaths) {
+            generatorHash.update(path);
+            generatorHash.update("\0");
+            generatorHash.update(readFileSync(join(repositoryRoot, path)));
+            generatorHash.update("\0");
+        }
+        const generatorDigest = generatorHash.digest("hex");
+        const manifest = {
+            schemaVersion: "1.0.0",
+            state: "PREVIEW_ASSETS_APPROVAL_PENDING",
+            profileId,
+            packageName,
+            version,
+            artifactId,
+            targetId,
+            sourceId,
+            sourcePath: authority.source.sourcePath,
+            sourceRevision: authority.source.sourceRevision,
+            sourceContentDigest: authority.source.contentDigest,
+            sourceCommit,
+            generatorPaths,
+            generatorDigest,
+            assets,
+            approvalEligible: false,
+            installationSupported: false,
+            publicationEligible: false,
+            promotionEligible: false,
+        };
+        writeJson(join(root, "preview-assets.json"), manifest);
+        writeJson(join(root, "preview-sbom.json"), {
+            schemaVersion: "1.0.0",
+            format: "cratis-passive-profile-sbom-v1",
+            profileId,
+            version,
+            components: [
+                {
+                    type: "agent-skill",
+                    name: targetId,
+                    sourcePath: authority.source.sourcePath,
+                    sourceRevision: authority.source.sourceRevision,
+                    contentDigest: authority.source.contentDigest,
+                    files: authority.source.bundledPaths,
+                    license: "MIT",
+                },
+            ],
+            dependencies: [],
+            executableComponents: [],
+            assets: assets.map(asset => ({
+                harness: asset.harness,
+                filename: asset.filename,
+                sha256: asset.sha256,
+            })),
+        });
+        const checksumPaths = walkFiles(root).sort();
+        writeFileSync(
+            join(root, "SHA256SUMS"),
+            `${checksumPaths
+                .map(
+                    path =>
+                        `${sha256(readFileSync(join(root, path)))}  ${path}`,
+                )
+                .join("\n")}\n`,
+            { flag: "wx" },
+        );
+        return manifest;
+    } catch (error) {
+        rmSync(root, { recursive: true, force: true });
+        throw error;
+    } finally {
+        rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+}
+
+function main() {
+    const [outputRoot, version] = process.argv.slice(2);
+    if (!outputRoot) {
+        process.stderr.write(
+            "Usage: node tooling/package-fundamentals-preview-assets.mjs <output> [exact-preview-version]\n",
+        );
+        process.exitCode = 1;
+        return;
+    }
+    const manifest = packageFundamentalsPreviewAssets({
+        outputRoot,
+        version: version ?? "0.1.0-preview.1",
+    });
+    process.stdout.write(
+        `Packaged ${manifest.assets.length} approval-pending preview assets.\n`,
+    );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/tooling/passive-profile-adapters.mjs
+++ b/tooling/passive-profile-adapters.mjs
@@ -143,8 +143,17 @@ export function generatePassiveProfileAdapters({
     packageName,
     description,
     skills,
+    codexInstallationPolicy = "AVAILABLE",
+    piPrivate = false,
 }) {
     assertInputs({ version, profileId, packageName, skills });
+    if (
+        !["AVAILABLE", "INSTALLED_BY_DEFAULT", "NOT_AVAILABLE"].includes(
+            codexInstallationPolicy,
+        ) ||
+        typeof piPrivate !== "boolean"
+    )
+        throw new Error("Profile adapter publication policy is invalid");
     const root = resolve(outputRoot);
     if (existsSync(root))
         throw new Error(`Profile adapter output must not exist: ${root}`);
@@ -192,8 +201,10 @@ export function generatePassiveProfileAdapters({
                     path: `./plugins/${profileId}`,
                 },
                 policy: {
-                    installation: "AVAILABLE",
-                    authentication: "ON_INSTALL",
+                    installation: codexInstallationPolicy,
+                    ...(codexInstallationPolicy === "NOT_AVAILABLE"
+                        ? {}
+                        : { authentication: "ON_INSTALL" }),
                 },
                 category: "Developer Tools",
             },
@@ -282,7 +293,7 @@ export function generatePassiveProfileAdapters({
         name: packageName,
         version,
         description,
-        private: false,
+        private: piPrivate,
         license: "MIT",
         files: ["skills"],
         keywords: ["pi-package", "cratis"],

--- a/tooling/specs/fundamentals-preview-assets.spec.mjs
+++ b/tooling/specs/fundamentals-preview-assets.spec.mjs
@@ -1,0 +1,248 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+    packageFundamentalsPreviewAssets,
+    readTarGzip,
+} from "../package-fundamentals-preview-assets.mjs";
+
+function withTemporaryDirectory(callback) {
+    const root = mkdtempSync(join(tmpdir(), "cratis-preview-assets-"));
+    try {
+        return callback(root);
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+}
+
+function commandAvailable(command) {
+    try {
+        execFileSync(command, ["--version"], { stdio: "pipe" });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function assetPath(root, manifest, harness) {
+    const asset = manifest.assets.find(candidate => candidate.harness === harness);
+    if (!asset) throw new Error(`Missing ${harness} preview asset`);
+    return join(root, asset.filename);
+}
+
+function packageVersion(consumerRoot) {
+    return JSON.parse(
+        readFileSync(
+            join(
+                consumerRoot,
+                "node_modules/@cratis/ai-fundamentals/package.json",
+            ),
+            "utf8",
+        ),
+    ).version;
+}
+
+test("Fundamentals preview assets are deterministic and non-publishable", () => {
+    withTemporaryDirectory(root => {
+        const firstRoot = join(root, "first");
+        const secondRoot = join(root, "second");
+        const first = packageFundamentalsPreviewAssets({
+            outputRoot: firstRoot,
+            version: "0.1.0-preview.1",
+        });
+        const second = packageFundamentalsPreviewAssets({
+            outputRoot: secondRoot,
+            version: "0.1.0-preview.1",
+        });
+        assert.deepEqual(second, first);
+        assert.equal(first.state, "PREVIEW_ASSETS_APPROVAL_PENDING");
+        assert.equal(first.artifactId, "cratis-fundamentals-concept-preview");
+        assert.equal(first.targetId, "cratis-fundamentals-concept");
+        assert.equal(
+            first.sourceRevision,
+            "e9d161a70e25334bb468a33240bcf00f03f87522",
+        );
+        assert.equal(first.assets.length, 11);
+        assert.match(first.generatorDigest, /^[0-9a-f]{64}$/);
+        assert.deepEqual(first.generatorPaths, [
+            "tooling/package-fundamentals-preview-assets.mjs",
+            "tooling/passive-profile-adapters.mjs",
+        ]);
+        assert.equal(first.approvalEligible, false);
+        assert.equal(first.installationSupported, false);
+        assert.equal(first.publicationEligible, false);
+        assert.equal(first.promotionEligible, false);
+        for (const asset of first.assets) {
+            assert.match(asset.sha256, /^[0-9a-f]{64}$/);
+            assert.deepEqual(
+                readFileSync(join(firstRoot, asset.filename)),
+                readFileSync(join(secondRoot, asset.filename)),
+            );
+            assert(readTarGzip(readFileSync(join(firstRoot, asset.filename))).size > 0);
+        }
+        const sbom = JSON.parse(
+            readFileSync(join(firstRoot, "preview-sbom.json"), "utf8"),
+        );
+        assert.equal(sbom.format, "cratis-passive-profile-sbom-v1");
+        assert.deepEqual(sbom.dependencies, []);
+        assert.deepEqual(sbom.executableComponents, []);
+        assert.deepEqual(sbom.components.map(component => component.name), [
+            "cratis-fundamentals-concept",
+        ]);
+        const checksums = readFileSync(join(firstRoot, "SHA256SUMS"), "utf8");
+        assert(checksums.includes("preview-assets.json"));
+        assert(checksums.includes("preview-sbom.json"));
+        assert.equal(checksums.trim().split("\n").length, 13);
+    });
+});
+
+test("preview asset generation fails closed on current authority drift", () => {
+    withTemporaryDirectory(root => {
+        assert.throws(
+            () =>
+                packageFundamentalsPreviewAssets({
+                    outputRoot: join(root, "invalid"),
+                    version: "latest",
+                }),
+            /exact SemVer/,
+        );
+        const existing = join(root, "existing");
+        mkdirSync(existing);
+        assert.throws(
+            () =>
+                packageFundamentalsPreviewAssets({
+                    outputRoot: existing,
+                    version: "0.1.0-preview.1",
+                }),
+            /must not exist/,
+        );
+    });
+});
+
+test("Pi npm preview asset updates rolls back uninstalls and preserves context", () => {
+    withTemporaryDirectory(root => {
+        const firstRoot = join(root, "first");
+        const secondRoot = join(root, "second");
+        const first = packageFundamentalsPreviewAssets({
+            outputRoot: firstRoot,
+            version: "0.1.0-preview.1",
+        });
+        const second = packageFundamentalsPreviewAssets({
+            outputRoot: secondRoot,
+            version: "0.1.0-preview.2",
+        });
+        const consumer = join(root, "consumer");
+        mkdirSync(consumer);
+        writeFileSync(
+            join(consumer, "package.json"),
+            `${JSON.stringify(
+                { name: "preview-consumer", version: "1.0.0", private: true },
+                null,
+                2,
+            )}\n`,
+        );
+        const context = {
+            "AGENTS.md": "# Project instructions\n",
+            ".cratis/PROJECT.md": "# Project context\n",
+            ".cratis/ai.json": '{"version":"existing"}\n',
+            ".pi/settings.json": '{"packages":[]}\n',
+        };
+        for (const [path, content] of Object.entries(context)) {
+            mkdirSync(join(consumer, path, ".."), { recursive: true });
+            writeFileSync(join(consumer, path), content);
+        }
+        const install = tarball =>
+            execFileSync(
+                "npm",
+                [
+                    "install",
+                    tarball,
+                    "--ignore-scripts",
+                    "--no-audit",
+                    "--no-fund",
+                ],
+                { cwd: consumer, stdio: "pipe" },
+            );
+        install(assetPath(firstRoot, first, "pi"));
+        assert.equal(packageVersion(consumer), "0.1.0-preview.1");
+        install(assetPath(secondRoot, second, "pi"));
+        assert.equal(packageVersion(consumer), "0.1.0-preview.2");
+        install(assetPath(firstRoot, first, "pi"));
+        assert.equal(packageVersion(consumer), "0.1.0-preview.1");
+        execFileSync(
+            "npm",
+            [
+                "uninstall",
+                "@cratis/ai-fundamentals",
+                "--ignore-scripts",
+                "--no-audit",
+                "--no-fund",
+            ],
+            { cwd: consumer, stdio: "pipe" },
+        );
+        assert.equal(
+            existsSync(join(consumer, "node_modules/@cratis/ai-fundamentals")),
+            false,
+        );
+        for (const [path, content] of Object.entries(context))
+            assert.equal(readFileSync(join(consumer, path), "utf8"), content);
+    });
+});
+
+test(
+    "Pi loads and removes the extracted exact preview package in an isolated home",
+    { skip: !commandAvailable("pi") },
+    () => {
+        withTemporaryDirectory(root => {
+            const outputRoot = join(root, "assets");
+            const manifest = packageFundamentalsPreviewAssets({
+                outputRoot,
+                version: "0.1.0-preview.1",
+            });
+            const extractRoot = join(root, "extract");
+            mkdirSync(extractRoot);
+            execFileSync(
+                "tar",
+                ["-xzf", assetPath(outputRoot, manifest, "pi"), "-C", extractRoot],
+                { stdio: "pipe" },
+            );
+            const packageRoot = join(extractRoot, "package");
+            const isolatedHome = join(root, "home");
+            mkdirSync(isolatedHome);
+            const environment = { ...process.env, HOME: isolatedHome };
+            execFileSync("pi", ["install", packageRoot], {
+                env: environment,
+                stdio: "pipe",
+            });
+            assert(
+                execFileSync("pi", ["list"], {
+                    env: environment,
+                    encoding: "utf8",
+                }).includes(packageRoot),
+            );
+            execFileSync("pi", ["remove", packageRoot], {
+                env: environment,
+                stdio: "pipe",
+            });
+            assert(
+                execFileSync("pi", ["list"], {
+                    env: environment,
+                    encoding: "utf8",
+                }).includes("No packages installed"),
+            );
+        });
+    },
+);

--- a/tooling/specs/fundamentals-preview-assets.spec.mjs
+++ b/tooling/specs/fundamentals-preview-assets.spec.mjs
@@ -38,7 +38,9 @@ function commandAvailable(command) {
 }
 
 function assetPath(root, manifest, harness) {
-    const asset = manifest.assets.find(candidate => candidate.harness === harness);
+    const asset = manifest.assets.find(
+        (candidate) => candidate.harness === harness,
+    );
     if (!asset) throw new Error(`Missing ${harness} preview asset`);
     return join(root, asset.filename);
 }
@@ -55,8 +57,34 @@ function packageVersion(consumerRoot) {
     ).version;
 }
 
+test("recorded Fundamentals preview evidence is immutable and non-promoting", () => {
+    const evidence = JSON.parse(
+        readFileSync(
+            "distribution/evidence/local-fundamentals-preview-assets-2026-08-23.json",
+            "utf8",
+        ),
+    );
+    assert.equal(evidence.state, "PREVIEW_ASSET_STAGING_PASS_APPROVAL_PENDING");
+    assert.equal(
+        evidence.sourceCommit,
+        "7d5307a011294bebe9112d1bac39ad461c984018",
+    );
+    assert.equal(
+        evidence.sourceRevision,
+        "e9d161a70e25334bb468a33240bcf00f03f87522",
+    );
+    assert.equal(evidence.assets.length, 11);
+    assert(evidence.results.every((result) => result.status === "PASS"));
+    assert.equal(evidence.sbom.dependencies, 0);
+    assert.equal(evidence.sbom.executableComponents, 0);
+    assert.equal(evidence.approvalEligible, false);
+    assert.equal(evidence.installationSupported, false);
+    assert.equal(evidence.publicationEligible, false);
+    assert.equal(evidence.promotionEligible, false);
+});
+
 test("Fundamentals preview assets are deterministic and non-publishable", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const firstRoot = join(root, "first");
         const secondRoot = join(root, "second");
         const first = packageFundamentalsPreviewAssets({
@@ -91,7 +119,10 @@ test("Fundamentals preview assets are deterministic and non-publishable", () => 
                 readFileSync(join(firstRoot, asset.filename)),
                 readFileSync(join(secondRoot, asset.filename)),
             );
-            assert(readTarGzip(readFileSync(join(firstRoot, asset.filename))).size > 0);
+            assert(
+                readTarGzip(readFileSync(join(firstRoot, asset.filename)))
+                    .size > 0,
+            );
         }
         const sbom = JSON.parse(
             readFileSync(join(firstRoot, "preview-sbom.json"), "utf8"),
@@ -99,9 +130,36 @@ test("Fundamentals preview assets are deterministic and non-publishable", () => 
         assert.equal(sbom.format, "cratis-passive-profile-sbom-v1");
         assert.deepEqual(sbom.dependencies, []);
         assert.deepEqual(sbom.executableComponents, []);
-        assert.deepEqual(sbom.components.map(component => component.name), [
-            "cratis-fundamentals-concept",
-        ]);
+        assert.deepEqual(
+            sbom.components.map((component) => component.name),
+            ["cratis-fundamentals-concept"],
+        );
+        const piFiles = readTarGzip(
+            readFileSync(assetPath(firstRoot, first, "pi")),
+        );
+        const piPackage = JSON.parse(
+            piFiles.get("package/package.json").toString("utf8"),
+        );
+        assert.equal(piPackage.name, "@cratis/ai-fundamentals");
+        assert.equal(piPackage.private, true);
+        assert.equal(piPackage.scripts, undefined);
+        assert.equal(piPackage.dependencies, undefined);
+        const codexFiles = readTarGzip(
+            readFileSync(assetPath(firstRoot, first, "codex")),
+        );
+        const codexMarketplace = JSON.parse(
+            codexFiles
+                .get(".agents/plugins/marketplace.json")
+                .toString("utf8"),
+        );
+        assert.equal(
+            codexMarketplace.plugins[0].policy.installation,
+            "NOT_AVAILABLE",
+        );
+        assert.equal(
+            codexMarketplace.plugins[0].policy.authentication,
+            undefined,
+        );
         const checksums = readFileSync(join(firstRoot, "SHA256SUMS"), "utf8");
         assert(checksums.includes("preview-assets.json"));
         assert(checksums.includes("preview-sbom.json"));
@@ -110,15 +168,20 @@ test("Fundamentals preview assets are deterministic and non-publishable", () => 
 });
 
 test("preview asset generation fails closed on current authority drift", () => {
-    withTemporaryDirectory(root => {
-        assert.throws(
-            () =>
-                packageFundamentalsPreviewAssets({
-                    outputRoot: join(root, "invalid"),
-                    version: "latest",
-                }),
-            /exact SemVer/,
-        );
+    withTemporaryDirectory((root) => {
+        for (const version of ["latest", "1.0.0", "0.1.0-rc.1"]) {
+            assert.throws(
+                () =>
+                    packageFundamentalsPreviewAssets({
+                        outputRoot: join(
+                            root,
+                            `invalid-${version.replaceAll(/[^a-z0-9]/gi, "-")}`,
+                        ),
+                        version,
+                    }),
+                /must match 0\.MINOR\.PATCH-preview\.N/,
+            );
+        }
         const existing = join(root, "existing");
         mkdirSync(existing);
         assert.throws(
@@ -133,7 +196,7 @@ test("preview asset generation fails closed on current authority drift", () => {
 });
 
 test("Pi npm preview asset updates rolls back uninstalls and preserves context", () => {
-    withTemporaryDirectory(root => {
+    withTemporaryDirectory((root) => {
         const firstRoot = join(root, "first");
         const secondRoot = join(root, "second");
         const first = packageFundamentalsPreviewAssets({
@@ -164,7 +227,7 @@ test("Pi npm preview asset updates rolls back uninstalls and preserves context",
             mkdirSync(join(consumer, path, ".."), { recursive: true });
             writeFileSync(join(consumer, path), content);
         }
-        const install = tarball =>
+        const install = (tarball) =>
             execFileSync(
                 "npm",
                 [
@@ -202,47 +265,45 @@ test("Pi npm preview asset updates rolls back uninstalls and preserves context",
     });
 });
 
-test(
-    "Pi loads and removes the extracted exact preview package in an isolated home",
-    { skip: !commandAvailable("pi") },
-    () => {
-        withTemporaryDirectory(root => {
-            const outputRoot = join(root, "assets");
-            const manifest = packageFundamentalsPreviewAssets({
-                outputRoot,
-                version: "0.1.0-preview.1",
-            });
-            const extractRoot = join(root, "extract");
-            mkdirSync(extractRoot);
-            execFileSync(
-                "tar",
-                ["-xzf", assetPath(outputRoot, manifest, "pi"), "-C", extractRoot],
-                { stdio: "pipe" },
-            );
-            const packageRoot = join(extractRoot, "package");
-            const isolatedHome = join(root, "home");
-            mkdirSync(isolatedHome);
-            const environment = { ...process.env, HOME: isolatedHome };
-            execFileSync("pi", ["install", packageRoot], {
-                env: environment,
-                stdio: "pipe",
-            });
-            assert(
-                execFileSync("pi", ["list"], {
-                    env: environment,
-                    encoding: "utf8",
-                }).includes(packageRoot),
-            );
-            execFileSync("pi", ["remove", packageRoot], {
-                env: environment,
-                stdio: "pipe",
-            });
-            assert(
-                execFileSync("pi", ["list"], {
-                    env: environment,
-                    encoding: "utf8",
-                }).includes("No packages installed"),
-            );
+test("Pi loads and removes the extracted exact preview package in an isolated home", {
+    skip: !commandAvailable("pi"),
+}, () => {
+    withTemporaryDirectory((root) => {
+        const outputRoot = join(root, "assets");
+        const manifest = packageFundamentalsPreviewAssets({
+            outputRoot,
+            version: "0.1.0-preview.1",
         });
-    },
-);
+        const extractRoot = join(root, "extract");
+        mkdirSync(extractRoot);
+        execFileSync(
+            "tar",
+            ["-xzf", assetPath(outputRoot, manifest, "pi"), "-C", extractRoot],
+            { stdio: "pipe" },
+        );
+        const packageRoot = join(extractRoot, "package");
+        const isolatedHome = join(root, "home");
+        mkdirSync(isolatedHome);
+        const environment = { ...process.env, HOME: isolatedHome };
+        execFileSync("pi", ["install", packageRoot], {
+            env: environment,
+            stdio: "pipe",
+        });
+        assert(
+            execFileSync("pi", ["list"], {
+                env: environment,
+                encoding: "utf8",
+            }).includes(packageRoot),
+        );
+        execFileSync("pi", ["remove", packageRoot], {
+            env: environment,
+            stdio: "pipe",
+        });
+        assert(
+            execFileSync("pi", ["list"], {
+                env: environment,
+                encoding: "utf8",
+            }).includes("No packages installed"),
+        );
+    });
+});

--- a/tooling/specs/fundamentals-preview-assets.spec.mjs
+++ b/tooling/specs/fundamentals-preview-assets.spec.mjs
@@ -3,6 +3,7 @@
 
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
     existsSync,
     mkdirSync,
@@ -65,10 +66,20 @@ test("recorded Fundamentals preview evidence is immutable and non-promoting", ()
         ),
     );
     assert.equal(evidence.state, "PREVIEW_ASSET_STAGING_PASS_APPROVAL_PENDING");
-    assert.equal(
-        evidence.sourceCommit,
-        "7d5307a011294bebe9112d1bac39ad461c984018",
-    );
+    assert.match(evidence.sourceCommit, /^[0-9a-f]{40}$/);
+    const generatorHash = createHash("sha256");
+    for (const path of [
+        "tooling/package-fundamentals-preview-assets.mjs",
+        "tooling/passive-profile-adapters.mjs",
+    ]) {
+        generatorHash.update(path);
+        generatorHash.update("\0");
+        generatorHash.update(
+            execFileSync("git", ["show", `${evidence.sourceCommit}:${path}`]),
+        );
+        generatorHash.update("\0");
+    }
+    assert.equal(evidence.generatorDigest, generatorHash.digest("hex"));
     assert.equal(
         evidence.sourceRevision,
         "e9d161a70e25334bb468a33240bcf00f03f87522",
@@ -148,9 +159,7 @@ test("Fundamentals preview assets are deterministic and non-publishable", () => 
             readFileSync(assetPath(firstRoot, first, "codex")),
         );
         const codexMarketplace = JSON.parse(
-            codexFiles
-                .get(".agents/plugins/marketplace.json")
-                .toString("utf8"),
+            codexFiles.get(".agents/plugins/marketplace.json").toString("utf8"),
         );
         assert.equal(
             codexMarketplace.plugins[0].policy.installation,

--- a/tooling/specs/workflow-safety.spec.mjs
+++ b/tooling/specs/workflow-safety.spec.mjs
@@ -33,6 +33,35 @@ test("verification workflow covers every release-relevant source", () => {
     }
 });
 
+test("Fundamentals preview workflow is read-only short-lived and non-publishing", () => {
+    const workflow = readFileSync(
+        ".github/workflows/distribution-fundamentals-preview-assets.yml",
+        "utf8",
+    );
+    for (const required of [
+        "permissions:\n  contents: read",
+        "fetch-depth: 0",
+        "package-fundamentals-preview-assets.mjs",
+        "PREVIEW_ASSETS_APPROVAL_PENDING",
+        "preview-assets.json').approvalEligible",
+        "preview-assets.json').publicationEligible",
+        "preview-assets.json').promotionEligible",
+        "retention-days: 7",
+        "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
+    ])
+        assert(workflow.includes(required), required);
+    for (const forbidden of [
+        "id-token: write",
+        "contents: write",
+        "pull-requests: write",
+        "npm publish",
+        "gh release create",
+        "git push",
+        "secrets:",
+    ])
+        assert.equal(workflow.includes(forbidden), false, forbidden);
+});
+
 test("approved profile workflow is bot-scoped and keeps publication separate", () => {
     const workflow = readFileSync(
         ".github/workflows/distribution-approved-profile-release.yml",


### PR DESCRIPTION
# Summary

Packages the first public candidate into deterministic, short-lived, explicitly approval-pending per-harness review assets so owner review and the first canary can proceed immediately when authorized.

## Changed

- Generate 11 root-native Agent Skills/Claude/Codex/Copilot/Cursor/DeepSeek/Gemini/Grok/Junie/Kiro/Pi archives (#148)
- Bind exact immutable source revision and catalog digest (#148)
- Emit preview manifest, passive SBOM and checksums (#148)
- Add npm-private Pi tgz install/update/rollback/uninstall and extracted Pi lifecycle evidence (#148)
- Preserve AGENTS, project context, subscription and Pi settings bytes (#148)
- Add read-only seven-day hosted review workflow with no secrets/write/publication authority (#148)
- Mark Codex installation NOT_AVAILABLE and reject stable/non-preview versions (#148)

## State

`PREVIEW_ASSETS_APPROVAL_PENDING`: approval, supported installation, publication and promotion are false. Non-Pi archives have deterministic byte parity only and are not support claims.
