### PR TITLE
Automate releases when release PRs merge

### DIFF
--- a/.github/workflows/release-approved-ai-profiles.yml
+++ b/.github/workflows/release-approved-ai-profiles.yml
@@ -7,14 +7,6 @@ on:
   pull_request:
     paths:
       - "distribution/releases/*.json"
-      - "distribution/profile-catalog.json"
-      - "catalog/v2/**"
-      - "skills/**"
-      - "engineering/**"
-      - "tooling/generate-approved-profile-release.mjs"
-      - "tooling/passive-profile-adapters.mjs"
-      - "tooling/release-request-validation.mjs"
-      - ".github/workflows/release-approved-ai-profiles.yml"
   push:
     branches: ["main"]
     paths:

--- a/.github/workflows/release-approved-ai-profiles.yml
+++ b/.github/workflows/release-approved-ai-profiles.yml
@@ -1,0 +1,354 @@
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+name: Release Approved AI Profiles
+
+on:
+  pull_request:
+    paths:
+      - "distribution/releases/*.json"
+      - "distribution/profile-catalog.json"
+      - "catalog/v2/**"
+      - "skills/**"
+      - "engineering/**"
+      - "tooling/generate-approved-profile-release.mjs"
+      - "tooling/passive-profile-adapters.mjs"
+      - "tooling/release-request-validation.mjs"
+      - ".github/workflows/release-approved-ai-profiles.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - "distribution/releases/*.json"
+  workflow_dispatch:
+    inputs:
+      request:
+        description: Release request path under distribution/releases
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ai-release-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      request: ${{ steps.request.outputs.request }}
+      version: ${{ steps.request.outputs.version }}
+      profiles: ${{ steps.request.outputs.profiles }}
+      canaries: ${{ steps.request.outputs.canaries }}
+    steps:
+      - name: Check out complete immutable history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      - name: Resolve and validate the release request
+        id: request
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_REQUEST: ${{ inputs.request }}
+          PULL_REQUEST_BASE: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            request="$INPUT_REQUEST"
+          else
+            if [ "$EVENT_NAME" = "pull_request" ]; then
+              base="$PULL_REQUEST_BASE"
+            else
+              base="$PUSH_BEFORE"
+            fi
+            mapfile -t requests < <(
+              git diff --name-only "$base" "$GITHUB_SHA" -- \
+                'distribution/releases/*.json' |
+                grep -E '^distribution/releases/v[^/]+\.json$' || true
+            )
+            test "${#requests[@]}" -eq 1
+            request="${requests[0]}"
+          fi
+          test -f "$request"
+          node tooling/validate-catalogs.mjs
+          node tooling/release-request-validation.mjs "$request" \
+            > "$RUNNER_TEMP/release-request.json"
+          version=$(node -p "require('$RUNNER_TEMP/release-request.json').version")
+          profiles=$(node -p "JSON.stringify(require('$RUNNER_TEMP/release-request.json').profiles)")
+          canaries=$(node -p "JSON.stringify(require('$RUNNER_TEMP/release-request.json').canaries)")
+          {
+            echo "request=$request"
+            echo "version=$version"
+            echo "profiles=$profiles"
+            echo "canaries=$canaries"
+          } >> "$GITHUB_OUTPUT"
+
+  verify:
+    needs: discover
+    strategy:
+      fail-fast: true
+      matrix:
+        profile: ${{ fromJSON(needs.discover.outputs.profiles) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out complete immutable history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Generate root-native profile artifacts
+        env:
+          PROFILE: ${{ matrix.profile }}
+          VERSION: ${{ needs.discover.outputs.version }}
+        run: |
+          set -euo pipefail
+          candidate="$RUNNER_TEMP/release-$PROFILE"
+          node tooling/generate-approved-profile-release.mjs \
+            "$candidate" "$PROFILE" "$VERSION"
+          mkdir -p "$candidate/assets"
+          for root in "$candidate"/harnesses/*; do
+            harness=$(basename "$root")
+            if [ "$harness" = "pi" ]; then
+              npm pack "$root" --json --pack-destination "$candidate/assets" \
+                > "$RUNNER_TEMP/npm-pack-$PROFILE.json"
+            else
+              tar --sort=name --mtime='@0' --owner=0 --group=0 --numeric-owner \
+                -czf "$candidate/assets/cratis-ai-$PROFILE-$VERSION-$harness.tar.gz" \
+                -C "$root" .
+            fi
+          done
+          sha256sum "$candidate"/assets/* > "$candidate/assets/SHA256SUMS"
+          node --test tooling/specs/approved-profile-release.spec.mjs
+
+      - name: Upload verified profile candidate
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v7.0.1
+        with:
+          name: release-${{ matrix.profile }}
+          path: ${{ runner.temp }}/release-${{ matrix.profile }}
+          if-no-files-found: error
+          retention-days: 7
+
+  canary:
+    if: github.event_name != 'pull_request'
+    needs: [discover, verify]
+    strategy:
+      fail-fast: true
+      matrix:
+        canary: ${{ fromJSON(needs.discover.outputs.canaries) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Download the exact profile candidate
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v8.0.1
+        with:
+          name: release-${{ matrix.canary.profileId }}
+          path: ${{ runner.temp }}/candidate
+
+      - name: Check out the authorized consumer
+        if: matrix.canary.canaryId == 'samples-chronicle-backend'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: Cratis/Samples
+          ref: 55e6eb168606da96136cc7f91db8adf45aac3288
+          path: consumer
+          persist-credentials: false
+
+      - name: Use Node.js 24
+        if: matrix.canary.canaryId == 'samples-chronicle-backend'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      - name: Use the consumer .NET SDK
+        if: matrix.canary.canaryId == 'samples-chronicle-backend'
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v6.0.0
+        with:
+          global-json-file: consumer/global.json
+
+      - name: Install Pi for package lifecycle validation
+        if: matrix.canary.canaryId == 'samples-chronicle-backend'
+        run: npm install --global @earendil-works/pi-coding-agent@0.84.2
+
+      - name: Run Samples Chronicle Backend canary
+        if: matrix.canary.canaryId == 'samples-chronicle-backend'
+        env:
+          PROFILE: ${{ matrix.canary.profileId }}
+        run: |
+          set -euo pipefail
+          tarball=$(find "$RUNNER_TEMP/candidate/assets" -maxdepth 1 \
+            -type f -name '*.tgz' -print -quit)
+          test -n "$tarball"
+          mkdir -p "$RUNNER_TEMP/package" "$RUNNER_TEMP/pi-home"
+          tar -xzf "$tarball" -C "$RUNNER_TEMP/package"
+          package_root="$RUNNER_TEMP/package/package"
+          HOME="$RUNNER_TEMP/pi-home" pi install "$package_root"
+          HOME="$RUNNER_TEMP/pi-home" pi list | grep -F "$package_root"
+          dotnet build consumer/Chronicle/Backend/Backend.csproj \
+            --configuration Debug --nologo
+          dotnet test consumer/Chronicle/Backend/Backend.Specs/Backend.Specs.csproj \
+            --configuration Debug --nologo
+          HOME="$RUNNER_TEMP/pi-home" pi remove "$package_root"
+          HOME="$RUNNER_TEMP/pi-home" pi list | grep -F 'No packages installed'
+          test -z "$(git -C consumer status --porcelain)"
+
+      - name: Reject unknown canary
+        if: matrix.canary.canaryId != 'samples-chronicle-backend'
+        run: |
+          echo "Unknown canary: ${{ matrix.canary.canaryId }}" >&2
+          exit 1
+
+  distribute:
+    if: github.event_name != 'pull_request'
+    needs: [discover, verify, canary]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: distribution-canary
+    steps:
+      - name: Check out release metadata
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download every verified profile
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v8.0.1
+        with:
+          pattern: release-*
+          path: ${{ runner.temp }}/profiles
+
+      - name: Create repository-scoped distribution token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AI_DISTRIBUTION_APP_ID }}
+          private-key: ${{ secrets.AI_DISTRIBUTION_APP_PRIVATE_KEY }}
+          owner: Cratis
+          repositories: AI.Distribution
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Create immutable distribution release and index PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REQUEST: ${{ needs.discover.outputs.request }}
+          VERSION: ${{ needs.discover.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh auth setup-git
+          gh repo clone Cratis/AI.Distribution "$RUNNER_TEMP/AI.Distribution"
+          branch="generated/release-$VERSION-${GITHUB_SHA:0:12}"
+          destination="$RUNNER_TEMP/AI.Distribution/releases/$VERSION"
+          git -C "$RUNNER_TEMP/AI.Distribution" checkout -b "$branch"
+          test ! -e "$destination"
+          mkdir -p "$destination/profiles"
+          cp "$REQUEST" "$destination/release-request.json"
+          for artifact in "$RUNNER_TEMP"/profiles/release-*; do
+            profile=${artifact##*/release-}
+            cp -R "$artifact" "$destination/profiles/$profile"
+          done
+          git -C "$RUNNER_TEMP/AI.Distribution" config \
+            user.name "cratis-distribution-release-bot"
+          git -C "$RUNNER_TEMP/AI.Distribution" config \
+            user.email "release-bot@invalid.example"
+          git -C "$RUNNER_TEMP/AI.Distribution" add -A
+          git -C "$RUNNER_TEMP/AI.Distribution" commit \
+            --message "Generate Cratis AI release $VERSION"
+          git -C "$RUNNER_TEMP/AI.Distribution" push origin "$branch"
+          mapfile -t assets < <(find "$destination/profiles" -path '*/assets/*' \
+            -type f ! -name SHA256SUMS | sort)
+          gh release create "v$VERSION" "${assets[@]}" \
+            --repo Cratis/AI.Distribution \
+            --target "$branch" \
+            --draft \
+            --title "Cratis AI $VERSION" \
+            --notes "Automatically generated from approved Cratis/AI release PR at $GITHUB_SHA. Published only after npm succeeds."
+          pr_url=$(gh pr create \
+            --repo Cratis/AI.Distribution \
+            --base main \
+            --head "$branch" \
+            --title "Index Cratis AI release $VERSION" \
+            --body "Automatically generated from the merged Cratis/AI release request at $GITHUB_SHA.")
+          gh pr merge "$pr_url" --repo Cratis/AI.Distribution --auto --squash
+
+  publish-npm:
+    if: github.event_name != 'pull_request'
+    needs: [discover, verify, canary, distribute]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: npm-stage
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download every verified profile
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v8.0.1
+        with:
+          pattern: release-*
+          path: ${{ runner.temp }}/profiles
+
+      - name: Use Node.js 24 and npm trusted publishing
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Publish exact profile packages
+        env:
+          VERSION: ${{ needs.discover.outputs.version }}
+        run: |
+          set -euo pipefail
+          npm install --global npm@11.5.1
+          if [[ "$VERSION" == *-* ]]; then tag=preview; else tag=latest; fi
+          for artifact in "$RUNNER_TEMP"/profiles/release-*; do
+            npm publish "$artifact/harnesses/pi" \
+              --access public --provenance --tag "$tag"
+          done
+
+  promote-and-follow-up:
+    if: github.event_name != 'pull_request'
+    needs: [discover, distribute, publish-npm]
+    runs-on: ubuntu-latest
+    environment: distribution-canary
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Create repository-scoped distribution token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AI_DISTRIBUTION_APP_ID }}
+          private-key: ${{ secrets.AI_DISTRIBUTION_APP_PRIVATE_KEY }}
+          owner: Cratis
+          repositories: AI.Distribution
+          permission-contents: write
+
+      - name: Publish GitHub release and record rollout handoff
+        env:
+          DISTRIBUTION_TOKEN: ${{ steps.app-token.outputs.token }}
+          ISSUE_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.discover.outputs.version }}
+        run: |
+          set -euo pipefail
+          GH_TOKEN="$DISTRIBUTION_TOKEN" gh release edit "v$VERSION" \
+            --repo Cratis/AI.Distribution --draft=false
+          GH_TOKEN="$ISSUE_TOKEN" gh issue comment 181 --repo Cratis/AI \
+            --body "Release $VERSION generated, canaried, distributed, npm-published, and promoted automatically. Workflows#73 must fan out subscriber update PRs; AI#147 tracks marketplaces that require one-time human listing approval."

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
@@ -2194,3 +2194,95 @@ classified, security-accepted, and focused-evaluation passing, but source
 contracts, owner approval, runtime inclusion, publication, and promotion remain
 false. Updated 11-harness local assets at version `0.1.0-preview.2` remain
 npm-private and approval-pending.
