### PR TITLE
Add data-driven release approvals

### DIFF
--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-HANDOVER.md
@@ -2242,6 +2242,31 @@ controller authorization, marketplace accounts/initial listing reviews, and
 removal of redundant recurring environment reviewers. These are setup tasks,
 not per-release approvals.
 
+## 56. Data-driven release approvals — 2026-08-23
+
+`distribution/release-approvals.json` is the deny-by-default source for profile,
+target, and source-contract approvals included in a release PR. The normal
+catalog generator now applies exact target approvals from that file and enables
+planned public/engineering artifacts only when at least one approved runtime
+target exists. Approval source revision/digest must match the current immutable
+source record.
+
+`tooling/release-approval-validation.mjs` cross-checks approval records against
+generated targets, profile states, admitted source contracts, and known evidence.
+Direct edits to generated target catalogs cannot bypass the release approval
+record. Profile and source-contract approval states cannot be enabled without a
+matching reviewed record.
+
+This allows the first release PR to contain only reviewable data changes:
+
+- exact owner/source-contract admission;
+- exact profile and target approval;
+- one immutable release request.
+
+Merging that PR is both approval and release trigger. Current approval arrays
+and release request directory remain empty, so no release can happen before the
+one-time setup and explicit release PR.
+
 ## 55. Release PR is the single recurring release gate — 2026-08-23
 
 Maintainer direction replaces separate recurring publication, promotion, and

--- a/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
+++ b/AI-REPOSITORY-REDESIGN-AUTONOMOUS-PLAN.md
@@ -718,5 +718,8 @@ handover section 51.
   `woksin` and `einari`.
 - [ ] Complete AI#181 credentials/account/App/canary scope setup before merging
   the first release request.
+- [x] Add a deny-by-default release approval catalog and cross-validator so
+  profile, target, source-contract, artifact, and release request state can be
+  approved atomically in a release PR.
 - [ ] Add the first approved `distribution/releases/v0.1.0-preview.1.json`; its
   merge must automatically release and deploy without another Cratis approval.

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "5547ecf86279e2a94ad1c79297a50323969af8a5380b84cc3a7a03b32bd7b260",
+  "indexDigest": "23b7e328d3a2de25d9dc406e9d5e8840f1a9c7a82f2561cc6dbd83a6465351b4",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -536,6 +536,10 @@
     },
     {
       "path": "distribution/profile-subscription.schema.json",
+      "status": "added"
+    },
+    {
+      "path": "distribution/release-approvals.json",
       "status": "added"
     },
     {
@@ -2083,6 +2087,10 @@
       "status": "added"
     },
     {
+      "path": "tooling/release-approval-validation.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/release-request-validation.mjs",
       "status": "added"
     },
@@ -2211,6 +2219,10 @@
       "status": "added"
     },
     {
+      "path": "tooling/specs/release-approval.spec.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/specs/release-request.spec.mjs",
       "status": "added"
     },
@@ -2235,11 +2247,7 @@
       "status": "added"
     }
   ],
-  "admittedUntracked": [
-    "distribution/release-approvals.json",
-    "tooling/release-approval-validation.mjs",
-    "tooling/specs/release-approval.spec.mjs"
-  ],
+  "admittedUntracked": [],
   "excludedRuntimePrefixes": [
     ".pi/delegate/",
     ".pi/fusion/",

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -2235,7 +2235,11 @@
       "status": "added"
     }
   ],
