### PR TITLE
Add complete profile adoption guidance

### DIFF
--- a/.ai/rules/general.md
+++ b/.ai/rules/general.md
@@ -40,11 +40,21 @@ Where a rule is convention rather than contract, this file says so. Do not claim
 
 ## Project-Specific Instructions
 
-This corpus is the shared, generic instruction set common to every Cratis repository. Individual projects need extra context that does not belong here — credentials, HTTP headers, environment endpoints, and other local conventions ("Product policy" above).
+This corpus is the shared, generic instruction set common to every Cratis
+repository. Individual projects need extra context that does not belong here,
+such as product composition, approved environment names, directions for
+obtaining credentials, and other local conventions ("Product policy" above).
 
-- Always look for a `.agents/PROJECT.md` file at the repository root. If it exists, read it and treat its contents as additional, project-specific instructions.
-- `.agents/PROJECT.md` lives in the **consuming project** and is never part of this shared corpus — it is the designated home for anything project-local, such as the HTTP headers or credentials needed to talk to that project's APIs.
-- When its guidance conflicts with these shared instructions, the project-specific file wins for that repository.
+- Read `.cratis/PROJECT.md` as the canonical project-specific context when it
+  exists.
+- Read `.agents/PROJECT.md` only as the documented legacy fallback when
+  `.cratis/PROJECT.md` does not exist; never merge both contexts.
+- Project context may explain which approved secret mechanism or local setup to
+  use, but it must never contain credential values, tokens, keys, passwords, or
+  other secrets.
+- Project-specific guidance wins when it deliberately narrows shared behavior,
+  but it may not weaken organization security, authorization, or required
+  quality gates.
 
 ## Collaboration Default
 
@@ -90,11 +100,21 @@ place while the replacement distribution remains under canary; do not restart
 legacy all-to-all propagation and do not delete legacy adapters before reviewed
 retirement evidence exists.
 
-The consuming repository owns its project facts and minimal host bootstraps.
-Use `.cratis/PROJECT.md` as canonical project context when that migration is
-active, with `.agents/PROJECT.md` only as the documented legacy fallback. Never
-merge, overwrite, or remove project context as a side effect of installing,
-updating, rolling back, or uninstalling shared AI capabilities.
+Shared public product and `engineering-*` packages contain only public-safe
+Cratis behavior. The `engineering-` prefix identifies the maintainer audience;
+it does not imply confidential package contents or a private registry.
+
+The consuming repository owns its project facts, confidential behavior, local
+skills, and minimal host bootstraps. Use `.cratis/PROJECT.md` as canonical
+project context when that migration is active, `.agents/skills/` for private or
+repository-specific local workflows, and `.agents/PROJECT.md` only as the
+documented legacy context fallback. Never merge, overwrite, or remove these
+local files as a side effect of installing, updating, rolling back, or
+uninstalling shared AI capabilities.
+
+Keep confidential and repository-specific behavior local. Generalize and remove
+private facts before proposing a reusable improvement to `Cratis/AI`; never
+reverse-sync a private repository's AI tree or generated adapters.
 
 Update shared AI by changing a version pin through the approved organization or
 host mechanism. Canary the new version, observe its behavior and gates, and roll

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
@@ -2084,3 +2084,53 @@ The bounded approval request on AI#148 and first-profile request on AI#165 now
 name exact revision/digest and a copy-ready approve/reject response. Workflows#73
 tracks the downstream subscriber-update controller after Stagehand#39 closed
 `NOT_PLANNED`.
+
+## 53. Public-safe engineering and private local overlays — 2026-08-23
+
+Maintainer direction accepts a simpler confidentiality model:
+
+- publish general, non-secret Cratis product and engineering behavior;
+- treat the `engineering-` prefix as an audience marker, not a confidentiality
+  or private-registry marker;
+- keep private repository architecture, deployment, roadmap, infrastructure,
+  incidents, customers, support, credentials, and exceptions in repository-local
+  AI overlays;
+- upstream only generalized public-safe behavior after removing private facts;
+- do not create a centralized confidential package or reverse-sync private AI
+  trees unless a later concrete cross-repository requirement proves necessary.
+
+`distribution/profile-catalog.json` is expanded from the first-release scaffold
+to 32 public and 20 public-safe engineering profiles. Coverage now explicitly
+includes Fundamentals, Arc, Arc React, Components, Chronicle core and .NET /
+Kotlin / Elixir / TypeScript / Python clients, Java authority gap, Arc identity,
+Chronicle compliance and multi-tenancy, Arc EF Core, Cratis CLI and terminal
+Workbench, Chronicle browser Workbench, Lens, Screenplay, Stage, public Studio,
+Chronicle MCP passive guidance, language-agnostic / .NET /
+TypeScript Specifications, Arc-only, Chronicle-only, Arc + Chronicle, React,
+full application, and Screenplay → Stage compositions.
+
+Engineering profiles cover application, every listed product/framework,
+Chronicle clients, CLI, Lens, Screenplay, Stage, Studio, Stagehand, Chronicle
+MCP, Specifications, documentation, AI, and Workflows. Every engineering profile
+is required to be public-visible, reject confidential content, compose
+`engineering-base` where applicable, and expect a repository-local overlay.
+
+Canonical adoption guidance now includes:
+
+- `Documentation/adopting-cratis-ai.md` for consuming developers;
+- `Documentation/adopting-cratis-ai-for-maintainers.md` for Cratis repositories;
+- `Documentation/private-repository-overlays.md` for private facts and skills;
+- `Documentation/profile-reference.md` for the complete product/profile map;
+- exact subscription examples for Arc-only, Arc React + Components, full
+  application, Chronicle Kotlin, Specifications, Chronicle framework, and
+  private Studio;
+- a complete non-secret private overlay example with `AGENTS.md`,
+  `.cratis/PROJECT.md`, `.cratis/ai.json`, `.agents/skills`, and Pi settings.
+
+The universal Shared AI Distribution rule now makes the public-safe/local-private
+boundary normative and resolves canonical `.cratis/PROJECT.md` versus legacy
+`.agents/PROJECT.md` precedence without permitting credential values. Product
+coverage grows to 15 products, 10 languages, and 71 capabilities; all remain
+unclaimed until authoritative source and release gates pass. Profile states are
+1 preview candidate, 19 planned source migrations, 24 content gaps, 1 authority
+gap, 6 planned compositions, and 1 owner-review pending. No new target approval or publication state is implied.

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
@@ -661,3 +661,23 @@ handover section 51.
   keep Cursor/Kiro/Junie structural and DeepSeek preview labels until reverified.
 - [ ] Keep companion corrective evaluation, broad legacy migration, publication,
   promotion, and retirement off the first-release critical path.
+
+### 2026-08-23 — Public-safe engineering adoption model
+
+- [x] Accept public-safe shared engineering packages plus private
+  repository-local overlays; do not create a confidential shared package by
+  default.
+- [x] Make `engineering-` an audience marker, require public visibility and no
+  confidential content, and keep private facts/skills under project ownership.
+- [x] Expand the profile catalog to cover Arc EF Core/React, client languages,
+  CLI/terminal Workbench, Chronicle browser Workbench, Lens, Screenplay, Stage,
+  Studio, Chronicle MCP, identity, compliance, multi-tenancy, Specifications,
+  and Arc-only/Chronicle-only/composed applications.
+- [x] Add developer, maintainer, private-overlay, and complete profile-reference
+  documentation with validated subscription and local overlay examples.
+- [x] Extend product coverage to Lens, Screenplay, Stage, Studio, Chronicle MCP,
+  TypeScript/Python clients, and Python language tracking without support claims.
+- [ ] Obtain owners and authoritative sources incrementally through AI#165;
+  retain content/authority gaps rather than synthesize product behavior.
+- [ ] Migrate the existing 39 legacy skill sources by product family after the
+  first Fundamentals release candidate is approved and canaried.

--- a/Documentation/adopting-cratis-ai-for-maintainers.md
+++ b/Documentation/adopting-cratis-ai-for-maintainers.md
@@ -1,0 +1,117 @@
+# Adopt Cratis AI in a Cratis repository
+
+Cratis-maintainer profiles are public-safe shared engineering packages. The
+`engineering-` prefix identifies the audience; it does not mean the package
+contains confidential information or requires a private registry.
+
+Packages are not published yet. Use this guide to prepare repositories and
+review the intended adoption contract.
+
+## Select shared engineering profiles
+
+Choose the narrowest product/repository profile:
+
+| Repository | Shared profile |
+| --- | --- |
+| Cratis/Fundamentals | `engineering-fundamentals` |
+| Cratis/Arc backend | `engineering-arc` |
+| Arc React packages | `engineering-arc-react` |
+| Cratis/Components | `engineering-components` |
+| Cratis/Chronicle kernel | `engineering-chronicle` |
+| Chronicle client repository | `engineering-chronicle-clients` |
+| Cratis/cli | `engineering-cratis-cli` |
+| Cratis/Lens | `engineering-lens` |
+| Cratis/Screenplay | `engineering-screenplay` |
+| Cratis/Stage | `engineering-stage` |
+| Cratis/Specifications | `engineering-specifications` |
+| Documentation | `engineering-documentation` |
+| Cratis/AI | `engineering-ai` |
+| Cratis/Workflows | `engineering-workflows` |
+| Private Studio repository | `engineering-studio` plus local overlay |
+| Private Stagehand repository | `engineering-stagehand` plus local overlay |
+
+Every engineering profile composes `engineering-base`. A generated profile
+artifact contains only approved public-safe skills and references.
+
+## Prepare the repository
+
+1. Add `.cratis/ai.json` with the exact profile and release version.
+2. Add or refine `.cratis/PROJECT.md` with repository-owned product facts.
+3. Keep `AGENTS.md` as a minimal bootstrap and repository policy surface.
+4. Put private or repository-specific skills under `.agents/skills`.
+5. Add only thin host adapters required by supported tools.
+6. Run the repository's own build, specification, documentation, security, and
+   release gates.
+
+Example Chronicle framework subscription:
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "channel": "cratis-engineering",
+  "version": "1.0.0",
+  "profiles": ["engineering-chronicle"],
+  "harnesses": ["claude", "codex", "copilot", "pi"],
+  "updatePolicy": "reviewed-pull-request",
+  "projectContext": ".cratis/PROJECT.md"
+}
+```
+
+## Separate shared behavior from product facts
+
+| Put in shared Cratis AI | Keep in the product repository |
+| --- | --- |
+| Public API workflow and trigger intent | Exact current APIs and implementation evidence |
+| General contributor conventions | Build/test/release commands specific to the repository |
+| Public-safe specification/review guidance | Unreleased behavior and private architecture |
+| Profile composition | Credentials, endpoints, infrastructure, incidents, customers |
+| Cross-harness package adapters | Repository-local exceptions and operational policy |
+
+Product facts may inform a shared skill only through an immutable source
+contract and product-owner review.
+
+## Work in a private repository
+
+Install the same public-safe engineering package. Add a private overlay locally;
+do not request a special package merely because the repository is private.
+
+Private Studio example:
+
+```text
+AGENTS.md
+.cratis/PROJECT.md
+.cratis/ai.json
+.agents/skills/studio-local-release/SKILL.md
+.pi/settings.json
+```
+
+See the complete
+[`private-repository-overlay`](./examples/private-repository-overlay/README.md)
+example.
+
+## Upstream an improvement
+
+Classify the improvement before moving it:
+
+- **General and public-safe:** propose it to `Cratis/AI`.
+- **Product fact:** update the product repository first, then cite its immutable
+  revision in the AI proposal.
+- **Private/repository-specific:** keep it local.
+- **Mixed:** split public workflow from private facts before proposing it.
+
+A consuming repository never publishes a Cratis AI package and never pushes
+local generated adapters back into `Cratis/AI`.
+
+## Review an update pull request
+
+Verify that the pull request:
+
+- changes only exact subscription/package settings;
+- points to an immutable release with checksums and provenance;
+- contains the expected profile and skill inventory;
+- does not modify project context or local private skills;
+- passes repository-specific gates;
+- can be rolled back to the previous exact pin.
+
+Do not auto-merge profile updates. A failed canary leaves the current stable pin
+unchanged.

--- a/Documentation/adopting-cratis-ai.md
+++ b/Documentation/adopting-cratis-ai.md
@@ -1,0 +1,158 @@
+# Adopt Cratis AI in a project
+
+Use this how-to after the selected profile has a published version. Cratis AI
+packages are currently approval-pending; package commands shown here describe
+the released workflow and will fail until publication.
+
+## 1. Choose the repository scenario
+
+| Repository scenario | Start with |
+| --- | --- |
+| Fundamentals library consumer | `public-fundamentals` |
+| Arc backend without Chronicle | `public-application-arc-only` |
+| Chronicle-only .NET application | `public-application-chronicle-dotnet` |
+| Arc + React + Components without Chronicle | `public-application-react` |
+| Full Arc + Chronicle + React application | `public-application` |
+| Chronicle Kotlin client | `public-chronicle-client-kotlin` |
+| Specification library or test project | `public-specifications-dotnet` or `public-specifications-typescript` |
+| Cratis Chronicle framework repository | `engineering-chronicle` |
+| Private Studio repository | `engineering-studio` plus a private local overlay |
+
+See [Profile reference](./profile-reference.md) for the complete planned map.
+
+## 2. Add the exact subscription
+
+Create `.cratis/ai.json` in the repository. Do not use `latest`, branches, or
+floating ranges.
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "channel": "public",
+  "version": "1.0.0",
+  "profiles": ["public-application-arc-only"],
+  "harnesses": ["claude", "codex", "copilot", "pi"],
+  "updatePolicy": "reviewed-pull-request",
+  "projectContext": ".cratis/PROJECT.md"
+}
+```
+
+Use `cratis-engineering` only for Cratis-maintainer profiles. Public and
+engineering profiles cannot appear in the same subscription; use separate
+reviewed subscriptions or generated artifacts when both audiences are needed.
+
+## 3. Add project context
+
+Create `.cratis/PROJECT.md` with facts owned by this repository:
+
+```markdown
+# Project context
+
+This is an Arc-only application. Do not assume Chronicle event sourcing.
+
+Run the solution's Debug and Release builds, relevant specifications, frontend
+lint/tests, and build before declaring work complete.
+```
+
+Keep credentials out of project context. Record only how to obtain or use them
+through the approved secret mechanism.
+
+## 4. Add a minimal bootstrap
+
+`AGENTS.md` should locate project context and selected shared behavior rather
+than copy the shared corpus:
+
+```markdown
+# Repository AI bootstrap
+
+Read `.cratis/PROJECT.md` before planning or changing code. Follow the exact
+Cratis AI profiles pinned in `.cratis/ai.json`. Repository-specific guidance
+wins when it deliberately narrows shared guidance.
+```
+
+Add thin host-native adapters only where a host cannot discover these files or
+package skills directly.
+
+## 5. Install the host package
+
+### Pi
+
+Install an exact project package:
+
+```bash
+pi install -l npm:@cratis/ai-application-arc@1.0.0
+pi list
+```
+
+Commit the resulting `.pi/settings.json` after review. Pi installs missing
+project packages after the repository is trusted.
+
+To load only selected skills from a broader package, use package-root-relative
+filters:
+
+```json
+{
+  "packages": [
+    {
+      "source": "npm:@cratis/ai-chronicle@1.0.0",
+      "skills": [
+        "skills/cratis-chronicle-projection",
+        "skills/cratis-chronicle-read-model"
+      ],
+      "extensions": []
+    }
+  ],
+  "enableSkillCommands": true
+}
+```
+
+### Other harnesses
+
+Use the root-native artifact generated for the exact profile, version, and
+harness. Do not point a host at the mixed `Cratis/AI` source repository or the
+multi-profile distribution root.
+
+The release page supplies exact Claude, Codex, Copilot, Cursor, Gemini, Grok,
+DeepSeek Harness, Kiro, Junie, and Agent Skills commands after each host is
+actually tested.
+
+## 6. Verify adoption
+
+Before merging adoption:
+
+1. confirm package/profile/version match `.cratis/ai.json`;
+2. inspect the package manifest, provenance, and checksums;
+3. start the selected harness in a clean project session;
+4. verify one positive skill trigger and one near-miss exclusion;
+5. run repository build, specifications, lint, and test gates;
+6. confirm `AGENTS.md`, `.cratis/PROJECT.md`, local skills, credentials, and
+   unrelated settings are unchanged;
+7. remove the package and confirm the repository remains usable.
+
+## 7. Update and roll back
+
+Updates arrive as normal pull requests. Review changes to:
+
+- `.cratis/ai.json`;
+- host-native package settings or lock files;
+- generated checksums/provenance references;
+- no shared skill or rule bodies.
+
+For Pi, move to another exact version:
+
+```bash
+pi install -l npm:@cratis/ai-application-arc@1.1.0
+```
+
+Rollback restores the previous exact version in `.cratis/ai.json` and
+`.pi/settings.json`, reruns installation, and executes the same repository gates.
+
+## 8. Improve shared behavior
+
+Do not edit generated package bytes. If an improvement is public-safe and useful
+across repositories, use the **Propose a shared Cratis AI improvement** issue in
+`Cratis/AI` with the originating repository, immutable revision, product
+authority, affected profiles, and compatibility impact.
+
+Keep confidential or repository-specific behavior local. See
+[Private repository overlays](./private-repository-overlays.md).