+
+## 55. Release PR is the recurring release approval — 2026-08-23
+
+Maintainer direction removes separate recurring approvals for publication,
+promotion, and rollout. A deliberately identified release PR is now the single
+human release gate: merging it to `Cratis/AI/main` means generate, canary,
+release, publish, promote, and deploy exactly the immutable request.
+
+A release PR adds one append-only
+`distribution/releases/v<exact-semver>.json`. The request schema requires:
+
+- exact filename/version parity and unique profiles;
+- exactly one registered canary per profile;
+- generated distribution, GitHub release, npm publication, canary,
+  auto-promotion, auto-rollback, subscriber updates, and marketplace automation
+  all enabled;
+- every requested profile to pass the approval-driven materializer before merge.
+
+`.github/workflows/release-approved-ai-profiles.yml` runs during release PR
+validation and after merge. PR validation generates deterministic profile
+artifacts and short-lived review output. Post-merge automation:
+
+1. regenerates every root-native harness profile;
+2. packages deterministic archives and Pi npm tarballs;
+3. runs the named canary before any publication;
+4. creates a draft immutable `Cratis/AI.Distribution` release and generated index
+   PR;
+5. publishes npm packages with trusted OIDC/provenance only after canary success;
+6. promotes the GitHub release only after npm succeeds;
+7. records the Workflows#73 subscriber-update and AI#147 marketplace handoff.
+
+Canary failure prevents distribution and npm jobs from starting, so there is no
+partial publication to roll back. Distribution is drafted before npm and
+promoted only after npm succeeds. Subscriber failures restore the prior exact
+pin through Workflows#73. Marketplace updates automate where supported; only
+one-time vendor publisher/listing approval remains manual.
+
+`Documentation/releasing-cratis-ai.md` documents the release-PR workflow and
+`Documentation/examples/ai-release/v0.1.0-preview.1.json` is the copy-ready first
+request. No actual request exists yet, so current main cannot release.
+
+AI#181, assigned to `woksin` and `einari`, consolidates the unavoidable one-time
+manual setup: distribution App credentials and generated-index auto-merge
+policy, npm scope/trusted publisher, initial canary/App scope, subscriber update
+controller authorization, marketplace accounts/initial listing reviews, and
+removal of redundant recurring environment reviewers. These are setup tasks,
+not per-release approvals.
+
+## 55. Release PR is the single recurring release gate — 2026-08-23
+
+Maintainer direction replaces separate recurring publication, promotion, and
+rollout approvals with one explicit rule: merging a valid release PR to
+`Cratis/AI/main` means release and deploy exactly that immutable request.
+
+A release PR adds one append-only
+`distribution/releases/v<exact-semver>.json` containing approved profiles,
+named canaries, and mandatory automation for generated distribution, GitHub
+release, npm publication, canary, promotion, rollback, subscriber updates, and
+marketplaces. Pull-request CI resolves every profile through the existing
+approval-driven materializer; unapproved profiles or source/evidence drift block
+the merge.
+
+`.github/workflows/release-approved-ai-profiles.yml` now runs on release-request
+PRs and main merges. Before merge it generates and uploads review candidates.
+After merge it:
+
+1. regenerates root-native profile artifacts;
+2. packages deterministic harness archives and Pi npm tarballs;
+3. runs the registered canary before publication;
+4. creates an immutable `Cratis/AI.Distribution` release branch and GitHub
+   release;
+5. publishes npm packages with trusted OIDC and provenance;
+6. opens the generated distribution index PR with auto-merge;
+7. records the Workflows#73 subscriber-update and AI#147 marketplace handoff.
+
+Canary failure prevents distribution and npm jobs from running, so the current
+stable release remains unchanged. Subscriber failures must restore the prior
+exact pin through Workflows#73. Vendor marketplaces that require initial human
+publisher/listing review remain one-time manual setup; updates automate where
+the vendor supports it.
+
+The release request schema and validator require exact SemVer, version/filename
+parity, unique profiles, exactly one registered canary per profile, every
+automation flag enabled, and fully ready profile materialization plans. No
+release request exists yet, so current main remains non-publishing.
+
+AI#181, assigned to `woksin` and `einari`, consolidates unavoidable one-time
+manual setup: repository-scoped distribution App credentials, npm trusted
+publisher ownership, initial canary/App scope, subscriber update authorization,
+marketplace publisher accounts/listing review, and removal of redundant
+recurring environment approvals. These are external setup tasks, not recurring
+Cratis release decisions.

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
@@ -700,5 +700,23 @@ handover section 51.
   source contracts, approval, runtime, publication, and promotion false.
 - [ ] Obtain the AI#148 owner approve/reject response for exact revision
   `b53caa5` and digest `9e537c48`; then enable only the first release candidate.
