### PR TITLE
Add portable Agent Plugin packages

### DIFF
--- a/Documentation/adopting-cratis-ai.md
+++ b/Documentation/adopting-cratis-ai.md
@@ -111,13 +111,15 @@ filters:
 
 ### Other harnesses
 
-Use the root-native artifact generated for the exact profile, version, and
-harness. Do not point a host at the mixed `Cratis/AI` source repository or the
-multi-profile distribution root.
+Use the root-native artifact generated for the exact profile and version. For
+Copilot, Cursor, Kiro, VS Code, and other compatible hosts, prefer the portable
+Agent Plugins 1.0 artifact; host marketplace wrappers point at the same plugin
+identity and skill layout. Do not point a host at the mixed `Cratis/AI` source
+repository or the multi-profile distribution root.
 
-The release page supplies exact Claude, Codex, Copilot, Cursor, Gemini, Grok,
-DeepSeek Harness, Kiro, Junie, and Agent Skills commands after each host is
-actually tested.
+The release page supplies exact Agent Plugin, Claude, Codex, Copilot, Cursor,
+Gemini, Grok, DeepSeek Harness, Kiro, Junie, and Agent Skills commands after
+each host is actually tested.
 
 ## 6. Verify adoption
 

--- a/Documentation/ai-distribution-and-subscriptions.md
+++ b/Documentation/ai-distribution-and-subscriptions.md
@@ -218,14 +218,15 @@ The same approved skill bytes are wrapped idiomatically for each host:
 | Host | Generated shape |
 | --- | --- |
 | Agent Skills | `skills/<name>/SKILL.md` |
+| Agent Plugins 1.0 | Portable `plugin.json` + `skills/` package for compatible hosts |
 | Claude Code | Claude plugin and marketplace |
 | Codex | Codex plugin and marketplace |
-| GitHub Copilot | Copilot plugin and marketplace |
-| Cursor | Cursor plugin |
+| GitHub Copilot / VS Code | Copilot marketplace around the portable Agent Plugin |
+| Cursor | Cursor marketplace around the portable Agent Plugin |
 | Gemini CLI | Gemini extension |
 | Grok Build | `.grok/skills/<name>/SKILL.md` and Claude compatibility |
 | DeepSeek Harness | `.dsh/skills/<name>/SKILL.md` while upstream remains preview |
-| Kiro | Agent Plugin power |
+| Kiro | The same portable Agent Plugin installed as a Power |
 | Junie | Junie extension |
 | Pi | Versioned npm/Git Pi package |
 