--- a/Documentation/ai-distribution-and-subscriptions.md
+++ b/Documentation/ai-distribution-and-subscriptions.md
@@ -4,6 +4,11 @@ Cratis AI has one controlled source for shared AI behavior, product-specific
 profiles, immutable releases, and reviewed downstream updates. It does not use
 folder propagation or automatic two-way synchronization.
 
+For step-by-step adoption, use [developer adoption](./adopting-cratis-ai.md) or
+[maintainer adoption](./adopting-cratis-ai-for-maintainers.md). Private
+repositories layer [local overlays](./private-repository-overlays.md) on the
+same public-safe shared packages.
+
 > **Current availability:** the architecture and fixture generation exist, but
 > no supported profile package has been published yet. The approval-driven
 > materializer exists but fails closed while profiles, targets, source contracts,
@@ -38,41 +43,22 @@ should not load application vertical-slice rules; a Components change should
 not load Orleans guidance; Studio and Stagehand need their own product context.
 
 The profile catalog is [`distribution/profile-catalog.json`](../distribution/profile-catalog.json).
-It defines separate public and engineering profiles.
+It defines separate public product, language-client, overlay, composition, and
+public-safe engineering profiles. See the complete
+[Profile reference](./profile-reference.md).
 
-### Public profiles
+Public coverage includes Fundamentals, Arc, Arc React, Components, Chronicle,
+Chronicle clients, identity, compliance, multi-tenancy, Cratis CLI, Lens,
+Screenplay, Stage, public Studio, Chronicle MCP guidance, and Specifications.
+Composition profiles preserve Arc-only, Chronicle-only, Arc + Chronicle, React,
+full application, and Screenplay → Stage boundaries.
 
-Public profiles help developers build with Cratis products:
-
-- `public-fundamentals`
-- `public-arc`
-- `public-chronicle`
-- `public-components`
-- `public-application`, which composes the four product profiles
-
-A repository using Chronicle without Arc subscribes only to Fundamentals and
-Chronicle. A full Arc + Chronicle + React application uses
-`public-application`.
-
-### Engineering profiles
-
-Engineering profiles add contributor behavior for Cratis-owned repositories:
-
-- `engineering-base`
-- `engineering-application`
-- `engineering-framework-fundamentals`
-- `engineering-framework-arc`
-- `engineering-framework-chronicle`
-- `engineering-framework-components`
-- `engineering-studio`
-- `engineering-stagehand`
-- `engineering-client`
-- `engineering-documentation`
-- `engineering-corpus`
-
-Profiles compose a small base rather than loading every rule and skill. Studio,
-Stagehand, client, and other content-gap profiles remain unpublished until their
-owning maintainers provide authoritative source behavior.
+Engineering profiles add public-safe contributor behavior for each Cratis
+product/repository family and compose `engineering-base`. The `engineering-`
+prefix identifies the maintainer audience, not confidentiality. Private Studio,
+Stagehand, client, customer, infrastructure, roadmap, incident, and repository
+facts remain in repository-local overlays; shared packages may not read or write
+them.
 
 ## Repository subscription
 
@@ -87,7 +73,7 @@ Chronicle framework example:
   "schemaVersion": "1.0.0",
   "channel": "cratis-engineering",
   "version": "1.0.0",
-  "profiles": ["engineering-framework-chronicle"],
+  "profiles": ["engineering-chronicle"],
   "harnesses": ["claude", "codex", "copilot", "pi"],
   "updatePolicy": "reviewed-pull-request",
   "projectContext": ".cratis/PROJECT.md"
@@ -113,9 +99,10 @@ The schema is
 Exact versions are mandatory. `latest`, branches, and floating ranges are not
 valid subscriptions.
 
-Stagehand owns the subscriber update controller tracked internally as
-`Cratis/Stagehand#39`. Its repository-scoped App discovers committed `.cratis/ai.json` files only in
-repositories where it is explicitly installed. A new release opens a normal
+Cratis/Workflows#73 tracks the subscriber update controller after the Stagehand
+proposal was closed as not planned. Its repository-scoped App will discover
+committed `.cratis/ai.json` files only in repositories where it is explicitly
+installed. A new release opens a normal
 pull request changing the subscription and host-native lock or settings files.
 It never merges automatically, pushes generated corpus folders, or receives
 broad organization write access.