-  "admittedUntracked": [],
+  "admittedUntracked": [
+    "distribution/release-approvals.json",
+    "tooling/release-approval-validation.mjs",
+    "tooling/specs/release-approval.spec.mjs"
+  ],
   "excludedRuntimePrefixes": [
     ".pi/delegate/",
     ".pi/fusion/",
@@ -3555,8 +3559,8 @@
       "evidenceIds": [
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 25,
-      "expectedPathsDigest": "45f156872e09afa65413297bacc455b931a534b29e6693ca50f9840acf95936d"
+      "expectedPathCount": 26,
+      "expectedPathsDigest": "7dbc3ad849f66c26519b10fd20fcbd441a894064c91daf916d6c32f5227c6976"
     },
     {
       "excludePathPatterns": [],
@@ -3578,8 +3582,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 35,
-      "expectedPathsDigest": "99fb7b30641340e1d2709ece28ec9577bc39e93e0885227462ee28900fb84adf"
+      "expectedPathCount": 36,
+      "expectedPathsDigest": "c3b1683c170edd3175b6aeba99d7f2f098980a3da14224f3ce6f7913655470fc"
     },
     {
       "excludePathPatterns": [],
@@ -3602,8 +3606,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 28,
-      "expectedPathsDigest": "be591c060279e107a6aa4fe601183712a96726cc59191bf03ae6a36c867ba8cc"
+      "expectedPathCount": 29,
+      "expectedPathsDigest": "20e71e982db741e9d959fb525c01485b8ae99252354f05629101857a1e80ed8b"
     },
     {
       "excludePathPatterns": [],

--- a/distribution/release-approvals.json
+++ b/distribution/release-approvals.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": "1.0.0",
+  "defaultPolicy": "deny",
+  "profileApprovals": [],
+  "targetApprovals": [],
+  "sourceContractApprovals": []
+}

--- a/tooling/generate-catalog-v2.mjs
+++ b/tooling/generate-catalog-v2.mjs
@@ -29,6 +29,22 @@ const v1Coverage = readCatalog(
 const v1Ecosystems = readCatalog(
     join(repositoryRoot, "catalog/ecosystem-versions.json"),
 );
+const releaseApprovals = readCatalog(
+    join(repositoryRoot, "distribution/release-approvals.json"),
+);
+if (
+    releaseApprovals.schemaVersion !== "1.0.0" ||
+    releaseApprovals.defaultPolicy !== "deny"
+)
+    throw new Error("Release approval catalog contract changed");
+const targetApprovals = new Map(
+    releaseApprovals.targetApprovals.map((approval) => [
+        approval.targetId,
+        approval,
+    ]),
+);
+if (targetApprovals.size !== releaseApprovals.targetApprovals.length)
+    throw new Error("Release approval catalog contains duplicate targets");
 
 const internalTargets = new Map([
     ["add-cratis-docs-page", "cratis-engineering-docs-add-page"],
@@ -1108,6 +1124,18 @@ const targets = allTargetIds.map((targetId) => {
     const engineeringClassification =
         publicClassifications.get(targetId) ??
         engineeringClassifications.get(targetId);
+    const releaseApproval = targetApprovals.get(targetId);
+    const sourceRecord = sources.find(
+        (source) => source.id === sourceSkillIds[0],
+    );
+    if (
+        releaseApproval &&
+        (sourceSkillIds.length !== 1 ||
+            !sourceRecord ||
+            releaseApproval.sourceRevision !== sourceRecord.sourceRevision ||
+            releaseApproval.contentDigest !== sourceRecord.contentDigest)
+    )
+        throw new Error(`${targetId}: release approval source binding changed`);
     return {
         id: targetId,
         semanticName: targetId,
@@ -1123,7 +1151,7 @@ const targets = allTargetIds.map((targetId) => {
         capabilityKind:
             engineeringClassification?.capabilityKind ?? "unclassified",
         invocation: engineeringClassification?.invocation ?? "unclassified",
-        lifecycle: "candidate",
+        lifecycle: releaseApproval ? "approved" : "candidate",
         architectures:
             engineeringClassification?.architectures ??
             unclassifiedApplicability("Architecture"),
@@ -1237,13 +1265,22 @@ const targets = allTargetIds.map((targetId) => {
                   }
                 : { status: "missing", evidenceIds: [] },
         },
-        approval: { state: "candidate", evidenceIds: [] },
+        approval: releaseApproval
+            ? {
+                  state: "approved",
+                  reviewer: releaseApproval.reviewer,
+                  approvedOn: releaseApproval.approvedOn,
+                  sourceRevision: releaseApproval.sourceRevision,
+                  contentDigest: releaseApproval.contentDigest,
+                  evidenceIds: releaseApproval.evidenceIds,
+              }
+            : { state: "candidate", evidenceIds: [] },
         evidenceIds: [
             "repo-main-b795d53",
             "reevaluation-authority",
             ...(engineeringClassification?.evidenceIds ?? []),
         ],
-        includeInRuntime: false,
+        includeInRuntime: Boolean(releaseApproval),
     };
 });
 writeJson("targets.json", {
@@ -1313,6 +1350,29 @@ const publicTargetIds = targets
 const engineeringTargetIds = targets
     .filter((target) => target.audience === "cratis-engineering")
     .map((target) => target.id);
+const approvedPublicTargets = targets.filter(
+    (target) =>
+        target.audience === "public" &&
+        target.approval.state === "approved" &&
+        target.includeInRuntime,
+);
+const approvedEngineeringTargets = targets.filter(
+    (target) =>
+        target.audience === "cratis-engineering" &&
+        target.approval.state === "approved" &&
+        target.includeInRuntime,
+);
+const exactPathsForTargets = (approvedTargets) => [
+    ...new Set(
+        approvedTargets
+            .flatMap((target) => target.sourceSkillIds)
+            .flatMap(
+                (sourceId) =>
+                    sources.find((source) => source.id === sourceId)
+                        ?.bundledPaths ?? [],
+            ),
+    ),
+].sort(compareOrdinal);
 writeJson("artifacts.json", {
     schemaVersion: 2,
     defaultPolicy: "deny",
@@ -1336,10 +1396,10 @@ writeJson("artifacts.json", {
             id: "planned-passive-public-release",
             audience: "public",
             fixtureOnly: false,
-            materializationAllowed: false,
-            runtimeEligible: false,
+            materializationAllowed: approvedPublicTargets.length > 0,
+            runtimeEligible: approvedPublicTargets.length > 0,
             componentInventory: { skills: publicTargetIds, mcp: [] },
-            exactSourcePaths: [],
+            exactSourcePaths: exactPathsForTargets(approvedPublicTargets),
             allowedPathPatterns: [
                 "skills/<approved-target>/SKILL.md",
                 "skills/<approved-target>/references/**",
@@ -1372,10 +1432,12 @@ writeJson("artifacts.json", {
             id: "planned-passive-engineering-release",
             audience: "cratis-engineering",
             fixtureOnly: false,
-            materializationAllowed: false,
-            runtimeEligible: false,
+            materializationAllowed: approvedEngineeringTargets.length > 0,
+            runtimeEligible: approvedEngineeringTargets.length > 0,
             componentInventory: { skills: engineeringTargetIds, mcp: [] },
-            exactSourcePaths: [],
+            exactSourcePaths: exactPathsForTargets(
+                approvedEngineeringTargets,
+            ),
             allowedPathPatterns: [
                 "engineering/skills/<approved-target>/SKILL.md",
                 "engineering/skills/<approved-target>/references/**",

--- a/tooling/release-approval-validation.mjs
+++ b/tooling/release-approval-validation.mjs
@@ -1,0 +1,122 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const defaultRepositoryRoot = resolve(
+    fileURLToPath(new URL("..", import.meta.url)),
+);
+
+function readJson(root, path) {
+    return JSON.parse(readFileSync(join(root, path), "utf8"));
+}
+
+function duplicates(values) {
+    const seen = new Set();
+    return [...new Set(values.filter((value) => seen.has(value) || !seen.add(value)))];
+}
+
+function completeApproval(approval) {
+    return (
+        typeof approval.reviewer === "string" &&
+        approval.reviewer.length > 0 &&
+        /^\d{4}-\d{2}-\d{2}$/.test(approval.approvedOn) &&
+        Array.isArray(approval.evidenceIds) &&
+        approval.evidenceIds.length > 0
+    );
+}
+
+export function validateReleaseApprovals(
+    repositoryRoot = defaultRepositoryRoot,
+) {
+    const errors = [];
+    const approvals = readJson(
+        repositoryRoot,
+        "distribution/release-approvals.json",
+    );
+    const profiles = readJson(
+        repositoryRoot,
+        "distribution/profile-catalog.json",
+    );
+    const targets = readJson(repositoryRoot, "catalog/v2/targets.json").targets;
+    const contracts = readJson(
+        repositoryRoot,
+        "catalog/v2/source-contracts.json",
+    ).contracts;
+    const evidenceIds = new Set(
+        readJson(repositoryRoot, "catalog/v2/evidence.json").evidence.map(
+            (evidence) => evidence.id,
+        ),
+    );
+    if (
+        approvals.schemaVersion !== "1.0.0" ||
+        approvals.defaultPolicy !== "deny"
+    )
+        errors.push("Release approval catalog contract changed");
+    for (const [name, records, key] of [
+        ["profile", approvals.profileApprovals, "profileId"],
+        ["target", approvals.targetApprovals, "targetId"],
+        ["source contract", approvals.sourceContractApprovals, "contractId"],
+    ]) {
+        if (!Array.isArray(records)) {
+            errors.push(`Release ${name} approvals must be an array`);
+            continue;
+        }
+        if (duplicates(records.map((record) => record[key])).length)
+            errors.push(`Release approval catalog contains duplicate ${name}s`);
+        for (const record of records) {
+            if (!completeApproval(record))
+                errors.push(`${record[key]}: incomplete ${name} approval`);
+            for (const evidenceId of record.evidenceIds ?? [])
+                if (!evidenceIds.has(evidenceId))
+                    errors.push(`${record[key]}: unknown evidence ${evidenceId}`);
+        }
+    }
+    const allProfiles = [...profiles.publicProfiles, ...profiles.engineeringProfiles];
+    const profileApprovals = new Map(
+        approvals.profileApprovals.map((approval) => [
+            approval.profileId,
+            approval,
+        ]),
+    );
+    for (const profile of allProfiles) {
+        const approval = profileApprovals.get(profile.id);
+        if ((profile.state === "approved") !== Boolean(approval))
+            errors.push(`${profile.id}: profile approval state is inconsistent`);
+    }
+    const targetApprovals = new Map(
+        approvals.targetApprovals.map((approval) => [approval.targetId, approval]),
+    );
+    for (const target of targets) {
+        const approval = targetApprovals.get(target.id);
+        if ((target.approval.state === "approved") !== Boolean(approval))
+            errors.push(`${target.id}: target approval state is inconsistent`);
+        if (
+            approval &&
+            (target.approval.reviewer !== approval.reviewer ||
+                target.approval.approvedOn !== approval.approvedOn ||
+                target.approval.sourceRevision !== approval.sourceRevision ||
+                target.approval.contentDigest !== approval.contentDigest ||
+                JSON.stringify(target.approval.evidenceIds) !==
+                    JSON.stringify(approval.evidenceIds))
+        )
+            errors.push(`${target.id}: generated target approval differs`);
+    }
+    const contractApprovals = new Map(
+        approvals.sourceContractApprovals.map((approval) => [
+            approval.contractId,
+            approval,
+        ]),
+    );
+    for (const contract of contracts) {
+        const approval = contractApprovals.get(contract.id);
+        const admitted =
+            contract.verificationState === "verified" &&
+            contract.distributionInputAllowed === true;
+        if (admitted !== Boolean(approval))
+            errors.push(`${contract.id}: source contract approval is inconsistent`);
+    }
+    return [...new Set(errors)].sort();
+}

--- a/tooling/specs/release-approval.spec.mjs
+++ b/tooling/specs/release-approval.spec.mjs
@@ -1,0 +1,111 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert from "node:assert/strict";
+import {
+    cpSync,
+    mkdtempSync,
+    mkdirSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { validateReleaseApprovals } from "../release-approval-validation.mjs";
+
+const files = [
+    "distribution/release-approvals.json",
+    "distribution/profile-catalog.json",
+    "catalog/v2/targets.json",
+    "catalog/v2/source-contracts.json",
+    "catalog/v2/evidence.json",
+];
+
+function readJson(path) {
+    return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function writeJson(path, value) {
+    writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function withFixture(callback) {
+    const root = mkdtempSync(join(tmpdir(), "cratis-release-approval-"));
+    try {
+        for (const path of files) {
+            const destination = join(root, path);
+            mkdirSync(dirname(destination), { recursive: true });
+            cpSync(path, destination);
+        }
+        return callback(root);
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+}
+
+test("current release approval catalog is empty and consistent", () => {
+    assert.deepEqual(validateReleaseApprovals(), []);
+    const approvals = readJson("distribution/release-approvals.json");
+    assert.deepEqual(approvals.profileApprovals, []);
+    assert.deepEqual(approvals.targetApprovals, []);
+    assert.deepEqual(approvals.sourceContractApprovals, []);
+});
+
+test("profile and source admission cannot bypass release approval records", () => {
+    withFixture((root) => {
+        const profilesPath = join(root, "distribution/profile-catalog.json");
+        const profiles = readJson(profilesPath);
+        profiles.publicProfiles[0].state = "approved";
+        writeJson(profilesPath, profiles);
+        const contractsPath = join(root, "catalog/v2/source-contracts.json");
+        const contracts = readJson(contractsPath);
+        contracts.contracts[0].verificationState = "verified";
+        contracts.contracts[0].distributionInputAllowed = true;
+        writeJson(contractsPath, contracts);
+        const errors = validateReleaseApprovals(root);
+        assert(
+            errors.includes(
+                `${profiles.publicProfiles[0].id}: profile approval state is inconsistent`,
+            ),
+        );
+        assert(
+            errors.includes(
+                `${contracts.contracts[0].id}: source contract approval is inconsistent`,
+            ),
+        );
+    });
+});
+
+test("approval records require known evidence and complete reviewer metadata", () => {
+    withFixture((root) => {
+        const path = join(root, "distribution/release-approvals.json");
+        const approvals = readJson(path);
+        approvals.targetApprovals.push({
+            targetId: "cratis-fundamentals-concept",
+            reviewer: "",
+            approvedOn: "not-a-date",
+            sourceRevision: "0".repeat(40),
+            contentDigest: "0".repeat(64),
+            evidenceIds: ["unknown-evidence"],
+        });
+        writeJson(path, approvals);
+        const errors = validateReleaseApprovals(root);
+        assert(
+            errors.includes(
+                "cratis-fundamentals-concept: incomplete target approval",
+            ),
+        );
+        assert(
+            errors.includes(
+                "cratis-fundamentals-concept: unknown evidence unknown-evidence",
+            ),
+        );
+        assert(
+            errors.includes(
+                "cratis-fundamentals-concept: target approval state is inconsistent",
+            ),
+        );
+    });
+});

--- a/tooling/validate-catalogs.mjs
+++ b/tooling/validate-catalogs.mjs
@@ -13,6 +13,7 @@ import { validateEngineeringDistributionConfiguration } from "./generate-enginee
 import { validateEngineeringDocsCompanions } from "./engineering-docs-companions-validation.mjs";
 import { validateProfileSubscriptions } from "./profile-subscription-validation.mjs";
 import { validateReleaseRequests } from "./release-request-validation.mjs";
+import { validateReleaseApprovals } from "./release-approval-validation.mjs";
 
 const errors = [
     ...validateCatalogs(),
@@ -26,6 +27,7 @@ const errors = [
     ...validateEngineeringDocsCompanions(),
     ...validateProfileSubscriptions(),
     ...validateReleaseRequests().errors,
+    ...validateReleaseApprovals(),
 ];
 if (errors.length > 0) {
     process.stderr.write(


### PR DESCRIPTION
# Summary

Adds the deny-by-default approval data consumed by release PRs.

- Profile, target and source-contract approvals live in `distribution/release-approvals.json`
- Generated target lifecycle/runtime state comes only from exact target approval records
- Target approval revision/digest must match immutable source records
- Profile/source admission cannot be enabled without matching approval records
- Planned artifacts enable automatically only when approved runtime targets exist
- Current approval arrays remain empty, so no release behavior changes

This prepares the first release PR to approve exact data and release automatically in one merge.