--- a/README.md
+++ b/README.md
@@ -110,9 +110,11 @@ packages exist. See the [Pi package workflow](Documentation/ai-distribution-and-
 
 ## Supported output formats
 
-The generator currently produces or models adapters for Agent Skills, Claude
-Code, Codex, GitHub Copilot, Cursor, Gemini CLI, Grok Build, DeepSeek Harness,
-Kiro, Junie, and Pi/npm.
+The generator now emits a portable Agent Plugins 1.0 package for compatible
+hosts alongside Agent Skills and native adapters for Claude Code, Codex, GitHub
+Copilot, Cursor, Gemini CLI, Grok Build, DeepSeek Harness, Kiro, Junie, and
+Pi/npm. Copilot, Cursor, Kiro, and VS Code share the same portable plugin
+identity and skill layout rather than separate skill instructions.
 
 Documentation and release records distinguish:
 

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "0cb3d3b4f381fe505db21b00f2e8c9dd904f6c98b6991056f96827aec615674a",
+  "indexDigest": "cc47ede22fdca38103305a08b3548b8d4349481b2478f1550d87498b9020f503",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/distribution/artifact-matrix.json
+++ b/distribution/artifact-matrix.json
@@ -30,6 +30,18 @@
       ]
     },
     {
+      "id": "portable-agent-plugin",
+      "requirementId": "agent-plugins-open-standard",
+      "state": "FIXTURE_GENERATION_ENABLED",
+      "outputRoot": "agent-plugin",
+      "packageKind": "PORTABLE_AGENT_PLUGIN",
+      "smokeGates": [
+        "agent-plugin-schema",
+        "exact-skill-inventory",
+        "canonical-byte-parity"
+      ]
+    },
+    {
       "id": "claude-code",
       "requirementId": "claude-code-marketplace",
       "state": "FIXTURE_GENERATION_ENABLED",
@@ -58,7 +70,7 @@
       "requirementId": "github-copilot-plugin",
       "state": "FIXTURE_GENERATION_ENABLED",
       "outputRoot": "copilot",
-      "packageKind": "SKILLS_ONLY_COPILOT_PLUGIN_MARKETPLACE",
+      "packageKind": "PORTABLE_AGENT_PLUGIN_WITH_COPILOT_MARKETPLACE",
       "smokeGates": [
         "manifest-parse",
         "canonical-byte-parity",
@@ -129,7 +141,7 @@
       "requirementId": "cursor-marketplace",
       "state": "FIXTURE_GENERATION_ENABLED",
       "outputRoot": "cursor",
-      "packageKind": "SKILLS_ONLY_CURSOR_PLUGIN",
+      "packageKind": "PORTABLE_AGENT_PLUGIN_WITH_CURSOR_MARKETPLACE",
       "smokeGates": [
         "manifest-parse",
         "canonical-byte-parity",

--- a/distribution/marketplace-requirements.json
+++ b/distribution/marketplace-requirements.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "verifiedAt": "2026-08-22",
+  "verifiedAt": "2026-08-24",
   "requirements": [
     {
       "id": "agent-skills-open-standard",
@@ -18,6 +18,33 @@
         "Skill directory and frontmatter name must match and use lowercase letters, digits, and single hyphens.",
         "SKILL.md requires nonempty name and description; scripts, references, and assets are optional.",
         "Passive Cratis artifacts omit scripts and experimental allowed-tools."
+      ]
+    },
+    {
+      "id": "agent-plugins-open-standard",
+      "status": "VERIFIED",
+      "sourceUrls": [
+        "https://agent-plugins.org/specification",
+        "https://agent-plugins.org/plugin-authors/manifest"
+      ],
+      "requiredRoots": [
+        "plugin.json",
+        "skills/<skill-name>/SKILL.md"
+      ],
+      "installCommands": [
+        "Install the generated Agent Plugin through a compatible host marketplace or local plugin flow"
+      ],
+      "updateCommands": [
+        "Use the compatible host marketplace update flow or replace the exact pinned plugin version"
+      ],
+      "uninstallCommands": [
+        "Use the compatible host plugin removal flow"
+      ],
+      "constraints": [
+        "Agent Plugins 1.0 defines the portable package format, not one universal marketplace or permission model.",
+        "plugin.json uses the canonical 1.0.0 schema and fixed skills/ discovery root.",
+        "The portable Cratis package contains passive Agent Skills only; no MCP server, hook, command, executable, or credential content is included.",
+        "Copilot, Cursor, Kiro, and VS Code support this portable core, but each host lifecycle is tested and reported separately."
       ]
     },
     {
@@ -102,7 +129,7 @@
         "copilot plugin marketplace remove cratis"
       ],
       "constraints": [
-        "plugin.json is required at the plugin root.",
+        "plugin.json uses the Agent Plugins 1.0 schema and fixed skills/ discovery root.",
         "Marketplace plugin sources are repository-relative; strict validation stays enabled.",
         "Release installs pin immutable full commit SHAs."
       ]
@@ -265,7 +292,7 @@
       ],
       "requiredRoots": [
         ".cursor-plugin/marketplace.json",
-        "plugins/cratis/.cursor-plugin/plugin.json",
+        "plugins/cratis/plugin.json",
         "plugins/cratis/skills/<skill-name>/SKILL.md"
       ],
       "installCommands": [
@@ -278,7 +305,7 @@
         "Cursor Customize > uninstall optional plugins"
       ],
       "constraints": [
-        "Cursor skills-only plugins use .cursor-plugin/plugin.json and skills/<skill-name>/SKILL.md.",
+        "Cursor consumes the portable Agent Plugins 1.0 plugin.json and skills/<skill-name>/SKILL.md package.",
         "Plugin names are lowercase kebab-case; manifest paths stay relative and inside the plugin.",
         "Public marketplace submission requires an open-source repository, local testing, manual review, and review of every update."
       ]

--- a/distribution/profile-subscription.schema.json
+++ b/distribution/profile-subscription.schema.json
@@ -68,6 +68,7 @@
       "items": {
         "enum": [
           "agent-skills",
+          "agent-plugin",
           "claude",
           "codex",
           "copilot",

--- a/tooling/generate-distribution-fixture.mjs
+++ b/tooling/generate-distribution-fixture.mjs
@@ -17,6 +17,7 @@ import {
 } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { createAgentPluginManifest } from "./passive-profile-adapters.mjs";
 import { materializeFixtureArtifact } from "./public-artifact-materializer.mjs";
 
 const defaultRepositoryRoot = resolve(
@@ -28,6 +29,7 @@ const approvedFiles = [
 ];
 const generatedTargets = [
     "canonical",
+    "agent-plugin",
     "claude",
     "codex",
     "copilot",
@@ -248,6 +250,18 @@ export function generateDistributionFixture({
             approvedFiles,
         });
 
+        const portableDescription = "Passive Cratis skills fixture.";
+        const agentPluginRoot = join(root, "agent-plugin");
+        copyCanonicalSkill(canonicalRoot, agentPluginRoot);
+        writeJson(
+            join(agentPluginRoot, "plugin.json"),
+            createAgentPluginManifest({
+                name: "cratis",
+                version,
+                description: portableDescription,
+            }),
+        );
+
         const claudeRoot = join(root, "claude");
         copyCanonicalSkill(canonicalRoot, join(claudeRoot, "plugins/cratis"));
         writeJson(join(claudeRoot, ".claude-plugin/marketplace.json"), {
@@ -320,12 +334,14 @@ export function generateDistributionFixture({
                 },
             ],
         });
-        writeJson(join(copilotRoot, "plugins/cratis/plugin.json"), {
-            name: "cratis",
-            version,
-            description: "Passive Cratis skills fixture.",
-            skills: "skills/",
-        });
+        writeJson(
+            join(copilotRoot, "plugins/cratis/plugin.json"),
+            createAgentPluginManifest({
+                name: "cratis",
+                version,
+                description: portableDescription,
+            }),
+        );
 
         const cursorRoot = join(root, "cursor");
         copyCanonicalSkill(canonicalRoot, join(cursorRoot, "plugins/cratis"));
@@ -346,13 +362,12 @@ export function generateDistributionFixture({
             ],
         });
         writeJson(
-            join(cursorRoot, "plugins/cratis/.cursor-plugin/plugin.json"),
-            {
+            join(cursorRoot, "plugins/cratis/plugin.json"),
+            createAgentPluginManifest({
                 name: "cratis",
                 version,
-                description: "Passive Cratis skills fixture.",
-                skills: "./skills/",
-            },
+                description: portableDescription,
+            }),
         );
 
         const deepSeekRoot = join(root, "deepseek/.dsh");
@@ -371,15 +386,14 @@ export function generateDistributionFixture({
 
         const kiroRoot = join(root, "kiro");
         copyCanonicalSkill(canonicalRoot, kiroRoot);
-        writeJson(join(kiroRoot, "plugin.json"), {
-            $schema:
-                "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
-            name: "cratis",
-            version,
-            description: "Passive Cratis skills fixture.",
-            author: { name: "Cratis" },
-            license: "MIT",
-        });
+        writeJson(
+            join(kiroRoot, "plugin.json"),
+            createAgentPluginManifest({
+                name: "cratis",
+                version,
+                description: portableDescription,
+            }),
+        );
 
         const junieRoot = join(root, "junie/extensions/cratis");
         copyCanonicalSkill(canonicalRoot, junieRoot);
@@ -490,6 +504,7 @@ export function validateDistributionFixture(outputRoot) {
     }
     const canonicalRoot = join(root, "canonical");
     const targetSkillRoots = [
+        "agent-plugin",
         "claude/plugins/cratis",
         "codex/plugins/cratis",
         "copilot/plugins/cratis",

--- a/tooling/generate-engineering-distribution-fixture.mjs
+++ b/tooling/generate-engineering-distribution-fixture.mjs
@@ -17,6 +17,7 @@ import {
 } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { createAgentPluginManifest } from "./passive-profile-adapters.mjs";
 import { materializeFixtureArtifact } from "./public-artifact-materializer.mjs";
 
 const defaultRepositoryRoot = resolve(
@@ -32,6 +33,7 @@ const approvedFiles = [
 ];
 const generatedTargets = [
     "canonical",
+    "agent-plugin",
     "claude",
     "codex",
     "copilot",
@@ -234,6 +236,19 @@ export function generateEngineeringDistributionFixture({
             approvedFiles,
         });
 
+        const portableDescription =
+            "Fixture-only passive Cratis engineering documentation skill.";
+        const agentPluginRoot = join(root, "agent-plugin");
+        copyCanonical(canonicalRoot, agentPluginRoot);
+        writeJson(
+            join(agentPluginRoot, "plugin.json"),
+            createAgentPluginManifest({
+                name: pluginName,
+                version,
+                description: portableDescription,
+            }),
+        );
+
         const claudeRoot = join(root, "claude");
         copyCanonical(canonicalRoot, join(claudeRoot, `plugins/${pluginName}`));
         writeJson(join(claudeRoot, ".claude-plugin/marketplace.json"), {
@@ -324,13 +339,14 @@ export function generateEngineeringDistributionFixture({
                 },
             ],
         });
-        writeJson(join(copilotRoot, `plugins/${pluginName}/plugin.json`), {
-            name: pluginName,
-            version,
-            description:
-                "Fixture-only passive Cratis engineering documentation skill.",
-            skills: "skills/",
-        });
+        writeJson(
+            join(copilotRoot, `plugins/${pluginName}/plugin.json`),
+            createAgentPluginManifest({
+                name: pluginName,
+                version,
+                description: portableDescription,
+            }),
+        );
 
         const cursorRoot = join(root, "cursor");
         copyCanonical(canonicalRoot, join(cursorRoot, `plugins/${pluginName}`));
@@ -353,17 +369,12 @@ export function generateEngineeringDistributionFixture({
             ],
         });
         writeJson(
-            join(
-                cursorRoot,
-                `plugins/${pluginName}/.cursor-plugin/plugin.json`,
-            ),
-            {
+            join(cursorRoot, `plugins/${pluginName}/plugin.json`),
+            createAgentPluginManifest({
                 name: pluginName,
                 version,
-                description:
-                    "Fixture-only passive Cratis engineering documentation skill.",
-                skills: "./skills/",
-            },
+                description: portableDescription,
+            }),
         );
 
         const deepSeekRoot = join(root, "deepseek/.dsh");
@@ -383,16 +394,14 @@ export function generateEngineeringDistributionFixture({
 
         const kiroRoot = join(root, "kiro");
         copyCanonical(canonicalRoot, kiroRoot);
-        writeJson(join(kiroRoot, "plugin.json"), {
-            $schema:
-                "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
-            name: pluginName,
-            version,
-            description:
-                "Fixture-only passive Cratis engineering documentation skill.",
-            author: { name: "Cratis" },
-            license: "MIT",
-        });
+        writeJson(
+            join(kiroRoot, "plugin.json"),
+            createAgentPluginManifest({
+                name: pluginName,
+                version,
+                description: portableDescription,
+            }),
+        );
 
         const junieRoot = join(root, `junie/extensions/${pluginName}`);
         copyCanonical(canonicalRoot, junieRoot);
@@ -496,6 +505,7 @@ export function validateEngineeringDistributionFixture(outputRoot) {
             );
     }
     const targetRoots = [
+        "agent-plugin",
         `claude/plugins/${pluginName}`,
         `codex/plugins/${pluginName}`,
         `copilot/plugins/${pluginName}`,

--- a/tooling/passive-profile-adapters.mjs
+++ b/tooling/passive-profile-adapters.mjs
@@ -17,6 +17,7 @@ import {
 
 export const passiveHarnesses = [
     "agent-skills",
+    "agent-plugin",
     "claude",
     "codex",
     "copilot",
@@ -40,6 +41,23 @@ function writeExclusive(path, content) {
 
 function writeJson(path, value) {
     writeExclusive(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function createAgentPluginManifest({ name, version, description }) {
+    return {
+        $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+        name,
+        version,
+        description,
+        author: {
+            name: "Cratis",
+            url: "https://cratis.io",
+        },
+        homepage: "https://cratis.io/ai",
+        repository: "https://github.com/Cratis/AI",
+        license: "MIT",
+        keywords: ["cratis", "agent-skills"],
+    };
 }
 
 function walkFiles(root, current = root) {
@@ -85,7 +103,7 @@ function copySkills(skills, root) {
             );
 }
 
-function assertInputs({ version, profileId, packageName, skills }) {
+function assertInputs({ version, profileId, packageName, description, skills }) {
     if (
         !/^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(
             version,
@@ -96,6 +114,12 @@ function assertInputs({ version, profileId, packageName, skills }) {
         throw new Error("Profile id is invalid");
     if (!/^@cratis\/[a-z0-9]+(?:-[a-z0-9]+)*$/.test(packageName))
         throw new Error("Profile package name is invalid");
+    if (
+        typeof description !== "string" ||
+        description.length === 0 ||
+        description.length > 1024
+    )
+        throw new Error("Profile package description is invalid");
     if (!Array.isArray(skills) || skills.length === 0)
         throw new Error("Profile release requires at least one skill");
     const names = new Set();
@@ -146,7 +170,7 @@ export function generatePassiveProfileAdapters({
     codexInstallationPolicy = "AVAILABLE",
     piPrivate = false,
 }) {
-    assertInputs({ version, profileId, packageName, skills });
+    assertInputs({ version, profileId, packageName, description, skills });
     if (
         !["AVAILABLE", "INSTALLED_BY_DEFAULT", "NOT_AVAILABLE"].includes(
             codexInstallationPolicy,
@@ -161,6 +185,17 @@ export function generatePassiveProfileAdapters({
     const harnessRoot = (harness) => join(root, "harnesses", harness);
 
     copySkills(skills, harnessRoot("agent-skills"));
+
+    const agentPluginRoot = harnessRoot("agent-plugin");
+    copySkills(skills, agentPluginRoot);
+    writeJson(
+        join(agentPluginRoot, "plugin.json"),
+        createAgentPluginManifest({
+            name: profileId,
+            version,
+            description,
+        }),
+    );
 
     const claudeRoot = harnessRoot("claude");
     copySkills(skills, join(claudeRoot, `plugins/${profileId}`));
@@ -231,12 +266,10 @@ export function generatePassiveProfileAdapters({
             },
         ],
     });
-    writeJson(join(copilotRoot, `plugins/${profileId}/plugin.json`), {
-        name: profileId,
-        version,
-        description,
-        skills: "skills/",
-    });
+    writeJson(
+        join(copilotRoot, `plugins/${profileId}/plugin.json`),
+        createAgentPluginManifest({ name: profileId, version, description }),
+    );
 
     const cursorRoot = harnessRoot("cursor");
     copySkills(skills, join(cursorRoot, `plugins/${profileId}`));
@@ -254,8 +287,8 @@ export function generatePassiveProfileAdapters({
         ],
     });
     writeJson(
-        join(cursorRoot, `plugins/${profileId}/.cursor-plugin/plugin.json`),
-        { name: profileId, version, description, skills: "./skills/" },
+        join(cursorRoot, `plugins/${profileId}/plugin.json`),
+        createAgentPluginManifest({ name: profileId, version, description }),
     );
 
     const directRoots = {
@@ -271,14 +304,10 @@ export function generatePassiveProfileAdapters({
         version,
         description,
     });
-    writeJson(join(harnessRoot("kiro"), "plugin.json"), {
-        $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
-        name: profileId,
-        version,
-        description,
-        author: { name: "Cratis" },
-        license: "MIT",
-    });
+    writeJson(
+        join(harnessRoot("kiro"), "plugin.json"),
+        createAgentPluginManifest({ name: profileId, version, description }),
+    );
 
     const junieRoot = join(harnessRoot("junie"), `extensions/${profileId}`);
     copySkills(skills, junieRoot);

--- a/tooling/specs/approved-profile-release.spec.mjs
+++ b/tooling/specs/approved-profile-release.spec.mjs
@@ -318,6 +318,48 @@ test("passive adapter materializer emits one install root per harness", () => {
         assert.deepEqual(manifest.harnesses, passiveHarnesses);
         for (const harness of passiveHarnesses)
             assert.equal(manifest.roots[harness], `harnesses/${harness}`);
+        const portablePlugin = readJson(
+            join(outputRoot, "harnesses/agent-plugin/plugin.json"),
+        );
+        const copilotPlugin = readJson(
+            join(
+                outputRoot,
+                "harnesses/copilot/plugins/public-example/plugin.json",
+            ),
+        );
+        const cursorPlugin = readJson(
+            join(
+                outputRoot,
+                "harnesses/cursor/plugins/public-example/plugin.json",
+            ),
+        );
+        const kiroPlugin = readJson(
+            join(outputRoot, "harnesses/kiro/plugin.json"),
+        );
+        assert.deepEqual(copilotPlugin, portablePlugin);
+        assert.deepEqual(cursorPlugin, portablePlugin);
+        assert.deepEqual(kiroPlugin, portablePlugin);
+        assert.equal(
+            portablePlugin.$schema,
+            "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+        );
+        assert.equal(portablePlugin.repository, "https://github.com/Cratis/AI");
+        assert.equal(portablePlugin.homepage, "https://cratis.io/ai");
+        assert.deepEqual(portablePlugin.keywords, ["cratis", "agent-skills"]);
+        assert.deepEqual(Object.keys(portablePlugin).sort(), [
+            "$schema",
+            "author",
+            "description",
+            "homepage",
+            "keywords",
+            "license",
+            "name",
+            "repository",
+            "version",
+        ]);
+        assert.equal(portablePlugin.skills, undefined);
+        assert.equal(portablePlugin.hooks, undefined);
+        assert.equal(portablePlugin.mcpServers, undefined);
         const piPackage = readJson(
             join(outputRoot, "harnesses/pi/package.json"),
         );

--- a/tooling/specs/distribution-fixture.spec.mjs
+++ b/tooling/specs/distribution-fixture.spec.mjs
@@ -84,6 +84,7 @@ test("distribution requirements and artifact matrix stay authority bounded", () 
         .map((item) => item.id);
     assert.deepEqual(verified, [
         "agent-skills-open-standard",
+        "agent-plugins-open-standard",
         "claude-code-marketplace",
         "openai-codex-plugin",
         "github-copilot-plugin",
@@ -174,6 +175,7 @@ test("distribution fixture generation is deterministic across native adapters", 
         assert.deepEqual(validateDistributionFixture(firstRoot), first);
         assert.deepEqual(first.generatedTargets, [
             "canonical",
+            "agent-plugin",
             "claude",
             "codex",
             "copilot",
@@ -219,6 +221,7 @@ test("generated marketplace manifests remain passive and idiomatic", () => {
     withTemporaryDirectory((root) => {
         const stage = join(root, "stage");
         generateDistributionFixture({ repositoryRoot, outputRoot: stage });
+        const portable = readJson(join(stage, "agent-plugin/plugin.json"));
         const claude = readJson(
             join(stage, "claude/plugins/cratis/.claude-plugin/plugin.json"),
         );
@@ -229,7 +232,7 @@ test("generated marketplace manifests remain passive and idiomatic", () => {
             join(stage, "copilot/plugins/cratis/plugin.json"),
         );
         const cursor = readJson(
-            join(stage, "cursor/plugins/cratis/.cursor-plugin/plugin.json"),
+            join(stage, "cursor/plugins/cratis/plugin.json"),
         );
         const gemini = readJson(join(stage, "gemini/gemini-extension.json"));
         const providerCompatibility = readJson(
@@ -242,8 +245,16 @@ test("generated marketplace manifests remain passive and idiomatic", () => {
         const piPackage = readJson(join(stage, "pi/package/package.json"));
         assert.equal(claude.name, "cratis");
         assert.equal(codex.skills, "./skills/");
-        assert.equal(copilot.skills, "skills/");
-        assert.equal(cursor.skills, "./skills/");
+        assert.deepEqual(copilot, portable);
+        assert.deepEqual(cursor, portable);
+        assert.deepEqual(kiro, portable);
+        assert.equal(
+            portable.$schema,
+            "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+        );
+        assert.equal(portable.repository, "https://github.com/Cratis/AI");
+        assert.equal(portable.homepage, "https://cratis.io/ai");
+        assert.equal(portable.skills, undefined);
         assert.equal(gemini.name, "cratis");
         assert.deepEqual(providerCompatibility.providers, [
             {
@@ -296,6 +307,7 @@ test("generated marketplace manifests remain passive and idiomatic", () => {
         );
         assert.equal(junie.name, "cratis");
         for (const manifest of [
+            portable,
             claude,
             codex,
             copilot,

--- a/tooling/specs/engineering-distribution-fixture.spec.mjs
+++ b/tooling/specs/engineering-distribution-fixture.spec.mjs
@@ -133,6 +133,7 @@ test("engineering fixture generation is deterministic and non-installable", () =
         assert.equal(first.promotionEligible, false);
         assert.deepEqual(first.generatedTargets, [
             "canonical",
+            "agent-plugin",
             "claude",
             "codex",
             "copilot",
@@ -210,15 +211,34 @@ test("engineering fixture contains one passive skill and no project context", ()
             ).skills,
             "./skills/",
         );
-        assert.equal(
-            readJson(
-                join(
-                    stage,
-                    `cursor/plugins/cratis-engineering-fixture/.cursor-plugin/plugin.json`,
-                ),
-            ).skills,
-            "./skills/",
+        const portablePlugin = readJson(
+            join(stage, "agent-plugin/plugin.json"),
         );
+        const copilotPlugin = readJson(
+            join(
+                stage,
+                "copilot/plugins/cratis-engineering-fixture/plugin.json",
+            ),
+        );
+        const cursorPlugin = readJson(
+            join(
+                stage,
+                "cursor/plugins/cratis-engineering-fixture/plugin.json",
+            ),
+        );
+        const kiroPlugin = readJson(join(stage, "kiro/plugin.json"));
+        assert.deepEqual(copilotPlugin, portablePlugin);
+        assert.deepEqual(cursorPlugin, portablePlugin);
+        assert.deepEqual(kiroPlugin, portablePlugin);
+        assert.equal(
+            portablePlugin.$schema,
+            "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+        );
+        assert.equal(
+            portablePlugin.repository,
+            "https://github.com/Cratis/AI",
+        );
+        assert.equal(portablePlugin.skills, undefined);
         assert.equal(
             readJson(join(stage, "gemini/gemini-extension.json")).name,
             "cratis-engineering-fixture",
@@ -251,7 +271,7 @@ test("engineering fixture contains one passive skill and no project context", ()
             canonicalSkill,
         );
         assert.equal(
-            readJson(join(stage, "kiro/plugin.json")).$schema,
+            kiroPlugin.$schema,
             "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
         );
         assert.equal(

--- a/tooling/specs/fundamentals-preview-assets.spec.mjs
+++ b/tooling/specs/fundamentals-preview-assets.spec.mjs
@@ -19,6 +19,7 @@ import {
     packageFundamentalsPreviewAssets,
     readTarGzip,
 } from "../package-fundamentals-preview-assets.mjs";
+import { passiveHarnesses } from "../passive-profile-adapters.mjs";
 
 function withTemporaryDirectory(callback) {
     const root = mkdtempSync(join(tmpdir(), "cratis-preview-assets-"));
@@ -166,7 +167,7 @@ test("Fundamentals preview assets are deterministic and non-publishable", () => 
             first.sourceRevision,
             "b53caa555b9a3f05ba1462b86202fe3ccb8a9470",
         );
-        assert.equal(first.assets.length, 11);
+        assert.equal(first.assets.length, passiveHarnesses.length);
         assert.match(first.generatorDigest, /^[0-9a-f]{64}$/);
         assert.deepEqual(first.generatorPaths, [
             "tooling/package-fundamentals-preview-assets.mjs",
@@ -224,7 +225,10 @@ test("Fundamentals preview assets are deterministic and non-publishable", () => 
         const checksums = readFileSync(join(firstRoot, "SHA256SUMS"), "utf8");
         assert(checksums.includes("preview-assets.json"));
         assert(checksums.includes("preview-sbom.json"));
-        assert.equal(checksums.trim().split("\n").length, 13);
+        assert.equal(
+            checksums.trim().split("\n").length,
+            passiveHarnesses.length + 2,
+        );
     });
 });
 


### PR DESCRIPTION
# Summary

Adds one standards-based Cratis plugin package that compatible AI tools can consume without receiving different skill instructions. Copilot, Cursor, Kiro, VS Code, and future Agent Plugins hosts now share the same portable identity, metadata, and fixed `skills/` layout.

## Added

- Adds a standalone Agent Plugins 1.0 artifact for every generated profile (#188)
- Adds useful repository, homepage, author, license, and discovery metadata to portable packages (#188)

## Changed

- Makes Copilot, Cursor, and Kiro wrappers use the same portable Agent Plugin manifest (#188)
- Documents the portable package as the preferred path for compatible hosts (#188)
- Extends public, engineering, and preview lifecycle fixtures to verify byte-identical portable packages (#188)