@@ -255,14 +242,14 @@ that root. Representative examples are:
 ```text
 # Claude Code interactive commands
 /plugin marketplace add <extracted-claude-root>
-/plugin install engineering-framework-chronicle@cratis
+/plugin install engineering-chronicle@cratis
 
 # Codex
 codex plugin marketplace add <extracted-codex-root>
 
 # GitHub Copilot CLI
 copilot plugin marketplace add <extracted-copilot-root>
-copilot plugin install engineering-framework-chronicle@cratis
+copilot plugin install engineering-chronicle@cratis
 
 # Gemini CLI local verification before remote publication
 gemini extensions link <extracted-gemini-root>

--- a/Documentation/examples/ai-subscriptions/arc-only-application.cratis-ai.json
+++ b/Documentation/examples/ai-subscriptions/arc-only-application.cratis-ai.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": "1.0.0",
-  "channel": "cratis-engineering",
+  "channel": "public",
   "version": "1.0.0",
   "profiles": [
-    "engineering-chronicle"
+    "public-application-arc-only"
   ],
   "harnesses": [
     "claude",

--- a/Documentation/examples/ai-subscriptions/arc-react-components.cratis-ai.json
+++ b/Documentation/examples/ai-subscriptions/arc-react-components.cratis-ai.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": "1.0.0",
-  "channel": "cratis-engineering",
+  "channel": "public",
   "version": "1.0.0",
   "profiles": [
-    "engineering-chronicle"
+    "public-application-react"
   ],
   "harnesses": [
     "claude",

--- a/Documentation/examples/ai-subscriptions/chronicle-kotlin-client.cratis-ai.json
+++ b/Documentation/examples/ai-subscriptions/chronicle-kotlin-client.cratis-ai.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": "1.0.0",
-  "channel": "cratis-engineering",
+  "channel": "public",
   "version": "1.0.0",
   "profiles": [
-    "engineering-chronicle"
+    "public-chronicle-client-kotlin"
   ],
   "harnesses": [
     "claude",

--- a/Documentation/examples/ai-subscriptions/private-studio.cratis-ai.json
+++ b/Documentation/examples/ai-subscriptions/private-studio.cratis-ai.json
@@ -3,7 +3,7 @@
   "channel": "cratis-engineering",
   "version": "1.0.0",
   "profiles": [
-    "engineering-chronicle"
+    "engineering-studio"
   ],
   "harnesses": [
     "claude",

--- a/Documentation/examples/ai-subscriptions/specifications-library.cratis-ai.json
+++ b/Documentation/examples/ai-subscriptions/specifications-library.cratis-ai.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": "1.0.0",
-  "channel": "cratis-engineering",
+  "channel": "public",
   "version": "1.0.0",
   "profiles": [
-    "engineering-chronicle"
+    "public-specifications-dotnet"
   ],
   "harnesses": [
     "claude",

--- a/Documentation/examples/private-repository-overlay/.agents/skills/studio-local-release/SKILL.md
+++ b/Documentation/examples/private-repository-overlay/.agents/skills/studio-local-release/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: studio-local-release
+description: Run the private Studio repository's local release preparation workflow. Use only inside this repository after reading its project context.
+---
+
+# Studio local release preparation
+
+Read `.cratis/PROJECT.md` and the repository's current release documentation.
+Confirm the requested release scope and authorization before changing files.
+
+Use only repository-local commands and approved secret mechanisms. Never echo,
+record, transmit, or commit credentials. Stop if required authority, environment,
+or release facts are missing.
+
+Run the exact repository build, specification, security, packaging, and release
+candidate gates. Report inspectable outcomes and leave publication to the
+repository's protected release workflow.

--- a/Documentation/examples/private-repository-overlay/.cratis/PROJECT.md
+++ b/Documentation/examples/private-repository-overlay/.cratis/PROJECT.md
@@ -1,0 +1,13 @@
+# Private Studio repository context
+
+This repository owns private Studio implementation behavior. Shared Cratis AI
+packages provide only public-safe engineering conventions.
+
+## Local boundaries
+
+- Treat deployment topology, infrastructure identifiers, unreleased APIs,
+  incidents, customers, and roadmap information as confidential.
+- Use repository-local source and documentation as authority.
+- Use the approved organization secret mechanism for credentials; never write
+  secret values in this file.
+- Run this repository's own build, specification, security, and release gates.

--- a/Documentation/examples/private-repository-overlay/.cratis/ai.json
+++ b/Documentation/examples/private-repository-overlay/.cratis/ai.json
@@ -3,7 +3,7 @@
   "channel": "cratis-engineering",
   "version": "1.0.0",
   "profiles": [
-    "engineering-chronicle"
+    "engineering-studio"
   ],
   "harnesses": [
     "claude",

--- a/Documentation/examples/private-repository-overlay/.pi/settings.json
+++ b/Documentation/examples/private-repository-overlay/.pi/settings.json
@@ -1,0 +1,6 @@
+{
+  "packages": [
+    "npm:@cratis/ai-engineering-studio@1.0.0"
+  ],
+  "enableSkillCommands": true
+}

--- a/Documentation/examples/private-repository-overlay/AGENTS.md
+++ b/Documentation/examples/private-repository-overlay/AGENTS.md
@@ -1,0 +1,11 @@
+# Private repository AI bootstrap
+
+Read `.cratis/PROJECT.md` before planning or changing code.
+
+Use the pinned shared `engineering-studio` profile for public-safe Cratis
+contributor behavior. Use repository-local skills under `.agents/skills` only
+for private Studio workflows.
+
+Never copy private repository facts into shared Cratis AI package sources.
+Never include credentials in prompts, rules, skills, commits, or generated
+artifacts.

--- a/Documentation/examples/private-repository-overlay/README.md
+++ b/Documentation/examples/private-repository-overlay/README.md
@@ -1,0 +1,21 @@
+# Private repository AI overlay example
+
+This example layers repository-owned private guidance on top of public-safe
+Cratis engineering packages.
+
+```text
+AGENTS.md
+.cratis/
+├── PROJECT.md
+└── ai.json
+.agents/
+└── skills/
+    └── studio-local-release/
+        └── SKILL.md
+.pi/
+└── settings.json
+```
+
+The shared package never writes these files. Replace every illustrative value
+with facts owned by the private repository. Do not place credentials in prompts
+or skill files; use the repository's approved secret mechanism.

--- a/Documentation/private-repository-overlays.md
+++ b/Documentation/private-repository-overlays.md
@@ -1,0 +1,119 @@
+# Private repository AI overlays
+
+A private repository uses public-safe Cratis product and engineering packages,
+then keeps confidential and repository-specific behavior beside its source.
+There is no centralized confidential Cratis AI package by default.
+
+## Why localize private behavior
+
+Repository-local ownership keeps secrets and rapidly changing implementation
+facts close to their authority. It avoids a second synchronized corpus, broad
+private package access, accidental public generation, and unclear ownership.
+
+The `engineering-` package prefix identifies maintainers as its audience. It
+does not imply confidentiality.
+
+## Recommended layout
+
+```text
+AGENTS.md
+.cratis/
+├── PROJECT.md
+└── ai.json
+.agents/
+└── skills/
+    └── <repository-local-skill>/
+        ├── SKILL.md
+        └── references/
+.pi/
+└── settings.json
+```
+
+- `AGENTS.md` contains always-on repository policy and locates project context.
+- `.cratis/PROJECT.md` contains repository-owned facts without credential values.
+- `.cratis/ai.json` pins shared public-safe profiles.
+- `.agents/skills` contains private local workflows.
+- `.pi/settings.json` pins the matching Pi package and remains project-owned.
+
+Hosts that do not discover `.agents/skills` may use thin repository-owned
+adapters. Maintain one local skill body; do not copy it between host folders.
+
+## What belongs locally
+
+Keep these in the private repository:
+
+- unreleased APIs and roadmap behavior;
+- private architecture and implementation details;
+- deployment topology and infrastructure identifiers;
+- incident and recovery procedures;
+- customer-specific behavior;
+- private support workflows;
+- repository-specific build, release, or security exceptions;
+- directions for obtaining credentials through approved mechanisms.
+
+Never place actual credential values in AI instructions, project context, skill
+files, commits, generated artifacts, or model prompts.
+
+## What belongs in shared Cratis AI
+
+Upstream behavior when it is useful across repositories and can be expressed
+without confidential facts:
+
+- general Cratis API usage based on public/approved sources;
+- Specification by Example philosophy;
+- language and framework conventions;
+- public-safe contribution, review, compatibility, and documentation workflows;
+- profile composition and host adapters.
+
+## Resolve conflicts
+
+Apply guidance in this order:
+
+1. security, legal, and organization policy;
+2. repository-local `AGENTS.md` and `.cratis/PROJECT.md`;
+3. repository-local private skills;
+4. pinned shared product/engineering profiles;
+5. general model knowledge.
+
+A local rule may deliberately narrow shared behavior. It must not silently
+weaken security, authorization, or required quality gates.
+
+## Share an improvement safely
+
+1. Identify the reusable behavior separately from private facts.
+2. Update authoritative product code/docs first when the behavior is a product
+   fact.
+3. Remove private repository names, URLs, environments, incidents, customers,
+   credentials, and unreleased examples.
+4. Open the shared-improvement issue in `Cratis/AI`.
+5. Include the originating private repository only when its existence and link
+   may be disclosed; otherwise coordinate the immutable authority evidence with
+   authorized maintainers.
+6. Review public expression, licensing, privacy, originality, compatibility, and
+   affected profiles.
+7. Deliver it downstream only through a new immutable release.
+
+Do not automate reverse synchronization from private repositories.
+
+## Provider and tool policy
+
+Package privacy and model-provider privacy are different concerns. Installing a
+public-safe package does not publish repository content, but an agent may still
+send context to its selected model provider or invoke networked tools.
+
+A private repository should document:
+
+- approved model providers and accounts;
+- data retention and training policy;
+- allowed network tools and MCP servers;
+- telemetry policy;
+- repository/tool trust requirements;
+- confirmation requirements for remote writes and destructive actions.
+
+Enforce those controls through organization and host configuration, not by
+embedding credentials or relying only on a skill prompt.
+
+## Example
+
+See [`Documentation/examples/private-repository-overlay`](./examples/private-repository-overlay/README.md)
+for a complete non-secret illustrative overlay.

--- a/Documentation/profile-reference.md
+++ b/Documentation/profile-reference.md
@@ -1,0 +1,129 @@
+# Cratis AI profile reference
+
+Profiles are generated views over approved capabilities. They do not create a
+second authored copy of a skill. Every package listed here remains planned until
+its profile and targets are explicitly approved.
+
+The `public-` and `engineering-` prefixes identify the subscription channel and
+audience. They do not indicate repository or package confidentiality.
+
+## Public product profiles
+
+| Profile | Intended package | Current state |
+| --- | --- | --- |
+| `public-fundamentals` | `@cratis/ai-fundamentals` | First preview source candidate |
+| `public-arc` | `@cratis/ai-arc` | Legacy source migration planned |
+| `public-arc-ef-core` | `@cratis/ai-arc-ef-core` | EF Core migration source requires canonical Arc persistence authority |
+| `public-arc-react` | `@cratis/ai-arc-react` | Legacy source migration planned |
+| `public-components` | `@cratis/ai-components` | Partial legacy sources; content gaps |
+| `public-chronicle` | `@cratis/ai-chronicle` | Legacy source migration planned |
+| `public-cratis-cli` | `@cratis/ai-cli` | Content gap |
+| `public-cratis-cli-terminal-workbench` | `@cratis/ai-cli-workbench` | Terminal Workbench content gap |
+| `public-chronicle-web-workbench` | `@cratis/ai-chronicle-web-workbench` | Browser Workbench content gap |
+| `public-lens` | `@cratis/ai-lens` | Content gap |
+| `public-screenplay` | `@cratis/ai-screenplay` | Content gap |
+| `public-stage` | `@cratis/ai-stage` | Content gap |
+| `public-studio` | `@cratis/ai-studio` | Public-safe content gap |
+| `public-chronicle-mcp` | `@cratis/ai-chronicle-mcp` | Passive guidance gap; executable server remains product-owned |
+
+## Chronicle client profiles
+
+| Profile | Intended package | Authority state |
+| --- | --- | --- |
+| `public-chronicle-client-dotnet` | `@cratis/ai-chronicle-dotnet` | Content gap |
+| `public-chronicle-client-kotlin` | `@cratis/ai-chronicle-kotlin` | Chronicle.Kotlin authority required |
+| `public-chronicle-client-elixir` | `@cratis/ai-chronicle-elixir` | Chronicle.Elixir authority required |
+| `public-chronicle-client-typescript` | `@cratis/ai-chronicle-typescript` | Chronicle.TypeScript authority required |
+| `public-chronicle-client-python` | `@cratis/ai-chronicle-python` | Chronicle.Python authority required |
+| `public-chronicle-client-java` | `@cratis/ai-chronicle-java` | Authority gap; no verified Java client |
+
+Do not translate .NET guidance into another language and call it client support.
+Each client profile requires language-native API, toolchain, error, lifecycle,
+and host evidence from its owning repository.
+
+## Identity, compliance, and tenancy overlays
+
+| Profile | Intended package | Scope |
+| --- | --- | --- |
+| `public-arc-identity` | `@cratis/ai-arc-identity` | Authentication providers, authorization, claims, frontend identity |
+| `public-chronicle-compliance` | `@cratis/ai-chronicle-compliance` | Subjects, keys, erasure, retention, privacy, audit |
+| `public-chronicle-multi-tenancy` | `@cratis/ai-chronicle-multi-tenancy` | Chronicle namespace isolation and tenant resolution |
+
+These remain separate because identity has different meanings across Arc,
+Chronicle compliance, event-source identities, and product-specific roles.
+
+## Specification by Example profiles
+
+| Profile | Intended package | Scope |
+| --- | --- | --- |
+| `public-specifications` | `@cratis/ai-specifications` | Language-agnostic philosophy, contexts, naming, observability |
+| `public-specifications-dotnet` | `@cratis/ai-specifications-dotnet` | Cratis.Specifications, C#, NSubstitute, scenario families |
+| `public-specifications-typescript` | `@cratis/ai-specifications-typescript` | TypeScript/React, Vitest, Chai, Sinon, view models |
+
+Language-specific profiles compose the shared philosophy rather than restating
+it independently.
+
+## Public composition profiles
+
+| Profile | Intended package | Composition |
+| --- | --- | --- |
+| `public-application-arc-only` | `@cratis/ai-application-arc` | Fundamentals + Arc + .NET specifications; no Chronicle assumptions |
+| `public-application-chronicle-dotnet` | `@cratis/ai-application-chronicle-dotnet` | Fundamentals + Chronicle + .NET client/specifications; no Arc assumptions |
+| `public-application-arc-chronicle` | `@cratis/ai-application-arc-chronicle` | Fundamentals + Arc + Chronicle backend |
+| `public-application-react` | `@cratis/ai-application-react` | Fundamentals + Arc + Arc React + Components + specifications |
+| `public-application` | `@cratis/ai-application` | Full Arc + Chronicle + React + Components application |
+| `public-modeling-screenplay-stage` | `@cratis/ai-modeling-screenplay-stage` | Screenplay authoring through Stage runtime/specification handoff |
+
+Composition packages contain generated views of approved component skills, not
+separately authored copies.
+
+## Public-safe engineering profiles
+
+All shared engineering packages are public-safe. Confidential facts remain in
+repository-local overlays.
+
+| Profile | Intended package |
+| --- | --- |
+| `engineering-base` | `@cratis/ai-engineering-base` |
+| `engineering-application` | `@cratis/ai-engineering-application` |
+| `engineering-fundamentals` | `@cratis/ai-engineering-fundamentals` |
+| `engineering-arc` | `@cratis/ai-engineering-arc` |
+| `engineering-arc-ef-core` | `@cratis/ai-engineering-arc-ef-core` |
+| `engineering-arc-react` | `@cratis/ai-engineering-arc-react` |
+| `engineering-components` | `@cratis/ai-engineering-components` |
+| `engineering-chronicle` | `@cratis/ai-engineering-chronicle` |
+| `engineering-chronicle-clients` | `@cratis/ai-engineering-chronicle-clients` |
+| `engineering-cratis-cli` | `@cratis/ai-engineering-cli` |
+| `engineering-lens` | `@cratis/ai-engineering-lens` |
+| `engineering-screenplay` | `@cratis/ai-engineering-screenplay` |
+| `engineering-stage` | `@cratis/ai-engineering-stage` |
+| `engineering-studio` | `@cratis/ai-engineering-studio` |
+| `engineering-stagehand` | `@cratis/ai-engineering-stagehand` |
+| `engineering-chronicle-mcp` | `@cratis/ai-engineering-chronicle-mcp` |
+| `engineering-specifications` | `@cratis/ai-engineering-specifications` |
+| `engineering-documentation` | `@cratis/ai-engineering-documentation` |
+| `engineering-ai` | `@cratis/ai-engineering-ai` |
+| `engineering-workflows` | `@cratis/ai-engineering-workflows` |
+
+Every engineering profile composes `engineering-base`. Studio and Stagehand
+packages may contain only public-safe contribution behavior. Their private
+architecture, deployment, roadmap, infrastructure, support, and incident
+workflows stay local to their private repositories.
+
+## Trust and publication
+
+A planned profile is not an installation or support claim. Approval requires:
+
+- named owner and reviewer;
+- immutable product/source authority;
+- exact skill revision and digest;
+- public-safe content and licensing review;
+- security, behavior, positive/negative trigger, collision, and portability
+  evidence;
+- profile and artifact runtime approval;
+- real host and consumer lifecycle evidence.
+
+Executable CLI, Lens, Studio MCP, and Chronicle MCP implementations remain owned
+and distributed by their product repositories. Cratis AI packages only passive
+selection, installation, safety, interpretation, and workflow guidance unless a
+separate executable package is explicitly reviewed.

--- a/README.md
+++ b/README.md
@@ -50,17 +50,21 @@ never package the repository wholesale.
 
 ## Profiles
 
-Public profile plan:
+The complete plan covers Fundamentals, Arc, Arc React, Components, Chronicle,
+language-specific Chronicle clients, identity, compliance, multi-tenancy,
+Cratis CLI, Lens, Screenplay, Stage, public Studio/MCP use, Chronicle MCP
+passive guidance, and language-agnostic/.NET/TypeScript Specifications.
 
-- `public-fundamentals`
-- `public-arc`
-- `public-chronicle`
-- `public-components`
-- `public-application`
+Composition profiles preserve Arc-only, Chronicle-only, Arc + Chronicle, React,
+full application, and Screenplay → Stage boundaries. Public-safe engineering
+profiles cover every Cratis product/repository family; private repositories add
+local overlays rather than receiving confidential shared packages.
 
-Engineering profile plan includes product-specific framework profiles plus
-application, client, documentation, Studio, Stagehand, and corpus profiles.
-See [`distribution/profile-catalog.json`](distribution/profile-catalog.json).
+See [`distribution/profile-catalog.json`](distribution/profile-catalog.json),
+[Profile reference](Documentation/profile-reference.md),
+[developer adoption](Documentation/adopting-cratis-ai.md),
+[maintainer adoption](Documentation/adopting-cratis-ai-for-maintainers.md), and
+[private repository overlays](Documentation/private-repository-overlays.md).
 
 A consuming repository will pin profiles in project-owned `.cratis/ai.json`:
 
@@ -69,7 +73,7 @@ A consuming repository will pin profiles in project-owned `.cratis/ai.json`:
   "schemaVersion": "1.0.0",
   "channel": "cratis-engineering",
   "version": "1.0.0",
-  "profiles": ["engineering-framework-chronicle"],
+  "profiles": ["engineering-chronicle"],
   "harnesses": ["claude", "codex", "copilot", "pi"],
   "updatePolicy": "reviewed-pull-request",
   "projectContext": ".cratis/PROJECT.md"

--- a/catalog/generated/human-catalog/catalog.json
+++ b/catalog/generated/human-catalog/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractVersion": 1,
   "disclaimer": "Catalog inclusion, evaluation evidence, bundle generation, or publication does not grant runtime permission or approval.",
-  "inputDigest": "a9b6487f3a794a7626aef556853fe4973e7714f638110abf913b2af817431b34",
+  "inputDigest": "935cf8eb8d422ee72efef1762948544ef6f2010796d26bceae6cf7e1054df871",
   "capabilities": [
     {
       "id": "cratis-application-react-specifications",

--- a/catalog/generated/human-catalog/manifest.json
+++ b/catalog/generated/human-catalog/manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "contractVersion": 1,
-  "inputDigest": "a9b6487f3a794a7626aef556853fe4973e7714f638110abf913b2af817431b34",
+  "inputDigest": "935cf8eb8d422ee72efef1762948544ef6f2010796d26bceae6cf7e1054df871",
   "files": [
     {
       "path": "CATALOG.md",
@@ -11,7 +11,7 @@
     {
       "path": "catalog.json",
       "size": 64765,
-      "sha256": "89bec06db9413415db04a2e6b5a7e9f3c1e89a71ecc1d4fbc3f5c00adbe15b96"
+      "sha256": "91ceb022cf5152e05c6a111cb73352ec03f389b090d741fd994155f0e06c1b17"
     }
   ]
 }

--- a/catalog/product-coverage.yml
+++ b/catalog/product-coverage.yml
@@ -51,6 +51,12 @@
       "name": "Elixir",
       "supportStatus": "verification-required",
       "notes": "Do not add a public skill until the client repository, supported version, API, and toolchain are verified."
+    },
+    {
+      "id": "python",
+      "name": "Python",
+      "supportStatus": "verification-required",
+      "notes": "Do not add a public skill until Chronicle.Python, supported versions, APIs, async behavior, and toolchain are verified."
     }
   ],
   "products": [
@@ -379,6 +385,33 @@
             "elixir"
           ],
           "sourceSkills": []
+        },
+        {
+          "id": "typescript-client",
+          "status": "verification-required",
+          "languages": [
+            "typescript"
+          ],
+          "sourceSkills": [],
+          "notes": "Requires Chronicle.TypeScript-owned source and version evidence."
+        },
+        {
+          "id": "python-client",
+          "status": "verification-required",
+          "languages": [
+            "python"
+          ],
+          "sourceSkills": [],
+          "notes": "Requires Chronicle.Python-owned source and version evidence."
+        },
+        {
+          "id": "browser-workbench",
+          "status": "backlog",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkills": [],
+          "notes": "Needs browser-first events, observers, failed partitions, read models, projected state, evidence capture, redaction, and support escalation guidance."
         }
       ]
     },
@@ -501,6 +534,15 @@
             "diagnose-slice",
             "inspect-running-chronicle"
           ]
+        },
+        {
+          "id": "terminal-workbench",
+          "status": "backlog",
+          "languages": [
+            "shell"
+          ],
+          "sourceSkills": [],
+          "notes": "Needs CLI-owned terminal Workbench discovery, read-only evidence capture, machine output, and separately confirmed recovery/administration guidance."
         }
       ]
     },
@@ -609,6 +651,153 @@
           "sourceSkills": [
             "add-ef-migration"
           ]
+        }
+      ]
+    },
+    {
+      "id": "lens",
+      "name": "Cratis Lens",
+      "capabilities": [
+        {
+          "id": "setup",
+          "status": "backlog",
+          "languages": [
+            "csharp",
+            "typescript"
+          ],
+          "sourceSkills": []
+        },
+        {
+          "id": "diagnostics-and-analysis",
+          "status": "backlog",
+          "languages": [
+            "csharp",
+            "typescript",
+            "language-agnostic"
+          ],
+          "sourceSkills": []
+        },
+        {
+          "id": "inspection-and-interpretation",
+          "status": "backlog",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkills": []
+        }
+      ]
+    },
+    {
+      "id": "screenplay",
+      "name": "Cratis Screenplay",
+      "capabilities": [
+        {
+          "id": "model-authoring",
+          "status": "backlog",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkills": []
+        },
+        {
+          "id": "compiler-and-diagnostics",
+          "status": "backlog",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkills": []
+        },
+        {
+          "id": "editor-and-generation",
+          "status": "backlog",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkills": []
+        }
+      ]
+    },
+    {
+      "id": "stage",
+      "name": "Cratis Stage",
+      "capabilities": [
+        {
+          "id": "runtime",
+          "status": "backlog",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkills": []
+        },
+        {
+          "id": "executable-specifications",
+          "status": "backlog",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkills": []
+        },
+        {
+          "id": "workbench-results-and-ci",
+          "status": "backlog",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkills": []
+        }
+      ]
+    },
+    {
+      "id": "studio",
+      "name": "Cratis Studio",
+      "capabilities": [
+        {
+          "id": "public-onboarding-and-mcp",
+          "status": "backlog",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkills": []
+        },
+        {
+          "id": "modeling-preparation",
+          "status": "backlog",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkills": []
+        },
+        {
+          "id": "support-redaction-and-issue-preparation",
+          "status": "backlog",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkills": [],
+          "notes": "Only public-safe behavior belongs in shared profiles; private Studio implementation remains repository-local."
+        }
+      ]
+    },
+    {
+      "id": "chronicle-mcp",
+      "name": "Chronicle MCP",
+      "capabilities": [
+        {
+          "id": "installation-and-selection",
+          "status": "backlog",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkills": []
+        },
+        {
+          "id": "safe-use-and-interpretation",
+          "status": "backlog",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkills": [],
+          "notes": "Cratis AI owns passive guidance; Chronicle.Mcp owns executable tools, schemas, credentials, and mutations."
         }
       ]
     },

--- a/catalog/v2/product-coverage.json
+++ b/catalog/v2/product-coverage.json
@@ -96,6 +96,17 @@
         "reevaluation-authority"
       ],
       "notes": "Do not add a public skill until the client repository, supported version, API, and toolchain are verified."
+    },
+    {
+      "id": "python",
+      "name": "Python",
+      "coverageState": "gap",
+      "claimState": "unclaimed",
+      "evidenceIds": [
+        "repo-main-b795d53",
+        "reevaluation-authority"
+      ],
+      "notes": "Do not add a public skill until Chronicle.Python, supported versions, APIs, async behavior, and toolchain are verified."
     }
   ],
   "products": [
@@ -671,6 +682,51 @@
             "repo-main-b795d53",
             "reevaluation-authority"
           ]
+        },
+        {
+          "id": "typescript-client",
+          "coverageState": "gap",
+          "claimState": "unclaimed",
+          "languages": [
+            "typescript"
+          ],
+          "sourceSkillIds": [],
+          "targetIds": [],
+          "evidenceIds": [
+            "repo-main-b795d53",
+            "reevaluation-authority"
+          ],
+          "notes": "Requires Chronicle.TypeScript-owned source and version evidence."
+        },
+        {
+          "id": "python-client",
+          "coverageState": "gap",
+          "claimState": "unclaimed",
+          "languages": [
+            "python"
+          ],
+          "sourceSkillIds": [],
+          "targetIds": [],
+          "evidenceIds": [
+            "repo-main-b795d53",
+            "reevaluation-authority"
+          ],
+          "notes": "Requires Chronicle.Python-owned source and version evidence."
+        },
+        {
+          "id": "browser-workbench",
+          "coverageState": "gap",
+          "claimState": "unclaimed",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkillIds": [],
+          "targetIds": [],
+          "evidenceIds": [
+            "repo-main-b795d53",
+            "reevaluation-authority"
+          ],
+          "notes": "Needs browser-first events, observers, failed partitions, read models, projected state, evidence capture, redaction, and support escalation guidance."
         }
       ]
     },
@@ -880,6 +936,21 @@
             "repo-main-b795d53",
             "reevaluation-authority"
           ]
+        },
+        {
+          "id": "terminal-workbench",
+          "coverageState": "gap",
+          "claimState": "unclaimed",
+          "languages": [
+            "shell"
+          ],
+          "sourceSkillIds": [],
+          "targetIds": [],
+          "evidenceIds": [
+            "repo-main-b795d53",
+            "reevaluation-authority"
+          ],
+          "notes": "Needs CLI-owned terminal Workbench discovery, read-only evidence capture, machine output, and separately confirmed recovery/administration guidance."
         }
       ]
     },
@@ -1066,6 +1137,257 @@
             "repo-main-b795d53",
             "reevaluation-authority"
           ]
+        }
+      ]
+    },
+    {
+      "id": "lens",
+      "name": "Cratis Lens",
+      "evidenceIds": [
+        "repo-main-b795d53",
+        "reevaluation-authority"
+      ],
+      "capabilities": [
+        {
+          "id": "setup",
+          "coverageState": "gap",
+          "claimState": "unclaimed",
+          "languages": [
+            "csharp",
+            "typescript"
+          ],
+          "sourceSkillIds": [],
+          "targetIds": [],
+          "evidenceIds": [
+            "repo-main-b795d53",
+            "reevaluation-authority"
+          ]
+        },
+        {
+          "id": "diagnostics-and-analysis",
+          "coverageState": "gap",
+          "claimState": "unclaimed",
+          "languages": [
+            "csharp",
+            "typescript",
+            "language-agnostic"
+          ],
+          "sourceSkillIds": [],
+          "targetIds": [],
+          "evidenceIds": [
+            "repo-main-b795d53",
+            "reevaluation-authority"
+          ]
+        },
+        {
+          "id": "inspection-and-interpretation",
+          "coverageState": "gap",
+          "claimState": "unclaimed",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkillIds": [],
+          "targetIds": [],
+          "evidenceIds": [
+            "repo-main-b795d53",
+            "reevaluation-authority"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "screenplay",
+      "name": "Cratis Screenplay",
+      "evidenceIds": [
+        "repo-main-b795d53",
+        "reevaluation-authority"
+      ],
+      "capabilities": [
+        {
+          "id": "model-authoring",
+          "coverageState": "gap",
+          "claimState": "unclaimed",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkillIds": [],
+          "targetIds": [],
+          "evidenceIds": [
+            "repo-main-b795d53",
+            "reevaluation-authority"
+          ]
+        },
+        {
+          "id": "compiler-and-diagnostics",
+          "coverageState": "gap",
+          "claimState": "unclaimed",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkillIds": [],
+          "targetIds": [],
+          "evidenceIds": [
+            "repo-main-b795d53",
+            "reevaluation-authority"
+          ]
+        },
+        {
+          "id": "editor-and-generation",
+          "coverageState": "gap",
+          "claimState": "unclaimed",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkillIds": [],
+          "targetIds": [],
+          "evidenceIds": [
+            "repo-main-b795d53",
+            "reevaluation-authority"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "stage",
+      "name": "Cratis Stage",
+      "evidenceIds": [
+        "repo-main-b795d53",
+        "reevaluation-authority"
+      ],
+      "capabilities": [
+        {
+          "id": "runtime",
+          "coverageState": "gap",
+          "claimState": "unclaimed",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkillIds": [],
+          "targetIds": [],
+          "evidenceIds": [
+            "repo-main-b795d53",
+            "reevaluation-authority"
+          ]
+        },
+        {
+          "id": "executable-specifications",
+          "coverageState": "gap",
+          "claimState": "unclaimed",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkillIds": [],
+          "targetIds": [],
+          "evidenceIds": [
+            "repo-main-b795d53",
+            "reevaluation-authority"
+          ]
+        },
+        {
+          "id": "workbench-results-and-ci",
+          "coverageState": "gap",
+          "claimState": "unclaimed",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkillIds": [],
+          "targetIds": [],
+          "evidenceIds": [
+            "repo-main-b795d53",
+            "reevaluation-authority"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "studio",
+      "name": "Cratis Studio",
+      "evidenceIds": [
+        "repo-main-b795d53",
+        "reevaluation-authority"
+      ],
+      "capabilities": [
+        {
+          "id": "public-onboarding-and-mcp",
+          "coverageState": "gap",
+          "claimState": "unclaimed",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkillIds": [],
+          "targetIds": [],
+          "evidenceIds": [
+            "repo-main-b795d53",
+            "reevaluation-authority"
+          ]
+        },
+        {
+          "id": "modeling-preparation",
+          "coverageState": "gap",
+          "claimState": "unclaimed",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkillIds": [],
+          "targetIds": [],
+          "evidenceIds": [
+            "repo-main-b795d53",
+            "reevaluation-authority"
+          ]
+        },
+        {
+          "id": "support-redaction-and-issue-preparation",
+          "coverageState": "gap",
+          "claimState": "unclaimed",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkillIds": [],
+          "targetIds": [],
+          "evidenceIds": [
+            "repo-main-b795d53",
+            "reevaluation-authority"
+          ],
+          "notes": "Only public-safe behavior belongs in shared profiles; private Studio implementation remains repository-local."
+        }
+      ]
+    },
+    {
+      "id": "chronicle-mcp",
+      "name": "Chronicle MCP",
+      "evidenceIds": [
+        "repo-main-b795d53",
+        "reevaluation-authority"
+      ],
+      "capabilities": [
+        {
+          "id": "installation-and-selection",
+          "coverageState": "gap",
+          "claimState": "unclaimed",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkillIds": [],
+          "targetIds": [],
+          "evidenceIds": [
+            "repo-main-b795d53",
+            "reevaluation-authority"
+          ]
+        },
+        {
+          "id": "safe-use-and-interpretation",
+          "coverageState": "gap",
+          "claimState": "unclaimed",
+          "languages": [
+            "language-agnostic"
+          ],
+          "sourceSkillIds": [],
+          "targetIds": [],
+          "evidenceIds": [
+            "repo-main-b795d53",
+            "reevaluation-authority"
+          ],
+          "notes": "Cratis AI owns passive guidance; Chronicle.Mcp owns executable tools, schemas, credentials, and mutations."
         }
       ]
     },

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -2107,7 +2107,23 @@
       "status": "added"
     }
   ],
-  "admittedUntracked": [],
+  "admittedUntracked": [
+    "Documentation/adopting-cratis-ai-for-maintainers.md",
+    "Documentation/adopting-cratis-ai.md",
+    "Documentation/examples/ai-subscriptions/arc-only-application.cratis-ai.json",
+    "Documentation/examples/ai-subscriptions/arc-react-components.cratis-ai.json",
+    "Documentation/examples/ai-subscriptions/chronicle-kotlin-client.cratis-ai.json",
+    "Documentation/examples/ai-subscriptions/private-studio.cratis-ai.json",
+    "Documentation/examples/ai-subscriptions/specifications-library.cratis-ai.json",
+    "Documentation/examples/private-repository-overlay/.agents/skills/studio-local-release/SKILL.md",
+    "Documentation/examples/private-repository-overlay/.cratis/PROJECT.md",
+    "Documentation/examples/private-repository-overlay/.cratis/ai.json",
+    "Documentation/examples/private-repository-overlay/.pi/settings.json",
+    "Documentation/examples/private-repository-overlay/AGENTS.md",
+    "Documentation/examples/private-repository-overlay/README.md",
+    "Documentation/private-repository-overlays.md",
+    "Documentation/profile-reference.md"
+  ],
   "excludedRuntimePrefixes": [
     ".pi/delegate/",
     ".pi/fusion/",
@@ -2898,8 +2914,13 @@
       "id": "redesign-decision-documents",
       "sourcePathPatterns": [
         "AI-REPOSITORY-REDESIGN-*.md",
+        "Documentation/adopting-cratis-ai.md",
+        "Documentation/adopting-cratis-ai-for-maintainers.md",
         "Documentation/ai-distribution-and-subscriptions.md",
+        "Documentation/private-repository-overlays.md",
+        "Documentation/profile-reference.md",
         "Documentation/examples/ai-subscriptions/**",
+        "Documentation/examples/private-repository-overlay/**",
         "Documentation/phase-0-verification.md",
         "Documentation/public-product-architecture.md",
         "Documentation/skill-classification-audit.md",
@@ -2923,8 +2944,8 @@
         "workflows-68",
         "reevaluation-authority"
       ],
-      "expectedPathCount": 23,
-      "expectedPathsDigest": "8bcfe69caab9977abea3ae57d37bc98ed0f47fa3b9323e3e678b5f0fa26a6760"
+      "expectedPathCount": 38,
+      "expectedPathsDigest": "bfb48a98e704ad38e22b58bfd5b137c059fd4b114fcf9dff382741e613b47964"
     },
     {
       "excludePathPatterns": [],

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "701c8a7a5bc995b3f627ba95511a31776cd5a83f47021271f3132cacac858bbe",
+  "indexDigest": "085b785d64098574f9e77c7c20edc302c990aab98b0226344c592898d599c3a6",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -135,6 +135,14 @@
       "status": "added"
     },
     {
+      "path": "Documentation/adopting-cratis-ai-for-maintainers.md",
+      "status": "added"
+    },
+    {
+      "path": "Documentation/adopting-cratis-ai.md",
+      "status": "added"
+    },
+    {
       "path": "Documentation/agents.md",
       "status": "modified"
     },
@@ -215,7 +223,19 @@
       "status": "added"
     },
     {
+      "path": "Documentation/examples/ai-subscriptions/arc-only-application.cratis-ai.json",
+      "status": "added"
+    },
+    {
+      "path": "Documentation/examples/ai-subscriptions/arc-react-components.cratis-ai.json",
+      "status": "added"
+    },
+    {
       "path": "Documentation/examples/ai-subscriptions/chronicle-framework.cratis-ai.json",
+      "status": "added"
+    },
+    {
+      "path": "Documentation/examples/ai-subscriptions/chronicle-kotlin-client.cratis-ai.json",
       "status": "added"
     },
     {
@@ -224,6 +244,38 @@
     },
     {
       "path": "Documentation/examples/ai-subscriptions/pi-settings.json",
+      "status": "added"
+    },
+    {
+      "path": "Documentation/examples/ai-subscriptions/private-studio.cratis-ai.json",
+      "status": "added"
+    },
+    {
+      "path": "Documentation/examples/ai-subscriptions/specifications-library.cratis-ai.json",
+      "status": "added"
+    },
+    {
+      "path": "Documentation/examples/private-repository-overlay/.agents/skills/studio-local-release/SKILL.md",
+      "status": "added"
+    },
+    {
+      "path": "Documentation/examples/private-repository-overlay/.cratis/PROJECT.md",
+      "status": "added"
+    },
+    {
+      "path": "Documentation/examples/private-repository-overlay/.cratis/ai.json",
+      "status": "added"
+    },
+    {
+      "path": "Documentation/examples/private-repository-overlay/.pi/settings.json",
+      "status": "added"
+    },
+    {
+      "path": "Documentation/examples/private-repository-overlay/AGENTS.md",
+      "status": "added"
+    },
+    {
+      "path": "Documentation/examples/private-repository-overlay/README.md",
       "status": "added"
     },
     {
@@ -244,6 +296,14 @@
     },
     {
       "path": "Documentation/phase-0-verification.md",
+      "status": "added"
+    },
+    {
+      "path": "Documentation/private-repository-overlays.md",
+      "status": "added"
+    },
+    {
+      "path": "Documentation/profile-reference.md",
       "status": "added"
     },
     {
@@ -2107,23 +2167,7 @@
       "status": "added"
     }
   ],
-  "admittedUntracked": [
-    "Documentation/adopting-cratis-ai-for-maintainers.md",
-    "Documentation/adopting-cratis-ai.md",
-    "Documentation/examples/ai-subscriptions/arc-only-application.cratis-ai.json",
-    "Documentation/examples/ai-subscriptions/arc-react-components.cratis-ai.json",
-    "Documentation/examples/ai-subscriptions/chronicle-kotlin-client.cratis-ai.json",
-    "Documentation/examples/ai-subscriptions/private-studio.cratis-ai.json",
-    "Documentation/examples/ai-subscriptions/specifications-library.cratis-ai.json",
-    "Documentation/examples/private-repository-overlay/.agents/skills/studio-local-release/SKILL.md",
-    "Documentation/examples/private-repository-overlay/.cratis/PROJECT.md",
-    "Documentation/examples/private-repository-overlay/.cratis/ai.json",
-    "Documentation/examples/private-repository-overlay/.pi/settings.json",
-    "Documentation/examples/private-repository-overlay/AGENTS.md",
-    "Documentation/examples/private-repository-overlay/README.md",
-    "Documentation/private-repository-overlays.md",
-    "Documentation/profile-reference.md"
-  ],
+  "admittedUntracked": [],
   "excludedRuntimePrefixes": [
     ".pi/delegate/",
     ".pi/fusion/",

--- a/catalog/v2/taxonomy.json
+++ b/catalog/v2/taxonomy.json
@@ -16,6 +16,7 @@
       { "id": "both", "name": "User or model invoked", "description": "Supports both explicit and model-selected invocation." }
     ],
     "products": [
+      { "id": "ai", "name": "Cratis AI", "description": "Shared Cratis AI authoring, profiles, evidence, and distribution workflows." },
       { "id": "application", "name": "Cratis application architecture", "description": "Composition guidance for applications built on Cratis products." },
       { "id": "arc", "name": "Cratis Arc", "description": "Arc backend commands, queries, validation, authorization, and integrations." },
       { "id": "arc-react", "name": "Arc React", "description": "Generated Arc React clients and observable frontend behavior." },
@@ -26,11 +27,15 @@
       { "id": "cross-product", "name": "Cross-product", "description": "Capabilities that apply across more than one Cratis product." },
       { "id": "cratis-engineering", "name": "Cratis engineering", "description": "Separately trusted contributor and maintainer behavior." },
       { "id": "entity-framework-core", "name": "Entity Framework Core", "description": "Arc and application EF Core integration." },
+      { "id": "documentation", "name": "Cratis Documentation", "description": "Cratis documentation authoring, integration, rendering, and quality workflows." },
       { "id": "fundamentals", "name": "Cratis Fundamentals", "description": "Strongly typed concepts and implementation discovery." },
+      { "id": "lens", "name": "Cratis Lens", "description": "Lens diagnostics, inspection, analysis, and interpretation workflows." },
       { "id": "screenplay", "name": "Cratis Screenplay", "description": "Model authoring, compilation, diagnostics, and editor workflows." },
       { "id": "specifications", "name": "Cratis Specifications", "description": "Specification by Example foundations and scenario families." },
       { "id": "stage", "name": "Cratis Stage", "description": "Model runtime, workbench, and executable specification workflows." },
-      { "id": "studio", "name": "Cratis Studio", "description": "Public Studio onboarding, modeling, support, and issue-preparation workflows." }
+      { "id": "stagehand", "name": "Cratis Stagehand", "description": "Public-safe Stagehand worker, scheduling, and control-plane contribution workflows." },
+      { "id": "studio", "name": "Cratis Studio", "description": "Public Studio onboarding, modeling, support, and issue-preparation workflows." },
+      { "id": "workflows", "name": "Cratis Workflows", "description": "Shared CI, release, fleet update, canary, and rollback workflows." }
     ],
     "languages": [
       { "id": "csharp", "name": "C#", "description": "C# and .NET-specific APIs and toolchains." },
@@ -39,6 +44,7 @@
       { "id": "kotlin", "name": "Kotlin", "description": "Kotlin and coroutine-specific APIs and toolchains." },
       { "id": "language-agnostic", "name": "Language agnostic", "description": "Conceptual behavior independent of a programming language." },
       { "id": "markdown", "name": "Markdown and Mermaid", "description": "Markdown documents and Mermaid models." },
+      { "id": "python", "name": "Python", "description": "Python-specific APIs, async behavior, and toolchains." },
       { "id": "react", "name": "React", "description": "React-specific application and component workflows." },
       { "id": "shell", "name": "Shell and HTTP", "description": "Terminal, shell, curl, and protocol-level workflows." },
       { "id": "typescript", "name": "TypeScript", "description": "TypeScript and Node-specific APIs and toolchains." }

--- a/distribution/profile-catalog.json
+++ b/distribution/profile-catalog.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "state": "DESIGNED_RELEASES_NOT_YET_PUBLISHED",
   "sourceRepository": "https://github.com/Cratis/AI",
   "generatedRepository": "https://github.com/Cratis/AI.Distribution",
@@ -18,11 +18,27 @@
     "directGeneratedEditsAllowed": false,
     "automaticReverseSyncAllowed": false
   },
+  "confidentiality": {
+    "publicProductPackages": "public-safe-only",
+    "engineeringPackages": "public-safe-only",
+    "engineeringPrefixImpliesConfidentiality": false,
+    "confidentialSharedPackagesAllowed": false,
+    "privateFactsOwner": "consuming private repository",
+    "privateOverlayPaths": [
+      "AGENTS.md",
+      ".cratis/PROJECT.md",
+      ".agents/skills/**",
+      "host-native project adapters"
+    ],
+    "packageMayReadOrWritePrivateOverlay": false,
+    "upstreamRule": "generalize and remove private facts before proposing a Cratis/AI change"
+  },
   "publicProfiles": [
     {
       "id": "public-fundamentals",
       "packageName": "@cratis/ai-fundamentals",
       "products": ["fundamentals"],
+      "languages": ["csharp"],
       "state": "preview-source-candidate",
       "availableTargets": ["cratis-fundamentals-concept"],
       "gapSummary": "Type discovery remains a legacy candidate."
@@ -30,40 +46,264 @@
     {
       "id": "public-arc",
       "packageName": "@cratis/ai-arc",
-      "products": ["arc", "arc-react"],
-      "state": "planned",
-      "availableTargets": [],
-      "gapSummary": "Commands, queries, validation, authorization, generated proxies, and React/MVVM journeys require canonical sources."
+      "products": ["arc"],
+      "languages": ["csharp"],
+      "state": "planned-source-migration",
+      "gapSummary": "Commands and execution have legacy sources; dedicated queries and separated validation/authorization guidance remain gaps."
     },
     {
-      "id": "public-chronicle",
-      "packageName": "@cratis/ai-chronicle",
-      "products": ["chronicle"],
-      "state": "planned",
-      "availableTargets": [],
-      "gapSummary": "Core .NET, compliance, operations, and client-language journeys require canonical sources."
+      "id": "public-arc-ef-core",
+      "packageName": "@cratis/ai-arc-ef-core",
+      "products": ["arc", "entity-framework-core"],
+      "languages": ["csharp"],
+      "state": "planned-source-migration",
+      "composes": ["public-arc"],
+      "gapSummary": "The EF Core migration legacy source requires canonical Arc persistence, DbContext, migration, specification, and version authority."
+    },
+    {
+      "id": "public-arc-react",
+      "packageName": "@cratis/ai-arc-react",
+      "products": ["arc-react"],
+      "languages": ["react", "typescript"],
+      "state": "planned-source-migration",
+      "gapSummary": "Page, observable query, paging, generated proxy, MVVM, lifecycle, and error-handling guidance require canonical sources."
     },
     {
       "id": "public-components",
       "packageName": "@cratis/ai-components",
       "products": ["components"],
-      "state": "planned",
-      "availableTargets": [],
-      "gapSummary": "Forms, dialogs, DataPage, tables, and styling journeys require canonical sources."
+      "languages": ["react", "typescript"],
+      "state": "planned-source-migration",
+      "gapSummary": "Toolbar and stepper sources exist; forms, dialogs, DataPage, tables, styling, accessibility, and schema editors remain incomplete."
+    },
+    {
+      "id": "public-chronicle",
+      "packageName": "@cratis/ai-chronicle",
+      "products": ["chronicle"],
+      "languages": ["csharp", "language-agnostic"],
+      "state": "planned-source-migration",
+      "gapSummary": "Event modeling, projections, read models, reducers, reactors, metadata, migrations, tenancy, and operations have legacy sources; core client and compliance journeys remain gaps."
+    },
+    {
+      "id": "public-chronicle-client-dotnet",
+      "packageName": "@cratis/ai-chronicle-dotnet",
+      "products": ["chronicle"],
+      "languages": ["csharp"],
+      "state": "content-gap",
+      "gapSummary": "Needs authoritative standalone .NET connect, append, read, observe, error, and lifecycle guidance."
+    },
+    {
+      "id": "public-chronicle-client-kotlin",
+      "packageName": "@cratis/ai-chronicle-kotlin",
+      "products": ["chronicle"],
+      "languages": ["kotlin"],
+      "state": "content-gap",
+      "gapSummary": "Needs Chronicle.Kotlin-owned source, versions, Gradle/Spring, coroutine, error, and lifecycle guidance."
+    },
+    {
+      "id": "public-chronicle-client-elixir",
+      "packageName": "@cratis/ai-chronicle-elixir",
+      "products": ["chronicle"],
+      "languages": ["elixir"],
+      "state": "content-gap",
+      "gapSummary": "Needs Chronicle.Elixir-owned source, OTP, supervision, configuration, error, and lifecycle guidance."
+    },
+    {
+      "id": "public-chronicle-client-typescript",
+      "packageName": "@cratis/ai-chronicle-typescript",
+      "products": ["chronicle"],
+      "languages": ["typescript"],
+      "state": "content-gap",
+      "gapSummary": "Needs Chronicle.TypeScript-owned source, runtime, transport, error, and lifecycle guidance."
+    },
+    {
+      "id": "public-chronicle-client-python",
+      "packageName": "@cratis/ai-chronicle-python",
+      "products": ["chronicle"],
+      "languages": ["python"],
+      "state": "content-gap",
+      "gapSummary": "Needs Chronicle.Python-owned source, environment, async, error, and lifecycle guidance."
+    },
+    {
+      "id": "public-chronicle-client-java",
+      "packageName": "@cratis/ai-chronicle-java",
+      "products": ["chronicle"],
+      "languages": ["java"],
+      "state": "authority-gap",
+      "gapSummary": "No authoritative supported Chronicle Java client repository was verified; do not synthesize one from Kotlin or .NET."
+    },
+    {
+      "id": "public-arc-identity",
+      "packageName": "@cratis/ai-arc-identity",
+      "products": ["arc"],
+      "languages": ["csharp", "react", "typescript"],
+      "state": "planned-source-migration",
+      "composes": ["public-arc"],
+      "gapSummary": "Authentication providers, authorization, claims, frontend identity, and tenancy boundaries must be separated from Chronicle compliance identity."
+    },
+    {
+      "id": "public-chronicle-compliance",
+      "packageName": "@cratis/ai-chronicle-compliance",
+      "products": ["chronicle"],
+      "languages": ["csharp", "language-agnostic"],
+      "state": "content-gap",
+      "composes": ["public-chronicle"],
+      "gapSummary": "Needs subjects, key lifecycle, erasure, retention, redaction, audit, and privacy guidance from authoritative Chronicle sources."
+    },
+    {
+      "id": "public-chronicle-multi-tenancy",
+      "packageName": "@cratis/ai-chronicle-multi-tenancy",
+      "products": ["chronicle"],
+      "languages": ["csharp", "language-agnostic"],
+      "state": "planned-source-migration",
+      "composes": ["public-chronicle"],
+      "gapSummary": "The namespace-based tenancy legacy source requires canonical authority, isolation, identity, and operational evidence."
+    },
+    {
+      "id": "public-cratis-cli",
+      "packageName": "@cratis/ai-cli",
+      "products": ["cli"],
+      "languages": ["shell"],
+      "state": "content-gap",
+      "gapSummary": "Needs setup, contexts, project generation, machine output, read-only inspection, and separately confirmed mutation workflows from Cratis/cli."
+    },
+    {
+      "id": "public-cratis-cli-terminal-workbench",
+      "packageName": "@cratis/ai-cli-workbench",
+      "products": ["cli"],
+      "languages": ["shell"],
+      "state": "content-gap",
+      "composes": ["public-cratis-cli"],
+      "gapSummary": "Needs CLI-owned terminal Workbench discovery, navigation, read-only evidence capture, machine output, and separately confirmed recovery/administration guidance."
+    },
+    {
+      "id": "public-lens",
+      "packageName": "@cratis/ai-lens",
+      "products": ["lens"],
+      "languages": ["csharp", "typescript", "language-agnostic"],
+      "state": "content-gap",
+      "gapSummary": "Needs Lens-owned setup, diagnostics, inspection, interpretation, safety, and contribution journeys."
+    },
+    {
+      "id": "public-screenplay",
+      "packageName": "@cratis/ai-screenplay",
+      "products": ["screenplay"],
+      "languages": ["language-agnostic"],
+      "state": "content-gap",
+      "gapSummary": "Needs Screenplay-owned authoring, compiler, diagnostics, editor, generation, and model handoff guidance."
+    },
+    {
+      "id": "public-stage",
+      "packageName": "@cratis/ai-stage",
+      "products": ["stage"],
+      "languages": ["language-agnostic"],
+      "state": "content-gap",
+      "gapSummary": "Needs Stage-owned runtime, executable specification, workbench, result, and CI guidance."
+    },
+    {
+      "id": "public-studio",
+      "packageName": "@cratis/ai-studio",
+      "products": ["studio"],
+      "languages": ["language-agnostic"],
+      "state": "content-gap",
+      "gapSummary": "Public guidance is limited to public Studio onboarding, MCP use, modeling preparation, support, redaction, and issue preparation; private implementation stays local."
+    },
+    {
+      "id": "public-chronicle-mcp",
+      "packageName": "@cratis/ai-chronicle-mcp",
+      "products": ["chronicle-mcp"],
+      "languages": ["language-agnostic"],
+      "state": "content-gap",
+      "gapSummary": "Cratis AI owns passive installation, selection, safety, and interpretation guidance; Chronicle.Mcp owns executable tools, schemas, credentials, and mutations."
+    },
+    {
+      "id": "public-chronicle-web-workbench",
+      "packageName": "@cratis/ai-chronicle-web-workbench",
+      "products": ["chronicle"],
+      "languages": ["language-agnostic"],
+      "state": "content-gap",
+      "composes": ["public-chronicle"],
+      "gapSummary": "Needs browser-first events, observers, failed partitions, read models, projected state, evidence capture, redaction, and support escalation guidance."
+    },
+    {
+      "id": "public-specifications",
+      "packageName": "@cratis/ai-specifications",
+      "products": ["specifications"],
+      "languages": ["language-agnostic"],
+      "state": "planned-source-migration",
+      "gapSummary": "Needs canonical language-agnostic Specification by Example philosophy, context hierarchy, naming, observability, and completion guidance."
+    },
+    {
+      "id": "public-specifications-dotnet",
+      "packageName": "@cratis/ai-specifications-dotnet",
+      "products": ["specifications"],
+      "languages": ["csharp"],
+      "state": "planned-source-migration",
+      "composes": ["public-specifications"],
+      "gapSummary": "Needs Cratis.Specifications, C# contexts, NSubstitute, assertions, framework specs, and application scenario-family guidance."
+    },
+    {
+      "id": "public-specifications-typescript",
+      "packageName": "@cratis/ai-specifications-typescript",
+      "products": ["specifications"],
+      "languages": ["typescript", "react"],
+      "state": "planned-source-migration",
+      "composes": ["public-specifications"],
+      "gapSummary": "Needs Vitest/Mocha structure, Chai, Sinon, view-model, React, and shared philosophy mapping."
+    },
+    {
+      "id": "public-application-arc-only",
+      "packageName": "@cratis/ai-application-arc",
+      "products": ["fundamentals", "arc"],
+      "languages": ["csharp"],
+      "state": "planned-composition",
+      "composes": ["public-fundamentals", "public-arc", "public-specifications-dotnet"],
+      "gapSummary": "Must preserve Arc-only commands, queries, validation, authorization, and persistence without Chronicle assumptions."
+    },
+    {
+      "id": "public-application-chronicle-dotnet",
+      "packageName": "@cratis/ai-application-chronicle-dotnet",
+      "products": ["fundamentals", "chronicle"],
+      "languages": ["csharp"],
+      "state": "planned-composition",
+      "composes": ["public-fundamentals", "public-chronicle", "public-chronicle-client-dotnet", "public-specifications-dotnet"],
+      "gapSummary": "Chronicle-only .NET application journey without Arc requires approved component profiles."
+    },
+    {
+      "id": "public-application-arc-chronicle",
+      "packageName": "@cratis/ai-application-arc-chronicle",
+      "products": ["fundamentals", "arc", "chronicle"],
+      "languages": ["csharp"],
+      "state": "planned-composition",
+      "composes": ["public-fundamentals", "public-arc", "public-chronicle", "public-specifications-dotnet"],
+      "gapSummary": "Backend Arc plus Chronicle composition requires approved Arc-only and Chronicle boundaries."
+    },
+    {
+      "id": "public-application-react",
+      "packageName": "@cratis/ai-application-react",
+      "products": ["fundamentals", "arc", "arc-react", "components"],
+      "languages": ["csharp", "react", "typescript"],
+      "state": "planned-composition",
+      "composes": ["public-fundamentals", "public-arc", "public-arc-react", "public-components", "public-specifications-dotnet", "public-specifications-typescript"],
+      "gapSummary": "Arc React and Components application composition requires approved generated-client, MVVM, forms, dialogs, tables, and spec profiles."
     },
     {
       "id": "public-application",
       "packageName": "@cratis/ai-application",
-      "products": ["fundamentals", "arc", "chronicle", "components"],
+      "products": ["fundamentals", "arc", "arc-react", "chronicle", "components"],
+      "languages": ["csharp", "react", "typescript"],
       "state": "planned-composition",
-      "composes": [
-        "public-fundamentals",
-        "public-arc",
-        "public-chronicle",
-        "public-components"
-      ],
-      "availableTargets": [],
-      "gapSummary": "The end-to-end application profile becomes publishable only after its component profiles have approved targets."
+      "composes": ["public-fundamentals", "public-arc", "public-arc-react", "public-chronicle", "public-components", "public-specifications-dotnet", "public-specifications-typescript"],
+      "gapSummary": "The full application profile becomes publishable only after every component profile has approved targets."
+    },
+    {
+      "id": "public-modeling-screenplay-stage",
+      "packageName": "@cratis/ai-modeling-screenplay-stage",
+      "products": ["screenplay", "stage"],
+      "languages": ["language-agnostic"],
+      "state": "planned-composition",
+      "composes": ["public-screenplay", "public-stage"],
+      "gapSummary": "Needs authoritative model authoring through runtime/executable specification handoff evidence."
     }
   ],
   "engineeringProfiles": [
@@ -72,47 +312,143 @@
       "packageName": "@cratis/ai-engineering-base",
       "repositoryKinds": ["application", "framework", "client", "documentation", "corpus"],
       "products": [],
-      "state": "planned",
-      "gapSummary": "Universal C#/TypeScript/spec/review behavior must be reconciled into a passive profile skill."
+      "state": "planned-source-migration",
+      "distributionVisibility": "public",
+      "confidentialContentAllowed": false,
+      "privateOverlayExpected": true,
+      "gapSummary": "Universal C#/TypeScript, Specification by Example, review, documentation, and contribution behavior must be reconciled into public-safe passive sources."
     },
     {
       "id": "engineering-application",
       "packageName": "@cratis/ai-engineering-application",
       "repositoryKinds": ["application"],
-      "products": ["fundamentals", "arc", "chronicle", "components"],
-      "state": "planned",
+      "products": ["fundamentals", "arc", "arc-react", "chronicle", "components"],
+      "state": "planned-source-migration",
+      "distributionVisibility": "public",
+      "confidentialContentAllowed": false,
+      "privateOverlayExpected": true,
       "composes": ["engineering-base"]
     },
     {
-      "id": "engineering-framework-fundamentals",
+      "id": "engineering-fundamentals",
       "packageName": "@cratis/ai-engineering-fundamentals",
       "repositoryKinds": ["framework"],
       "products": ["fundamentals"],
-      "state": "planned",
+      "state": "planned-source-migration",
+      "distributionVisibility": "public",
+      "confidentialContentAllowed": false,
+      "privateOverlayExpected": true,
       "composes": ["engineering-base"]
     },
     {
-      "id": "engineering-framework-arc",
+      "id": "engineering-arc",
       "packageName": "@cratis/ai-engineering-arc",
       "repositoryKinds": ["framework"],
-      "products": ["arc", "arc-react"],
-      "state": "planned",
+      "products": ["arc"],
+      "state": "planned-source-migration",
+      "distributionVisibility": "public",
+      "confidentialContentAllowed": false,
+      "privateOverlayExpected": true,
       "composes": ["engineering-base"]
     },
     {
-      "id": "engineering-framework-chronicle",
-      "packageName": "@cratis/ai-engineering-chronicle",
+      "id": "engineering-arc-ef-core",
+      "packageName": "@cratis/ai-engineering-arc-ef-core",
+      "repositoryKinds": ["application", "framework"],
+      "products": ["arc", "entity-framework-core"],
+      "state": "planned-source-migration",
+      "distributionVisibility": "public",
+      "confidentialContentAllowed": false,
+      "privateOverlayExpected": true,
+      "composes": ["engineering-base", "engineering-arc"]
+    },
+    {
+      "id": "engineering-arc-react",
+      "packageName": "@cratis/ai-engineering-arc-react",
       "repositoryKinds": ["framework"],
-      "products": ["chronicle"],
-      "state": "planned",
+      "products": ["arc-react"],
+      "state": "content-gap",
+      "distributionVisibility": "public",
+      "confidentialContentAllowed": false,
+      "privateOverlayExpected": true,
       "composes": ["engineering-base"]
     },
     {
-      "id": "engineering-framework-components",
+      "id": "engineering-components",
       "packageName": "@cratis/ai-engineering-components",
       "repositoryKinds": ["framework"],
       "products": ["components"],
-      "state": "planned",
+      "state": "planned-source-migration",
+      "distributionVisibility": "public",
+      "confidentialContentAllowed": false,
+      "privateOverlayExpected": true,
+      "composes": ["engineering-base"]
+    },
+    {
+      "id": "engineering-chronicle",
+      "packageName": "@cratis/ai-engineering-chronicle",
+      "repositoryKinds": ["framework"],
+      "products": ["chronicle"],
+      "state": "planned-source-migration",
+      "distributionVisibility": "public",
+      "confidentialContentAllowed": false,
+      "privateOverlayExpected": true,
+      "composes": ["engineering-base"]
+    },
+    {
+      "id": "engineering-chronicle-clients",
+      "packageName": "@cratis/ai-engineering-chronicle-clients",
+      "repositoryKinds": ["client"],
+      "products": ["chronicle"],
+      "languages": ["csharp", "kotlin", "elixir", "typescript", "python"],
+      "state": "content-gap",
+      "distributionVisibility": "public",
+      "confidentialContentAllowed": false,
+      "privateOverlayExpected": true,
+      "composes": ["engineering-base"]
+    },
+    {
+      "id": "engineering-cratis-cli",
+      "packageName": "@cratis/ai-engineering-cli",
+      "repositoryKinds": ["framework"],
+      "products": ["cli"],
+      "state": "content-gap",
+      "distributionVisibility": "public",
+      "confidentialContentAllowed": false,
+      "privateOverlayExpected": true,
+      "composes": ["engineering-base"]
+    },
+    {
+      "id": "engineering-lens",
+      "packageName": "@cratis/ai-engineering-lens",
+      "repositoryKinds": ["framework"],
+      "products": ["lens"],
+      "state": "content-gap",
+      "distributionVisibility": "public",
+      "confidentialContentAllowed": false,
+      "privateOverlayExpected": true,
+      "composes": ["engineering-base"]
+    },
+    {
+      "id": "engineering-screenplay",
+      "packageName": "@cratis/ai-engineering-screenplay",
+      "repositoryKinds": ["framework"],
+      "products": ["screenplay"],
+      "state": "content-gap",
+      "distributionVisibility": "public",
+      "confidentialContentAllowed": false,
+      "privateOverlayExpected": true,
+      "composes": ["engineering-base"]
+    },
+    {
+      "id": "engineering-stage",
+      "packageName": "@cratis/ai-engineering-stage",
+      "repositoryKinds": ["framework"],
+      "products": ["stage"],
+      "state": "content-gap",
+      "distributionVisibility": "public",
+      "confidentialContentAllowed": false,
+      "privateOverlayExpected": true,
       "composes": ["engineering-base"]
     },
     {
@@ -121,7 +457,11 @@
       "repositoryKinds": ["application", "framework"],
       "products": ["studio"],
       "state": "content-gap",
-      "composes": ["engineering-base"]
+      "distributionVisibility": "public",
+      "confidentialContentAllowed": false,
+      "privateOverlayExpected": true,
+      "composes": ["engineering-base"],
+      "gapSummary": "Only public-safe Studio engineering behavior belongs here; private architecture, deployment, roadmap, and support details remain repository-local."
     },
     {
       "id": "engineering-stagehand",
@@ -129,14 +469,32 @@
       "repositoryKinds": ["framework", "corpus"],
       "products": ["stagehand"],
       "state": "content-gap",
+      "distributionVisibility": "public",
+      "confidentialContentAllowed": false,
+      "privateOverlayExpected": true,
+      "composes": ["engineering-base"],
+      "gapSummary": "Only public-safe Stagehand engineering behavior belongs here; private infrastructure and operational details remain repository-local."
+    },
+    {
+      "id": "engineering-chronicle-mcp",
+      "packageName": "@cratis/ai-engineering-chronicle-mcp",
+      "repositoryKinds": ["framework"],
+      "products": ["chronicle-mcp"],
+      "state": "content-gap",
+      "distributionVisibility": "public",
+      "confidentialContentAllowed": false,
+      "privateOverlayExpected": true,
       "composes": ["engineering-base"]
     },
     {
-      "id": "engineering-client",
-      "packageName": "@cratis/ai-engineering-clients",
-      "repositoryKinds": ["client"],
-      "products": ["chronicle-clients"],
-      "state": "content-gap",
+      "id": "engineering-specifications",
+      "packageName": "@cratis/ai-engineering-specifications",
+      "repositoryKinds": ["application", "framework", "client"],
+      "products": ["specifications"],
+      "state": "planned-source-migration",
+      "distributionVisibility": "public",
+      "confidentialContentAllowed": false,
+      "privateOverlayExpected": true,
       "composes": ["engineering-base"]
     },
     {
@@ -145,15 +503,32 @@
       "repositoryKinds": ["documentation"],
       "products": ["documentation"],
       "state": "owner-review-pending",
+      "distributionVisibility": "public",
+      "confidentialContentAllowed": false,
+      "privateOverlayExpected": true,
       "availableTargets": ["cratis-engineering-docs-authoring"],
       "composes": ["engineering-base"]
     },
     {
-      "id": "engineering-corpus",
-      "packageName": "@cratis/ai-engineering-corpus",
+      "id": "engineering-ai",
+      "packageName": "@cratis/ai-engineering-ai",
       "repositoryKinds": ["corpus"],
-      "products": ["ai", "workflows"],
-      "state": "planned",
+      "products": ["ai"],
+      "state": "planned-source-migration",
+      "distributionVisibility": "public",
+      "confidentialContentAllowed": false,
+      "privateOverlayExpected": true,
+      "composes": ["engineering-base"]
+    },
+    {
+      "id": "engineering-workflows",
+      "packageName": "@cratis/ai-engineering-workflows",
+      "repositoryKinds": ["corpus"],
+      "products": ["workflows"],
+      "state": "content-gap",
+      "distributionVisibility": "public",
+      "confidentialContentAllowed": false,
+      "privateOverlayExpected": true,
       "composes": ["engineering-base"]
     }
   ],
@@ -175,6 +550,7 @@
       "behavior or authority evidence",
       "migration and compatibility impact"
     ],
+    "privateImprovementRule": "keep repository-specific or confidential behavior local; upstream only generalized public-safe behavior",
     "downstreamDelivery": "new immutable release followed by reviewed subscriber update pull requests"
   }
 }

--- a/tooling/generate-repository-inventory.mjs
+++ b/tooling/generate-repository-inventory.mjs
@@ -107,10 +107,12 @@ const unexpectedUntracked = admittedUntracked.filter(
             path === ".github/workflows/distribution-npm-stage.yml" ||
             /^AI-REPOSITORY-REDESIGN-[A-Z0-9-]+\.md$/.test(path) ||
             path === "Documentation/.markdownlint.json" ||
-            /^Documentation\/(?:ai-distribution-and-subscriptions|capability-catalog-v2|phase-0-verification|public-product-architecture|skill-authoring-contract|skill-classification-audit|project-context-bootstrap|redesign-foundation-validation|source-evidence-contract)\.md$/.test(
+            /^Documentation\/(?:adopting-cratis-ai|adopting-cratis-ai-for-maintainers|ai-distribution-and-subscriptions|capability-catalog-v2|phase-0-verification|private-repository-overlays|profile-reference|public-product-architecture|skill-authoring-contract|skill-classification-audit|project-context-bootstrap|redesign-foundation-validation|source-evidence-contract)\.md$/.test(
                 path,
             ) ||
-            /^Documentation\/examples\/ai-subscriptions\//.test(path) ||
+            /^Documentation\/examples\/(?:ai-subscriptions|private-repository-overlay)\//.test(
+                path,
+            ) ||
             /^Documentation\/evidence\/redesign-autonomous-execution-2026-08-20\//.test(
                 path,
             ) ||
@@ -651,8 +653,13 @@ const definitions = [
         id: "redesign-decision-documents",
         sourcePathPatterns: [
             "AI-REPOSITORY-REDESIGN-*.md",
+            "Documentation/adopting-cratis-ai.md",
+            "Documentation/adopting-cratis-ai-for-maintainers.md",
             "Documentation/ai-distribution-and-subscriptions.md",
+            "Documentation/private-repository-overlays.md",
+            "Documentation/profile-reference.md",
             "Documentation/examples/ai-subscriptions/**",
+            "Documentation/examples/private-repository-overlay/**",
             "Documentation/phase-0-verification.md",
             "Documentation/public-product-architecture.md",
             "Documentation/skill-classification-audit.md",

--- a/tooling/profile-subscription-validation.mjs
+++ b/tooling/profile-subscription-validation.mjs
@@ -2,7 +2,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -53,7 +53,7 @@ export function validateProfileSubscriptions(
         ...validateSchemaVocabulary(schema, "profile-subscription.schema.json"),
     );
     if (
-        profileCatalog.schemaVersion !== "1.0.0" ||
+        profileCatalog.schemaVersion !== "1.1.0" ||
         profileCatalog.state !== "DESIGNED_RELEASES_NOT_YET_PUBLISHED" ||
         profileCatalog.versioning?.strategy !== "semver" ||
         profileCatalog.versioning?.releaseTrain !== "atomic" ||
@@ -65,7 +65,19 @@ export function validateProfileSubscriptions(
         profileCatalog.authority?.projectContextOwner !==
             "consuming repository" ||
         profileCatalog.authority?.directGeneratedEditsAllowed !== false ||
-        profileCatalog.authority?.automaticReverseSyncAllowed !== false
+        profileCatalog.authority?.automaticReverseSyncAllowed !== false ||
+        profileCatalog.confidentiality?.publicProductPackages !==
+            "public-safe-only" ||
+        profileCatalog.confidentiality?.engineeringPackages !==
+            "public-safe-only" ||
+        profileCatalog.confidentiality
+            ?.engineeringPrefixImpliesConfidentiality !== false ||
+        profileCatalog.confidentiality?.confidentialSharedPackagesAllowed !==
+            false ||
+        profileCatalog.confidentiality?.privateFactsOwner !==
+            "consuming private repository" ||
+        profileCatalog.confidentiality?.packageMayReadOrWritePrivateOverlay !==
+            false
     )
         errors.push("Profile catalog authority or versioning contract changed");
     const profiles = [
@@ -79,15 +91,34 @@ export function validateProfileSubscriptions(
     if (duplicates(packageNames).length)
         errors.push("Profile catalog contains duplicate package names");
     const knownProfiles = new Set(profileIds);
+    const publicProfileIds = new Set(
+        profileCatalog.publicProfiles.map((profile) => profile.id),
+    );
+    const engineeringProfileIds = new Set(
+        profileCatalog.engineeringProfiles.map((profile) => profile.id),
+    );
+    const taxonomy = readJson(
+        join(repositoryRoot, "catalog/v2/taxonomy.json"),
+        errors,
+    );
+    const knownProducts = new Set(
+        taxonomy?.dimensions?.products?.map((product) => product.id) ?? [],
+    );
+    const knownLanguages = new Set(
+        taxonomy?.dimensions?.languages?.map((language) => language.id) ?? [],
+    );
     const allowedProfileStates = new Set([
         "approved",
+        "authority-gap",
         "content-gap",
         "owner-review-pending",
         "planned",
         "planned-composition",
+        "planned-source-migration",
         "preview-source-candidate",
     ]);
     for (const profile of profiles) {
+        const isPublic = publicProfileIds.has(profile.id);
         if (!allowedProfileStates.has(profile.state))
             errors.push(
                 `${profile.id}: unknown profile state ${profile.state}`,
@@ -97,11 +128,38 @@ export function validateProfileSubscriptions(
             (profile.availableTargets?.length ?? 0) === 0
         )
             errors.push(`${profile.id}: approved profile has no targets`);
-        for (const dependency of profile.composes ?? [])
-            if (!knownProfiles.has(dependency))
+        if (!/^@cratis\/ai-[a-z0-9]+(?:-[a-z0-9]+)*$/.test(profile.packageName))
+            errors.push(`${profile.id}: invalid package name`);
+        for (const product of profile.products ?? [])
+            if (!knownProducts.has(product))
+                errors.push(`${profile.id}: unknown product ${product}`);
+        for (const language of profile.languages ?? [])
+            if (!knownLanguages.has(language))
+                errors.push(`${profile.id}: unknown language ${language}`);
+        if (
+            !isPublic &&
+            (profile.distributionVisibility !== "public" ||
+                profile.confidentialContentAllowed !== false ||
+                profile.privateOverlayExpected !== true)
+        )
+            errors.push(
+                `${profile.id}: engineering profile must be public-safe with a private local overlay`,
+            );
+        for (const dependency of profile.composes ?? []) {
+            if (!knownProfiles.has(dependency)) {
                 errors.push(
                     `${profile.id}: unknown composed profile ${dependency}`,
                 );
+                continue;
+            }
+            if (
+                (isPublic && !publicProfileIds.has(dependency)) ||
+                (!isPublic && !engineeringProfileIds.has(dependency))
+            )
+                errors.push(
+                    `${profile.id}: composition crosses public and engineering audiences`,
+                );
+        }
     }
     if (
         profileCatalog.subscription?.projectFile !== ".cratis/ai.json" ||
@@ -116,28 +174,27 @@ export function validateProfileSubscriptions(
     )
         errors.push("Profile subscription or contribution boundary changed");
 
+    const exampleRoot = join(
+        repositoryRoot,
+        "Documentation/examples/ai-subscriptions",
+    );
     const examples = [
-        [
-            "Documentation/examples/ai-subscriptions/chronicle-framework.cratis-ai.json",
-            "cratis-engineering",
-        ],
-        [
-            "Documentation/examples/ai-subscriptions/cratis-application.cratis-ai.json",
-            "public",
-        ],
+        ...readdirSync(exampleRoot)
+            .filter((name) => name.endsWith(".cratis-ai.json"))
+            .sort()
+            .map((name) => `Documentation/examples/ai-subscriptions/${name}`),
+        "Documentation/examples/private-repository-overlay/.cratis/ai.json",
     ];
     const parsedExamples = new Map();
-    for (const [relativePath, expectedChannel] of examples) {
+    for (const relativePath of examples) {
         const example = readJson(join(repositoryRoot, relativePath), errors);
         if (!example) continue;
         parsedExamples.set(relativePath, example);
         errors.push(
             ...validateAgainstSchema(example, schema, schema, relativePath),
         );
-        if (example.channel !== expectedChannel)
-            errors.push(`${relativePath}: unexpected channel`);
         const allowedProfiles = new Set(
-            (expectedChannel === "public"
+            (example.channel === "public"
                 ? profileCatalog.publicProfiles
                 : profileCatalog.engineeringProfiles
             ).map((profile) => profile.id),
@@ -182,8 +239,24 @@ function main() {
         for (const error of errors) process.stderr.write(`- ${error}\n`);
         process.exitCode = 1;
     } else {
+        const profileCatalog = JSON.parse(
+            readFileSync(
+                join(
+                    defaultRepositoryRoot,
+                    "distribution/profile-catalog.json",
+                ),
+                "utf8",
+            ),
+        );
+        const exampleCount =
+            readdirSync(
+                join(
+                    defaultRepositoryRoot,
+                    "Documentation/examples/ai-subscriptions",
+                ),
+            ).filter((name) => name.endsWith(".cratis-ai.json")).length + 1;
         process.stdout.write(
-            "Profile subscription validation passed: 16 profiles and 2 examples.\n",
+            `Profile subscription validation passed: ${profileCatalog.publicProfiles.length + profileCatalog.engineeringProfiles.length} profiles and ${exampleCount} examples.\n`,
         );
     }
 }

--- a/tooling/specs/profile-subscription.spec.mjs
+++ b/tooling/specs/profile-subscription.spec.mjs
@@ -23,9 +23,11 @@ const repositoryRoot = resolve(
 const profileFiles = [
     "distribution/profile-catalog.json",
     "distribution/profile-subscription.schema.json",
+    "catalog/v2/taxonomy.json",
     "Documentation/examples/ai-subscriptions/chronicle-framework.cratis-ai.json",
     "Documentation/examples/ai-subscriptions/cratis-application.cratis-ai.json",
     "Documentation/examples/ai-subscriptions/pi-settings.json",
+    "Documentation/examples/private-repository-overlay/.cratis/ai.json",
 ];
 
 function withFixture(callback) {
@@ -55,10 +57,63 @@ test("profile catalog and project subscriptions pass", () => {
     const catalog = readJson(
         join(repositoryRoot, "distribution/profile-catalog.json"),
     );
-    assert.equal(catalog.publicProfiles.length, 5);
-    assert.equal(catalog.engineeringProfiles.length, 11);
+    assert.equal(catalog.publicProfiles.length, 32);
+    assert.equal(catalog.engineeringProfiles.length, 20);
     assert.equal(catalog.versioning.exactPinsRequired, true);
     assert.equal(catalog.authority.automaticReverseSyncAllowed, false);
+    assert.equal(
+        catalog.confidentiality.engineeringPackages,
+        "public-safe-only",
+    );
+    assert.equal(
+        catalog.confidentiality.confidentialSharedPackagesAllowed,
+        false,
+    );
+    assert(
+        catalog.engineeringProfiles.every(
+            (profile) =>
+                profile.distributionVisibility === "public" &&
+                profile.confidentialContentAllowed === false &&
+                profile.privateOverlayExpected === true,
+        ),
+    );
+    const reference = readFileSync(
+        join(repositoryRoot, "Documentation/profile-reference.md"),
+        "utf8",
+    );
+    for (const profile of [
+        ...catalog.publicProfiles,
+        ...catalog.engineeringProfiles,
+    ]) {
+        assert(reference.includes(`\`${profile.id}\``), profile.id);
+        assert(
+            reference.includes(`\`${profile.packageName}\``),
+            profile.packageName,
+        );
+    }
+});
+
+test("private repository overlay composes public-safe package and local facts", () => {
+    const root = join(
+        repositoryRoot,
+        "Documentation/examples/private-repository-overlay",
+    );
+    const subscription = readJson(join(root, ".cratis/ai.json"));
+    const piSettings = readJson(join(root, ".pi/settings.json"));
+    const agents = readFileSync(join(root, "AGENTS.md"), "utf8");
+    const project = readFileSync(join(root, ".cratis/PROJECT.md"), "utf8");
+    const localSkill = readFileSync(
+        join(root, ".agents/skills/studio-local-release/SKILL.md"),
+        "utf8",
+    );
+    assert.deepEqual(subscription.profiles, ["engineering-studio"]);
+    assert.deepEqual(piSettings.packages, [
+        "npm:@cratis/ai-engineering-studio@1.0.0",
+    ]);
+    assert(agents.includes("repository-local skills"));
+    assert(project.includes("private Studio implementation behavior"));
+    assert.match(localSkill, /^---\nname: studio-local-release\ndescription: /);
+    assert.equal(localSkill.includes("@cratis/ai-engineering-studio"), false);
 });
 
 test("profile subscription rejects floating versions and unknown profiles", () => {
@@ -108,7 +163,7 @@ test("subscription schema rejects cross-audience profiles", () => {
             "Documentation/examples/ai-subscriptions/cratis-application.cratis-ai.json",
         );
         const example = readJson(path);
-        example.profiles = ["engineering-framework-chronicle"];
+        example.profiles = ["engineering-chronicle"];
         writeJson(path, example);
         const errors = validateProfileSubscriptions(root);
         assert(
@@ -118,9 +173,7 @@ test("subscription schema rejects cross-audience profiles", () => {
         );
         assert(
             errors.some((error) =>
-                error.includes(
-                    "unknown profile engineering-framework-chronicle",
-                ),
+                error.includes("unknown profile engineering-chronicle"),
             ),
         );
     });
@@ -131,6 +184,8 @@ test("profile catalog rejects unknown composition and authority drift", () => {
         const path = join(root, "distribution/profile-catalog.json");
         const catalog = readJson(path);
         catalog.authority.automaticReverseSyncAllowed = true;
+        catalog.confidentiality.confidentialSharedPackagesAllowed = true;
+        catalog.engineeringProfiles[0].confidentialContentAllowed = true;
         catalog.engineeringProfiles[0].composes = ["engineering-missing"];
         writeJson(path, catalog);
         const errors = validateProfileSubscriptions(root);


### PR DESCRIPTION
# Summary

Implements the accepted Cratis AI adoption model: publish general public-safe product and engineering guidance, while private repositories keep specific confidential AI overlays locally.

## Profiles and coverage

- Expand to 32 public and 20 public-safe engineering profiles (#165)
- Cover Arc EF Core/React, Components, Chronicle clients, identity, compliance, multi-tenancy, CLI and terminal Workbench, browser Workbench, Lens, Screenplay, Stage, Studio, Chronicle MCP and Specifications (#165)
- Preserve Arc-only, Chronicle-only, Arc+Chronicle, React, full application and Screenplay→Stage compositions (#165)
- Track Java as authority gap rather than invent support (#165)

## Adoption guidance

- Developer adoption how-to
- Cratis maintainer adoption how-to
- Private repository overlay/security guidance
- Complete profile reference
- Seven validated subscription examples
- Full non-secret private Studio overlay example
- Public-safe engineering confidentiality rules in universal guidance

## State

Packages remain unpublished and all product/profile support claims remain unclaimed. Private facts, credentials, infrastructure and repository-specific behavior remain local.