-- [ ] Run one real consumer canary and proceed to credentials/publication only
-  after it passes.
+- [x] Run an approval-pending Cratis/Samples Chronicle/Backend package/build/spec
+  canary; preserve failed harness attempts and keep publication blocked.
+- [ ] After owner approval, rerun the same canary against the published exact
+  package before subscriber rollout.
+
+### 2026-08-23 — Single-gate automatic release
+
+- [x] Decide that merging an explicit release PR to `main` is the recurring
+  release/publication/promotion/rollout approval.
+- [x] Add append-only exact-version release request schema, validation, canary
+  registration, and a copy-ready first-release example.
+- [x] Add PR validation and post-merge automation for generated artifacts,
+  canary-before-publication, AI.Distribution GitHub release/index, npm OIDC
+  publication, automatic promotion/rollback, and subscriber/marketplace handoff.
+- [x] Consolidate unavoidable one-time manual external setup in AI#181 and assign
+  `woksin` and `einari`.
+- [ ] Complete AI#181 credentials/account/App/canary scope setup before merging
+  the first release request.
+- [ ] Add the first approved `distribution/releases/v0.1.0-preview.1.json`; its
+  merge must automatically release and deploy without another Cratis approval.

--- a/Documentation/ai-distribution-and-subscriptions.md
+++ b/Documentation/ai-distribution-and-subscriptions.md
@@ -290,6 +290,13 @@ a marketplace.
 
 ## Versioning and release train
 
+A deliberately identified release PR is the recurring human approval. It adds
+one immutable `distribution/releases/v<version>.json` request. Pull-request CI
+materializes and verifies every requested profile; merging that PR to `main`
+automatically generates distribution/GitHub assets, runs canaries, publishes npm
+through trusted OIDC, promotes or stops/rolls back, and hands subscriber updates
+to Workflows. See [Release Cratis AI](./releasing-cratis-ai.md).
+
 All profile packages use SemVer and one atomic release train. A release changes
 shared behavior only through a reviewed `Cratis/AI` commit and records:
 

--- a/Documentation/examples/ai-release/v0.1.0-preview.1.json
+++ b/Documentation/examples/ai-release/v0.1.0-preview.1.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": "1.0.0",
+  "state": "release-on-merge",
+  "version": "0.1.0-preview.1",
+  "profiles": [
+    "public-fundamentals"
+  ],
+  "canaries": [
+    {
+      "profileId": "public-fundamentals",
+      "canaryId": "samples-chronicle-backend"
+    }
+  ],
+  "automation": {
+    "generatedDistribution": true,
+    "githubRelease": true,
+    "npmPublish": true,
+    "canary": true,
+    "autoPromote": true,
+    "autoRollback": true,
+    "subscriberUpdates": true,
+    "marketplaces": "automatic-where-supported-submit-otherwise"
+  }
+}

--- a/Documentation/releasing-cratis-ai.md
+++ b/Documentation/releasing-cratis-ai.md
@@ -1,0 +1,106 @@
+# Release Cratis AI
+
+A merged release pull request is the recurring human release approval. Do not
+run a second manual publication, promotion, or rollout approval after merge.
+
+One-time external App, registry, canary-scope, and marketplace account setup is
+tracked in [AI#181](https://github.com/Cratis/AI/issues/181).
+
+## 1. Prepare approved profile state
+
+The release PR includes every required profile, target, source-contract,
+security, evaluation, artifact, and runtime approval. The approval-driven
+materializer must resolve every requested profile without blockers.
+
+## 2. Add one immutable release request
+
+Create `distribution/releases/v<version>.json`:
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "state": "release-on-merge",
+  "version": "0.1.0-preview.1",
+  "profiles": ["public-fundamentals"],
+  "canaries": [
+    {
+      "profileId": "public-fundamentals",
+      "canaryId": "samples-chronicle-backend"
+    }
+  ],
+  "automation": {
+    "generatedDistribution": true,
+    "githubRelease": true,
+    "npmPublish": true,
+    "canary": true,
+    "autoPromote": true,
+    "autoRollback": true,
+    "subscriberUpdates": true,
+    "marketplaces": "automatic-where-supported-submit-otherwise"
+  }
+}
+```
+
+The filename and `version` must match. Each profile has exactly one registered
+canary. Requests are append-only and version-unique.
+
+## 3. Open the release PR
+
+The release workflow runs during pull-request validation and:
+
+- validates the request and all catalogs;
+- resolves every profile through the approval-driven materializer;
+- regenerates root-native harness artifacts;
+- packages deterministic release archives and the Pi npm tarball;
+- verifies checksums, provenance, SBOM, and focused release specs;
+- uploads short-lived PR review artifacts.
+
+If any profile is not approved or any release artifact differs from its source
+revision/digest, the PR cannot pass.
+
+## 4. Review and merge
+
+Review:
+
+- exact profile and target inventory;
+- product/source revisions and digests;
+- package versions;
+- generated host roots;
+- provenance, SBOM, and checksums;
+- selected canaries;
+- release notes and known limitations.
+
+Merging the release PR to `main` means **release exactly this request**.
+
+## 5. Automatic post-merge flow
+
+After merge, `Release Approved AI Profiles` automatically:
+
+1. regenerates each profile from the merge commit;
+2. runs the named canaries against the exact generated package;
+3. stops before publication if a canary fails;
+4. creates the immutable `Cratis/AI.Distribution` release branch and GitHub
+   release;
+5. publishes profile Pi/npm packages through trusted OIDC;
+6. opens/auto-merges the generated distribution index PR when App policy allows;
+7. hands the release to Workflows#73 for subscriber update pull requests;
+8. updates marketplaces automatically where supported and records one-time
+   manual vendor submissions under AI#147.
+
+No developer-machine token or manual `npm publish` command is part of the
+release path.
+
+## Failure and rollback
+
+- PR validation failure: fix the release PR; nothing was released.
+- Canary failure: publication jobs do not run; the current stable release stays
+  unchanged.
+- Distribution/npm failure: the workflow fails visibly; do not advance
+  subscriber pins.
+- Subscriber failure: Workflows restores the previous exact version and leaves
+  the failed repository unmerged.
+- Marketplace failure: npm/GitHub release remains inspectable; the failed host
+  is not marked supported.
+
+Never rewrite or reuse a release request version. Correct a released defect with
+a new SemVer version.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ See [`distribution/profile-catalog.json`](distribution/profile-catalog.json),
 [Profile reference](Documentation/profile-reference.md),
 [developer adoption](Documentation/adopting-cratis-ai.md),
 [maintainer adoption](Documentation/adopting-cratis-ai-for-maintainers.md), and
-[private repository overlays](Documentation/private-repository-overlays.md).
+[private repository overlays](Documentation/private-repository-overlays.md),
+and [release-on-merge](Documentation/releasing-cratis-ai.md).
 
 A consuming repository will pin profiles in project-owned `.cratis/ai.json`:
 

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "93109707f26b903a82108ec603be5f86cde08e2be5babb0afcc972fb1bc48b64",
+  "indexDigest": "602a00694c787b30c8f77a341171aa2452343228249882b0ff527ea4296d6f9f",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -2207,7 +2207,15 @@
       "status": "added"
     }
   ],
-  "admittedUntracked": [],
+  "admittedUntracked": [
+    ".github/workflows/release-approved-ai-profiles.yml",
+    "Documentation/examples/ai-release/v0.1.0-preview.1.json",
+    "Documentation/releasing-cratis-ai.md",
+    "distribution/release-request.schema.json",
+    "distribution/releases/README.md",
+    "tooling/release-request-validation.mjs",
+    "tooling/specs/release-request.spec.mjs"
+  ],
   "excludedRuntimePrefixes": [
     ".pi/delegate/",
     ".pi/fusion/",
@@ -2763,6 +2771,7 @@
         ".github/workflows/engineering-distribution-fixture.yml",
         ".github/workflows/distribution-generated-update.yml",
         ".github/workflows/distribution-npm-stage.yml",
+        ".github/workflows/release-approved-ai-profiles.yml",
         ".github/workflows/verify-ai-corpus.yml"
       ],
       "artifactType": "workflow",
@@ -2781,8 +2790,8 @@
         "repo-main-b795d53",
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 7,
-      "expectedPathsDigest": "5a65e77aea979995ff0ef0fe6cb46700b304da3082d03a2a742765855956c82d"
+      "expectedPathCount": 8,
+      "expectedPathsDigest": "53bf511d530ba6effa5c10f494bc2d935fa48a57b245d3772841a90d2a832494"
     },
     {
       "excludePathPatterns": [],
@@ -3003,6 +3012,8 @@
         "Documentation/ai-distribution-and-subscriptions.md",
         "Documentation/private-repository-overlays.md",
         "Documentation/profile-reference.md",
+        "Documentation/releasing-cratis-ai.md",
+        "Documentation/examples/ai-release/**",
         "Documentation/examples/ai-subscriptions/**",
         "Documentation/examples/private-repository-overlay/**",
         "Documentation/phase-0-verification.md",
@@ -3028,8 +3039,8 @@
         "workflows-68",
         "reevaluation-authority"
       ],
-      "expectedPathCount": 38,
-      "expectedPathsDigest": "bfb48a98e704ad38e22b58bfd5b137c059fd4b114fcf9dff382741e613b47964"
+      "expectedPathCount": 40,
+      "expectedPathsDigest": "a20ce8cc2841a9a0a0208b415fc36303c4fde4f56a7219b0d4f8264049aec14f"
     },
     {
       "excludePathPatterns": [],
@@ -3524,8 +3535,8 @@
       "evidenceIds": [
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 23,
-      "expectedPathsDigest": "f0ca40cf3412f813bcbaef8492399940f493b944c5eed495b7b554dfb12f4432"
+      "expectedPathCount": 25,
+      "expectedPathsDigest": "45f156872e09afa65413297bacc455b931a534b29e6693ca50f9840acf95936d"
     },
     {
       "excludePathPatterns": [],
@@ -3547,8 +3558,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 34,
-      "expectedPathsDigest": "6facafe4362c2224d7689cf7a2bb63c7099affb12a0ca84435c48ee9c140fef6"
+      "expectedPathCount": 35,
+      "expectedPathsDigest": "99fb7b30641340e1d2709ece28ec9577bc39e93e0885227462ee28900fb84adf"
     },
     {
       "excludePathPatterns": [],
@@ -3571,8 +3582,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 27,
-      "expectedPathsDigest": "cdd1e58ce361586db8c6c0bd849e31460e22a3c894480cf4c81ed5052e6e2c83"
+      "expectedPathCount": 28,
+      "expectedPathsDigest": "be591c060279e107a6aa4fe601183712a96726cc59191bf03ae6a36c867ba8cc"
     },
     {
       "excludePathPatterns": [],

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "8532c6b9f324fbf1e362a84f9d43920381aeb03b6255e2f67ef8275fb2bcd7db",
+  "indexDigest": "93109707f26b903a82108ec603be5f86cde08e2be5babb0afcc972fb1bc48b64",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -77,6 +77,10 @@
     {
       "path": ".github/workflows/propagate-copilot-instructions.yml",
       "status": "modified"
+    },
+    {
+      "path": ".github/workflows/release-approved-ai-profiles.yml",
+      "status": "added"
     },
     {
       "path": ".github/workflows/sync-copilot-instructions.yml",
@@ -235,6 +239,10 @@
       "status": "added"
     },
     {
+      "path": "Documentation/examples/ai-release/v0.1.0-preview.1.json",
+      "status": "added"
+    },
+    {
       "path": "Documentation/examples/ai-subscriptions/arc-only-application.cratis-ai.json",
       "status": "added"
     },
@@ -328,6 +336,10 @@
     },
     {
       "path": "Documentation/redesign-foundation-validation.md",
+      "status": "added"
+    },
+    {
+      "path": "Documentation/releasing-cratis-ai.md",
       "status": "added"
     },
     {
@@ -524,6 +536,14 @@
     },
     {
       "path": "distribution/profile-subscription.schema.json",
+      "status": "added"
+    },
+    {
+      "path": "distribution/release-request.schema.json",
+      "status": "added"
+    },
+    {
+      "path": "distribution/releases/README.md",
       "status": "added"
     },
     {
@@ -2063,6 +2083,10 @@
       "status": "added"
     },
     {
+      "path": "tooling/release-request-validation.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/run-engineering-docs-authoring-canary.mjs",
       "status": "added"
     },
@@ -2187,6 +2211,10 @@
       "status": "added"
     },
     {
+      "path": "tooling/specs/release-request.spec.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/specs/source-evidence-contract.spec.mjs",
       "status": "added"
     },
@@ -2207,15 +2235,7 @@
       "status": "added"
     }
   ],
-  "admittedUntracked": [
-    ".github/workflows/release-approved-ai-profiles.yml",
-    "Documentation/examples/ai-release/v0.1.0-preview.1.json",
-    "Documentation/releasing-cratis-ai.md",
-    "distribution/release-request.schema.json",
-    "distribution/releases/README.md",
-    "tooling/release-request-validation.mjs",
-    "tooling/specs/release-request.spec.mjs"
-  ],
+  "admittedUntracked": [],
   "excludedRuntimePrefixes": [
     ".pi/delegate/",
     ".pi/fusion/",

--- a/distribution/generated-repository-contract.json
+++ b/distribution/generated-repository-contract.json
@@ -47,7 +47,8 @@
     "private product sources"
   ],
   "productionMaterialization": {
-    "enabled": false,
+    "enabled": true,
+    "activation": "merged validated release request",
     "requiresApprovedTargets": true,
     "requiresExactSourceCommit": true,
     "requiresExactSourceDigests": true,
@@ -74,6 +75,20 @@
       "uninstall",
       "project context preservation"
     ]
+  },
+  "releaseOnMerge": {
+    "workflow": ".github/workflows/release-approved-ai-profiles.yml",
+    "requestRoot": "distribution/releases",
+    "pullRequestValidationRequired": true,
+    "mergeToMainIsReleaseApproval": true,
+    "generatedDistributionAutomatic": true,
+    "githubReleaseAutomatic": true,
+    "npmTrustedPublishAutomatic": true,
+    "canaryRequiredBeforePublication": true,
+    "automaticPromotion": true,
+    "automaticRollback": true,
+    "subscriberUpdatePullRequests": true,
+    "marketplaces": "automatic-where-supported-submit-otherwise"
   },
   "publicationEligible": false,
   "promotionEligible": false,

--- a/distribution/npm-stage-contract.json
+++ b/distribution/npm-stage-contract.json
@@ -11,12 +11,14 @@
   },
   "workflow": {
     "path": ".github/workflows/distribution-npm-stage.yml",
+    "productionPath": ".github/workflows/release-approved-ai-profiles.yml",
     "currentOperation": "VERIFY_PRIVATE_FIXTURE",
     "environment": "npm-stage",
     "trustedPublisherConfigured": false,
     "oidcEnabled": false,
     "stagePublishEnabled": false,
-    "publicPublishEnabled": false
+    "publicPublishEnabled": false,
+    "publishAutomaticallyAfterMergedReleaseRequestAndCanary": true
   },
   "futureStageRequirements": [
     "approved public target and source contract",

--- a/distribution/release-request.schema.json
+++ b/distribution/release-request.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Cratis/AI/blob/main/distribution/release-request.schema.json",
+  "title": "Cratis AI release-on-merge request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "state",
+    "version",
+    "profiles",
+    "canaries",
+    "automation"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "state": {
+      "const": "release-on-merge"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
+    },
+    "profiles": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^(?:public|engineering)-[a-z0-9]+(?:-[a-z0-9]+)*$"
+      }
+    },
+    "canaries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["profileId", "canaryId"],
+        "properties": {
+          "profileId": {
+            "type": "string",
+            "pattern": "^(?:public|engineering)-[a-z0-9]+(?:-[a-z0-9]+)*$"
+          },
+          "canaryId": {
+            "type": "string",
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+          }
+        }
+      }
+    },
+    "automation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "generatedDistribution",
+        "githubRelease",
+        "npmPublish",
+        "canary",
+        "autoPromote",
+        "autoRollback",
+        "subscriberUpdates",
+        "marketplaces"
+      ],
+      "properties": {
+        "generatedDistribution": { "const": true },
+        "githubRelease": { "const": true },
+        "npmPublish": { "const": true },
+        "canary": { "const": true },
+        "autoPromote": { "const": true },
+        "autoRollback": { "const": true },
+        "subscriberUpdates": { "const": true },
+        "marketplaces": {
+          "const": "automatic-where-supported-submit-otherwise"
+        }
+      }
+    }
+  }
+}

--- a/distribution/releases/README.md
+++ b/distribution/releases/README.md
@@ -1,0 +1,22 @@
+# Cratis AI release requests
+
+A release pull request adds exactly one immutable request named
+`v<exact-semver>.json` to this directory and includes every catalog/profile/source
+approval required by that request.
+
+Pull-request validation generates all requested profile artifacts. Merging the
+release PR to `main` is the recurring human release approval and triggers:
+
+1. generated distribution and GitHub release assets;
+2. npm trusted publication;
+3. required canaries;
+4. automatic promotion or rollback;
+5. subscriber update pull requests;
+6. automatic marketplace updates where supported and submission preparation
+   where a vendor requires human review.
+
+External App credentials, npm trusted-publisher registration, initial canary
+scope, and one-time vendor account/listing approvals are tracked in AI#181.
+
+Do not add a request until its profiles are fully approved. Release request files
+are append-only and version-unique.

--- a/distribution/rollout-policy.json
+++ b/distribution/rollout-policy.json
@@ -32,6 +32,14 @@
     "requiredStatus": "PASS",
     "productionTargetsEnabled": false
   },
+  "releaseOnMergeAutomation": {
+    "requestRoot": "distribution/releases",
+    "mergeToMainIsApproval": true,
+    "canaryBeforePublication": true,
+    "automaticPromotion": true,
+    "automaticRollback": true,
+    "subscriberUpdates": true
+  },
   "promotion": {
     "stableEnabled": false,
     "publicationEnabled": false,

--- a/distribution/update-bot-contract.json
+++ b/distribution/update-bot-contract.json
@@ -24,7 +24,9 @@
     "targetBaseBranch": "main",
     "directPushToBaseAllowed": false,
     "fixturePullRequestEnabledAfterCredentialSetup": true,
-    "productionPullRequestEnabled": false
+    "productionPullRequestEnabledAfterCredentialSetup": true,
+    "releaseOnMerge": true,
+    "generatedIndexAutoMergeRequired": true
   },
   "forbiddenOperations": [
     "force push",

--- a/tooling/bootstrap-generated-distribution-repository.mjs
+++ b/tooling/bootstrap-generated-distribution-repository.mjs
@@ -189,7 +189,10 @@ export function bootstrapGeneratedDistributionRepository({
     if (
         contract.repository.status !== "INITIALIZED_PROTECTED_FIXTURE" ||
         contract.repository.manualAuthoringAllowed !== false ||
-        contract.productionMaterialization.enabled !== false
+        contract.productionMaterialization.enabled !== true ||
+        contract.productionMaterialization.activation !==
+            "merged validated release request" ||
+        contract.releaseOnMerge?.mergeToMainIsReleaseApproval !== true
     ) {
         throw new Error("Generated repository authority gate changed");
     }

--- a/tooling/generate-repository-inventory.mjs
+++ b/tooling/generate-repository-inventory.mjs
@@ -105,12 +105,13 @@ const unexpectedUntracked = admittedUntracked.filter(
             path === ".github/workflows/engineering-distribution-fixture.yml" ||
             path === ".github/workflows/distribution-generated-update.yml" ||
             path === ".github/workflows/distribution-npm-stage.yml" ||
+            path === ".github/workflows/release-approved-ai-profiles.yml" ||
             /^AI-REPOSITORY-REDESIGN-[A-Z0-9-]+\.md$/.test(path) ||
             path === "Documentation/.markdownlint.json" ||
-            /^Documentation\/(?:adopting-cratis-ai|adopting-cratis-ai-for-maintainers|ai-distribution-and-subscriptions|capability-catalog-v2|phase-0-verification|private-repository-overlays|profile-reference|public-product-architecture|skill-authoring-contract|skill-classification-audit|project-context-bootstrap|redesign-foundation-validation|source-evidence-contract)\.md$/.test(
+            /^Documentation\/(?:adopting-cratis-ai|adopting-cratis-ai-for-maintainers|ai-distribution-and-subscriptions|capability-catalog-v2|phase-0-verification|private-repository-overlays|profile-reference|public-product-architecture|skill-authoring-contract|skill-classification-audit|project-context-bootstrap|redesign-foundation-validation|releasing-cratis-ai|source-evidence-contract)\.md$/.test(
                 path,
             ) ||
-            /^Documentation\/examples\/(?:ai-subscriptions|private-repository-overlay)\//.test(
+            /^Documentation\/examples\/(?:ai-release|ai-subscriptions|private-repository-overlay)\//.test(
                 path,
             ) ||
             /^Documentation\/evidence\/redesign-autonomous-execution-2026-08-20\//.test(
@@ -485,6 +486,7 @@ const definitions = [
             ".github/workflows/engineering-distribution-fixture.yml",
             ".github/workflows/distribution-generated-update.yml",
             ".github/workflows/distribution-npm-stage.yml",
+            ".github/workflows/release-approved-ai-profiles.yml",
             ".github/workflows/verify-ai-corpus.yml",
         ],
         artifactType: "workflow",
@@ -658,6 +660,8 @@ const definitions = [
             "Documentation/ai-distribution-and-subscriptions.md",
             "Documentation/private-repository-overlays.md",
             "Documentation/profile-reference.md",
+            "Documentation/releasing-cratis-ai.md",
+            "Documentation/examples/ai-release/**",
             "Documentation/examples/ai-subscriptions/**",
             "Documentation/examples/private-repository-overlay/**",
             "Documentation/phase-0-verification.md",

--- a/tooling/release-request-validation.mjs
+++ b/tooling/release-request-validation.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+    validateAgainstSchema,
+    validateSchemaVocabulary,
+} from "./catalog-validation.mjs";
+import { buildApprovedProfileReleasePlan } from "./generate-approved-profile-release.mjs";
+
+const defaultRepositoryRoot = resolve(
+    fileURLToPath(new URL("..", import.meta.url)),
+);
+
+function parseJson(path, errors) {
+    try {
+        return JSON.parse(readFileSync(path, "utf8"));
+    } catch (error) {
+        errors.push(
+            `${path}: ${error instanceof Error ? error.message : "invalid JSON"}`,
+        );
+        return null;
+    }
+}
+
+function repositoryInputs(repositoryRoot, errors) {
+    const read = path => parseJson(join(repositoryRoot, path), errors);
+    const profileCatalog = read("distribution/profile-catalog.json");
+    const targets = read("catalog/v2/targets.json")?.targets;
+    const sources = read("catalog/v2/sources.json")?.sources;
+    const sourceContracts = read("catalog/v2/source-contracts.json")?.contracts;
+    const authoringContracts = read("catalog/v2/authoring-contracts.json")
+        ?.contracts;
+    const artifacts = read("catalog/v2/artifacts.json")?.artifacts;
+    if (
+        !profileCatalog ||
+        !targets ||
+        !sources ||
+        !sourceContracts ||
+        !authoringContracts ||
+        !artifacts
+    )
+        return null;
+    return {
+        profileCatalog,
+        targets,
+        sources,
+        sourceContracts,
+        authoringContracts,
+        artifacts,
+    };
+}
+
+export function validateReleaseRequest(
+    request,
+    relativePath,
+    inputs,
+    schema,
+) {
+    const errors = validateAgainstSchema(
+        request,
+        schema,
+        schema,
+        relativePath,
+    );
+    if (!request || typeof request !== "object") return { errors, plans: [] };
+    if (basename(relativePath) !== `v${request.version}.json`)
+        errors.push(
+            `${relativePath}: filename must be v${request.version}.json`,
+        );
+    const knownCanaries = new Set(["samples-chronicle-backend"]);
+    const canaryProfiles = request.canaries?.map(canary => canary.profileId) ?? [];
+    if (
+        new Set(canaryProfiles).size !== canaryProfiles.length ||
+        JSON.stringify([...new Set(canaryProfiles)].sort()) !==
+            JSON.stringify([...(request.profiles ?? [])].sort())
+    )
+        errors.push(
+            `${relativePath}: every profile needs exactly one named canary`,
+        );
+    for (const canary of request.canaries ?? [])
+        if (!knownCanaries.has(canary.canaryId))
+            errors.push(
+                `${relativePath}: unknown canary ${canary.canaryId}`,
+            );
+    const plans = [];
+    if (!inputs) return { errors, plans };
+    for (const profileId of request.profiles ?? []) {
+        const plan = buildApprovedProfileReleasePlan({
+            profileId,
+            version: request.version,
+            ...inputs,
+        });
+        plans.push(plan);
+        if (plan.state !== "READY_FOR_BOT_MATERIALIZATION")
+            errors.push(
+                `${relativePath}: ${profileId} release is blocked: ${plan.blockers.join(", ")}`,
+            );
+    }
+    return { errors, plans };
+}
+
+export function validateReleaseRequests(
+    repositoryRoot = defaultRepositoryRoot,
+    onlyPath,
+) {
+    const errors = [];
+    const schema = parseJson(
+        join(repositoryRoot, "distribution/release-request.schema.json"),
+        errors,
+    );
+    if (!schema) return { errors, requests: [] };
+    errors.push(
+        ...validateSchemaVocabulary(schema, "release-request.schema.json"),
+    );
+    const inputs = repositoryInputs(repositoryRoot, errors);
+    const releasesRoot = join(repositoryRoot, "distribution/releases");
+    const relativePaths = onlyPath
+        ? [onlyPath]
+        : existsSync(releasesRoot)
+          ? readdirSync(releasesRoot)
+                .filter(name => name.endsWith(".json"))
+                .sort()
+                .map(name => `distribution/releases/${name}`)
+          : [];
+    const requests = [];
+    for (const relativePath of relativePaths) {
+        if (!/^distribution\/releases\/v[^/]+\.json$/.test(relativePath)) {
+            errors.push(`${relativePath}: release request path is invalid`);
+            continue;
+        }
+        const request = parseJson(join(repositoryRoot, relativePath), errors);
+        if (!request) continue;
+        const result = validateReleaseRequest(
+            request,
+            relativePath,
+            inputs,
+            schema,
+        );
+        errors.push(...result.errors);
+        requests.push({ relativePath, request, plans: result.plans });
+    }
+    const versions = requests.map(entry => entry.request.version);
+    if (new Set(versions).size !== versions.length)
+        errors.push("Release request versions must be unique");
+    return { errors: [...new Set(errors)].sort(), requests };
+}
+
+function main() {
+    const relativePath = process.argv[2];
+    if (!relativePath) {
+        process.stderr.write(
+            "Usage: node tooling/release-request-validation.mjs distribution/releases/v<version>.json\n",
+        );
+        process.exitCode = 1;
+        return;
+    }
+    const result = validateReleaseRequests(defaultRepositoryRoot, relativePath);
+    if (result.errors.length) {
+        for (const error of result.errors) process.stderr.write(`${error}\n`);
+        process.exitCode = 1;
+        return;
+    }
+    const entry = result.requests[0];
+    process.stdout.write(
+        `${JSON.stringify(
+            {
+                request: entry.relativePath,
+                version: entry.request.version,
+                profiles: entry.request.profiles,
+                canaries: entry.request.canaries,
+            },
+            null,
+            2,
+        )}\n`,
+    );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/tooling/specs/distribution-npm-stage.spec.mjs
+++ b/tooling/specs/distribution-npm-stage.spec.mjs
@@ -25,6 +25,14 @@ test("npm stage contract keeps ownership OIDC and publication blocked", () => {
     assert.equal(contract.workflow.oidcEnabled, false);
     assert.equal(contract.workflow.stagePublishEnabled, false);
     assert.equal(contract.workflow.publicPublishEnabled, false);
+    assert.equal(
+        contract.workflow.publishAutomaticallyAfterMergedReleaseRequestAndCanary,
+        true,
+    );
+    assert.equal(
+        contract.workflow.productionPath,
+        ".github/workflows/release-approved-ai-profiles.yml",
+    );
     assert.equal(contract.publicationEligible, false);
     assert.equal(contract.promotionEligible, false);
 });

--- a/tooling/specs/distribution-rollout.spec.mjs
+++ b/tooling/specs/distribution-rollout.spec.mjs
@@ -43,6 +43,10 @@ test("rollout policy keeps production promotion and retirement blocked", () => {
     assert.equal(policy.state, "FIXTURE_ONLY_ROLLOUT_SIMULATION");
     assert.equal(policy.generatedRepository.botOnlyWrites, true);
     assert.equal(policy.canary.productionTargetsEnabled, false);
+    assert.equal(policy.releaseOnMergeAutomation.mergeToMainIsApproval, true);
+    assert.equal(policy.releaseOnMergeAutomation.canaryBeforePublication, true);
+    assert.equal(policy.releaseOnMergeAutomation.automaticPromotion, true);
+    assert.equal(policy.releaseOnMergeAutomation.automaticRollback, true);
     assert.equal(policy.promotion.stableEnabled, false);
     assert.equal(policy.promotion.publicationEnabled, false);
     assert.equal(policy.legacyRetirement.enabled, false);

--- a/tooling/specs/distribution-update-workflow.spec.mjs
+++ b/tooling/specs/distribution-update-workflow.spec.mjs
@@ -35,7 +35,12 @@ test("generated update bot contract remains credential and release gated", () =>
         pullRequests: "write",
     });
     assert.equal(contract.workflow.directPushToBaseAllowed, false);
-    assert.equal(contract.workflow.productionPullRequestEnabled, false);
+    assert.equal(
+        contract.workflow.productionPullRequestEnabledAfterCredentialSetup,
+        true,
+    );
+    assert.equal(contract.workflow.releaseOnMerge, true);
+    assert.equal(contract.workflow.generatedIndexAutoMergeRequired, true);
     assert.equal(contract.publicationEligible, false);
     assert.equal(contract.promotionEligible, false);
     assert.equal(contract.legacyRetirementEligible, false);

--- a/tooling/specs/generated-distribution-repository.spec.mjs
+++ b/tooling/specs/generated-distribution-repository.spec.mjs
@@ -80,7 +80,15 @@ test("generated repository contract keeps remote authority and production blocke
         contract.repository.writeCredentialState,
         "ABSENT_PENDING_PR_RELEASE_BOT",
     );
-    assert.equal(contract.productionMaterialization.enabled, false);
+    assert.equal(contract.productionMaterialization.enabled, true);
+    assert.equal(
+        contract.productionMaterialization.activation,
+        "merged validated release request",
+    );
+    assert.equal(contract.releaseOnMerge.mergeToMainIsReleaseApproval, true);
+    assert.equal(contract.releaseOnMerge.canaryRequiredBeforePublication, true);
+    assert.equal(contract.releaseOnMerge.automaticPromotion, true);
+    assert.equal(contract.releaseOnMerge.automaticRollback, true);
     assert.equal(
         contract.productionMaterialization.artifactTopology,
         "one-profile-one-harness-root-asset",

--- a/tooling/specs/release-request.spec.mjs
+++ b/tooling/specs/release-request.spec.mjs
@@ -1,0 +1,115 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+    validateReleaseRequest,
+    validateReleaseRequests,
+} from "../release-request-validation.mjs";
+
+function readJson(path) {
+    return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function approvedInputs() {
+    const inputs = structuredClone({
+        profileCatalog: readJson("distribution/profile-catalog.json"),
+        targets: readJson("catalog/v2/targets.json").targets,
+        sources: readJson("catalog/v2/sources.json").sources,
+        sourceContracts: readJson("catalog/v2/source-contracts.json").contracts,
+        authoringContracts: readJson("catalog/v2/authoring-contracts.json")
+            .contracts,
+        artifacts: readJson("catalog/v2/artifacts.json").artifacts,
+    });
+    const profile = inputs.profileCatalog.publicProfiles.find(
+        candidate => candidate.id === "public-fundamentals",
+    );
+    profile.state = "approved";
+    const target = inputs.targets.find(
+        candidate => candidate.id === "cratis-fundamentals-concept",
+    );
+    target.approval = {
+        state: "approved",
+        reviewer: "woksin",
+        approvedOn: "2026-08-23",
+        sourceRevision: "b53caa555b9a3f05ba1462b86202fe3ccb8a9470",
+        contentDigest:
+            "9e537c48a95c414709008c69ebfb616354d60992578ddd9da3d7dc7308c42caa",
+        evidenceIds: [
+            "fundamentals-concept-source-review-2026-08-23",
+            "fundamentals-concept-focused-evaluation-2026-08-23",
+            "fundamentals-concept-samples-canary-2026-08-23",
+        ],
+    };
+    target.lifecycle = "approved";
+    target.includeInRuntime = true;
+    for (const id of [
+        "cratis-fundamentals-source",
+        "cratis-chronicle-source",
+    ]) {
+        const contract = inputs.sourceContracts.find(
+            candidate => candidate.id === id,
+        );
+        contract.verificationState = "verified";
+        contract.distributionInputAllowed = true;
+    }
+    const artifact = inputs.artifacts.find(
+        candidate => candidate.id === "planned-passive-public-release",
+    );
+    artifact.materializationAllowed = true;
+    artifact.runtimeEligible = true;
+    return inputs;
+}
+
+test("repository has no release request before owner approval", () => {
+    const result = validateReleaseRequests();
+    assert.deepEqual(result.errors, []);
+    assert.deepEqual(result.requests, []);
+});
+
+test("approved release request resolves every requested profile", () => {
+    const request = readJson(
+        "Documentation/examples/ai-release/v0.1.0-preview.1.json",
+    );
+    const schema = readJson("distribution/release-request.schema.json");
+    const result = validateReleaseRequest(
+        request,
+        "distribution/releases/v0.1.0-preview.1.json",
+        approvedInputs(),
+        schema,
+    );
+    assert.deepEqual(result.errors, []);
+    assert.equal(result.plans.length, 1);
+    assert.equal(result.plans[0].state, "READY_FOR_BOT_MATERIALIZATION");
+    assert.equal(result.plans[0].profileId, "public-fundamentals");
+});
+
+test("release request rejects partial automation and canary drift", () => {
+    const request = readJson(
+        "Documentation/examples/ai-release/v0.1.0-preview.1.json",
+    );
+    request.automation.npmPublish = false;
+    request.canaries = [];
+    const schema = readJson("distribution/release-request.schema.json");
+    const result = validateReleaseRequest(
+        request,
+        "distribution/releases/wrong.json",
+        approvedInputs(),
+        schema,
+    );
+    assert(
+        result.errors.some(error =>
+            error.includes("expected constant true"),
+        ),
+    );
+    assert(
+        result.errors.some(error =>
+            error.includes("every profile needs exactly one named canary"),
+        ),
+    );
+    assert(
+        result.errors.some(error => error.includes("filename must be")),
+    );
+});

--- a/tooling/specs/workflow-safety.spec.mjs
+++ b/tooling/specs/workflow-safety.spec.mjs
@@ -33,6 +33,44 @@ test("verification workflow covers every release-relevant source", () => {
     }
 });
 
+test("merged release request automatically generates canaries publishes and distributes", () => {
+    const workflow = readFileSync(
+        ".github/workflows/release-approved-ai-profiles.yml",
+        "utf8",
+    );
+    for (const required of [
+        "pull_request:",
+        "push:\n    branches: [\"main\"]",
+        "distribution/releases/*.json",
+        "release-request-validation.mjs",
+        "generate-approved-profile-release.mjs",
+        "needs: [discover, verify]",
+        "needs: [discover, verify, canary]",
+        "needs: [discover, verify, canary, distribute]",
+        "needs: [discover, distribute, publish-npm]",
+        "samples-chronicle-backend",
+        "gh release create",
+        "--draft",
+        "gh release edit \"v$VERSION\"",
+        "--draft=false",
+        "npm publish",
+        "--provenance",
+        "id-token: write",
+        "gh pr merge \"$pr_url\" --repo Cratis/AI.Distribution --auto --squash",
+        "Workflows#73",
+        "AI#147",
+    ])
+        assert(workflow.includes(required), required);
+    for (const forbidden of [
+        "NPM_TOKEN",
+        "push --force",
+        "push -f",
+        "direct push to main",
+        "secrets: inherit",
+    ])
+        assert.equal(workflow.includes(forbidden), false, forbidden);
+});
+
 test("Fundamentals preview workflow is read-only short-lived and non-publishing", () => {
     const workflow = readFileSync(
         ".github/workflows/distribution-fundamentals-preview-assets.yml",

--- a/tooling/validate-catalogs.mjs
+++ b/tooling/validate-catalogs.mjs
@@ -12,6 +12,7 @@ import { validateEngineeringDocsAuthoring } from "./engineering-docs-authoring-v
 import { validateEngineeringDistributionConfiguration } from "./generate-engineering-distribution-fixture.mjs";
 import { validateEngineeringDocsCompanions } from "./engineering-docs-companions-validation.mjs";
 import { validateProfileSubscriptions } from "./profile-subscription-validation.mjs";
+import { validateReleaseRequests } from "./release-request-validation.mjs";
 
 const errors = [
     ...validateCatalogs(),
@@ -24,6 +25,7 @@ const errors = [
     ...validateEngineeringDistributionConfiguration(),
     ...validateEngineeringDocsCompanions(),
     ...validateProfileSubscriptions(),
+    ...validateReleaseRequests().errors,
 ];
 if (errors.length > 0) {
     process.stderr.write(


### PR DESCRIPTION
# Summary

Makes a merged, validated release request PR the single recurring Cratis AI release approval.

## Before merge

- Validate exact release request/profile/canary inventory
- Require every profile to pass approval-driven materialization
- Generate root-native harness artifacts and Pi npm tarballs
- Upload short-lived review candidates

## After merge to main

- Regenerate exact artifacts
- Run named canaries before publication
- Create draft immutable AI.Distribution release and generated index PR
- Publish npm through trusted OIDC/provenance
- Promote GitHub release only after npm succeeds
- Auto-merge generated index when App policy allows
- Hand off subscriber updates and marketplace automation

Canary failure prevents publication. No actual release request is added in this PR. One-time external setup remains tracked in AI#181 with `woksin` and `einari` only where genuinely required.
