### PR TITLE
Record managed APM installation evaluation

### DIFF
--- a/Documentation/ai-distribution-and-subscriptions.md
+++ b/Documentation/ai-distribution-and-subscriptions.md
@@ -107,6 +107,42 @@ pull request changing the subscription and host-native lock or settings files.
 It never merges automatically, pushes generated corpus folders, or receives
 broad organization write access.
 
+## Managed multi-tool installation
+
+Native marketplaces remain the easiest path for an individual developer. For a
+team that needs the same exact skills across several AI tools, Cratis evaluated
+Microsoft Agent Package Manager (APM) 0.28.0 as an optional managed-team path.
+
+The disposable public and engineering evaluations demonstrated:
+
+- exact Git commit and content-hash locks;
+- frozen installation on a second machine;
+- deployment to shared Agent Skills and host-native locations;
+- nonzero drift detection after an installed skill was modified;
+- repair from the lock;
+- update to a new revision and rollback to the previous revision;
+- clean uninstall; and
+- byte-for-byte preservation of `AGENTS.md`, `.cratis/PROJECT.md`, and an
+  unrelated local skill.
+
+This is promising, but it is not a supported Cratis installation path yet. APM
+is pre-1.0, does not support Pi, writes package-managed copies into host skill
+directories, and skipped organization-policy discovery in the disposable
+fixtures because they had no Git remote. Managed adoption therefore waits for
+an immutable package from `Cratis/AI.Distribution`, a real application and
+framework collision/context canary, and fail-closed organization policy.
+
+Until those gates pass:
+
+- `.cratis/ai.json` remains the Cratis profile and project-context intent;
+- Pi keeps its exact npm/Git package settings;
+- APM may not replace native marketplaces or the reviewed subscriber PR; and
+- Workflows#73 should reuse APM resolution, lock, audit, and uninstall behavior
+  if the real canary passes instead of rebuilding those features.
+
+The bounded evidence and adoption gates are recorded in
+[`distribution/apm-managed-install-evaluation.json`](../distribution/apm-managed-install-evaluation.json).
+
 ## Pi package workflow
 
 Pi is a first-class host, not a copied adapter directory. Pi packages can load

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "c696db07d59249e44370608c10c1fc85082f3403122af3bfc52f87395620b25a",
+  "indexDigest": "0fac9898b905efbf9dd66cfa52252fa910ef035e84f23f150e4e7f7a3fa3622c",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -456,6 +456,10 @@
     },
     {
       "path": "catalog/v2/upstream-companions.json",
+      "status": "added"
+    },
+    {
+      "path": "distribution/apm-managed-install-evaluation.json",
       "status": "added"
     },
     {
@@ -2123,6 +2127,10 @@
       "status": "added"
     },
     {
+      "path": "tooling/specs/apm-managed-install-evaluation.spec.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/specs/approved-profile-release.spec.mjs",
       "status": "added"
     },
@@ -3575,8 +3583,8 @@
       "evidenceIds": [
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 26,
-      "expectedPathsDigest": "7dbc3ad849f66c26519b10fd20fcbd441a894064c91daf916d6c32f5227c6976"
+      "expectedPathCount": 27,
+      "expectedPathsDigest": "4125e521908692f5e040a30d2c62c8c5dfe8a79d5d0d294fb0a3dc4c28d8ac36"
     },
     {
       "excludePathPatterns": [],
@@ -3622,8 +3630,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 30,
-      "expectedPathsDigest": "d9f85d6588e18ba401b82c3ed0525886e815f7273041b6eae5497b975a6639d5"
+      "expectedPathCount": 31,
+      "expectedPathsDigest": "35162356e3ad539410d723d3de6c0b4c66af312fc479ba3a642a08fd6ecea4ad"
     },
     {
       "excludePathPatterns": [],

--- a/distribution/apm-managed-install-evaluation.json
+++ b/distribution/apm-managed-install-evaluation.json
@@ -1,0 +1,114 @@
+{
+  "schemaVersion": "1.0.0",
+  "observedOn": "2026-08-24",
+  "state": "OPTIONAL_MANAGED_PATH_RECOMMENDED_AFTER_DISTRIBUTION_CANARY",
+  "tool": {
+    "name": "Microsoft Agent Package Manager",
+    "repository": "https://github.com/microsoft/apm",
+    "version": "0.28.0",
+    "buildRevision": "e041462",
+    "release": "https://github.com/microsoft/apm/releases/tag/v0.28.0",
+    "asset": "apm-darwin-arm64.tar.gz",
+    "assetSha256": "9676a6e7bf2bcb3966538a7130faea14ba030baa45f678597cc3fa15c902cb0a"
+  },
+  "decision": {
+    "individualDevelopers": "Use each host's native Cratis marketplace or plugin experience.",
+    "managedTeams": "Offer APM as an optional exact-lock, multi-tool installation path after an AI.Distribution package canary.",
+    "pi": "Keep Pi's native exact npm or Git package path; APM 0.28.0 does not support Pi.",
+    "subscription": "Keep .cratis/ai.json as the Cratis profile and project-context intent contract until APM reaches a stable boundary and duplicate state can be removed safely.",
+    "customInstaller": "Do not build a custom multi-agent package resolver, hash lock, drift scanner, or uninstall ledger while APM can provide those capabilities."
+  },
+  "publicFixture": {
+    "source": "Cratis/AI/skills/cratis-fundamentals-concept",
+    "oldRevision": "422ec8eebc198f9c25c28831a94623a3d4432fea",
+    "newRevision": "0d3a566a55c996c4a972f03e9dc20464f075bf24",
+    "oldSkillSha256": "06c164b26460fb914fc3146716c6f60b445a5f9839c1cb5f6d4d92c6489532fe",
+    "newSkillSha256": "423ab2d27b08e13d3c7c3fbaf9bbc06ea1fb9a13610bdcfdf37398b12d593ec9",
+    "targets": [
+      "agent-skills",
+      "claude",
+      "codex",
+      "cursor",
+      "gemini",
+      "grok-build",
+      "kiro"
+    ],
+    "projectContextSha256": {
+      "AGENTS.md": "e225ea112b6daa6c6aa39777445624e78eee8d3841c5d06d94816c629870e0f8",
+      ".cratis/PROJECT.md": "fb832bdd9c4f2650be54b47a3f998459ece30d549d2ded031a13ee340c786142",
+      ".agents/skills/local-context/SKILL.md": "ff4d3c373c7248d9a28dd005b177e9a274224f4d741abef73cf39204faa74b3c"
+    }
+  },
+  "engineeringFixture": {
+    "source": "Cratis/AI/engineering/skills/cratis-engineering-docs-authoring",
+    "revision": "f58bcf7f5cc9fc0e11305ada3b5ecb6fa20953e9",
+    "skillSha256": "014f2e7b55d4f1a7dd982e4e352cffc8cfa078a262056bb55b76eb2b81da0791",
+    "projectContextSha256": {
+      "AGENTS.md": "885b31a3d511cd812397a3858492546215249fd1d027a5c1abbcac57d9391dcc",
+      ".cratis/PROJECT.md": "337a03a8d31986a00eb54d331f95012f441ebd0f30f1d23696f311006d84270c",
+      ".agents/skills/local-context/SKILL.md": "ff4d3c373c7248d9a28dd005b177e9a274224f4d741abef73cf39204faa74b3c"
+    }
+  },
+  "results": [
+    {
+      "gate": "release-asset-checksum",
+      "status": "PASS",
+      "detail": "The downloaded APM 0.28.0 darwin-arm64 archive matched the publisher SHA-256 file."
+    },
+    {
+      "gate": "exact-remote-install-and-lock",
+      "status": "PASS",
+      "detail": "An exact Git commit produced apm.yml and apm.lock.yaml with resolved commit, content hash, deployed-file hashes, and deployment ownership."
+    },
+    {
+      "gate": "frozen-second-machine-restore",
+      "status": "PASS",
+      "detail": "apm install --frozen reproduced the same files from the committed manifest and lock without changing the lockfile."
+    },
+    {
+      "gate": "audit-and-drift-detection",
+      "status": "PASS",
+      "detail": "apm audit --ci passed clean state, returned nonzero for a modified installed skill, and identified the exact hash drift and file."
+    },
+    {
+      "gate": "repair",
+      "status": "PASS",
+      "detail": "apm install --frozen restored the modified skill to the locked SHA-256 and the audit returned clean."
+    },
+    {
+      "gate": "update-and-rollback",
+      "status": "PASS",
+      "detail": "Changing the exact manifest revision updated the skill and lock; restoring the prior revision restored the prior skill hash and lock commit."
+    },
+    {
+      "gate": "uninstall-and-context-preservation",
+      "status": "PASS",
+      "detail": "Uninstall removed only package-owned deployments and preserved AGENTS.md, .cratis/PROJECT.md, and an unrelated local skill byte-for-byte."
+    },
+    {
+      "gate": "public-safe-engineering-fixture",
+      "status": "PASS",
+      "detail": "The engineering skill installed at its exact revision, passed audit, uninstalled cleanly, and preserved private project context."
+    }
+  ],
+  "observations": [
+    "APM deploys package-managed skill copies into shared host directories such as .agents/skills, .claude/skills, .grok/skills, and .kiro/skills.",
+    "Collision and ownership tracking preserved unrelated local skills in the evaluated fixtures; adoption still needs a real repository namespace/collision canary.",
+    "APM adds apm_modules/ to .gitignore and expects apm.yml, apm.lock.yaml, and deployed host files to be reviewed according to team policy.",
+    "A local unpacked Agent Plugin generated a deployment ledger but no reproducible dependency entry; managed adoption must use an immutable remote AI.Distribution source.",
+    "The temporary fixtures had no Git remote, so organization policy discovery warned and skipped; a real Cratis canary must fail closed on policy-fetch failure.",
+    "APM 0.28.0 is pre-1.0 and has no Pi target."
+  ],
+  "adoptionGates": [
+    "Publish an immutable APM/Agent Plugin package from Cratis/AI.Distribution rather than installing from the mixed authoring repository.",
+    "Canary reserved Cratis skill namespaces and collision behavior in one authorized application and one framework repository.",
+    "Set organization policy fetch failure to block in managed repositories.",
+    "Decide whether deployed host files are committed, ignored and regenerated, or limited to the shared .agents/skills path.",
+    "Keep Pi exact package settings aligned through the same reviewed update pull request.",
+    "Pin and review APM upgrades while it remains pre-1.0.",
+    "Simplify Workflows#73 around manifest and lock updates instead of reimplementing dependency resolution and drift detection."
+  ],
+  "installationEligible": false,
+  "publicationEligible": false,
+  "promotionEligible": false
+}

--- a/tooling/specs/apm-managed-install-evaluation.spec.mjs
+++ b/tooling/specs/apm-managed-install-evaluation.spec.mjs
@@ -1,0 +1,109 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const evaluation = JSON.parse(
+    readFileSync(
+        "distribution/apm-managed-install-evaluation.json",
+        "utf8",
+    ),
+);
+
+const sha256Pattern = /^[0-9a-f]{64}$/;
+
+function assertHashes(values) {
+    for (const value of Object.values(values)) assert.match(value, sha256Pattern);
+}
+
+test("APM evaluation records a bounded optional-path decision", () => {
+    assert.equal(evaluation.schemaVersion, "1.0.0");
+    assert.equal(
+        evaluation.state,
+        "OPTIONAL_MANAGED_PATH_RECOMMENDED_AFTER_DISTRIBUTION_CANARY",
+    );
+    assert.equal(evaluation.tool.version, "0.28.0");
+    assert.equal(evaluation.tool.buildRevision, "e041462");
+    assert.match(evaluation.tool.assetSha256, sha256Pattern);
+    assert.match(evaluation.decision.individualDevelopers, /native Cratis marketplace/);
+    assert.match(evaluation.decision.managedTeams, /optional exact-lock/);
+    assert.match(evaluation.decision.pi, /does not support Pi/);
+    assert.match(evaluation.decision.customInstaller, /Do not build/);
+    assert.equal(evaluation.installationEligible, false);
+    assert.equal(evaluation.publicationEligible, false);
+    assert.equal(evaluation.promotionEligible, false);
+});
+
+test("APM evaluation covers reproducibility security lifecycle and both audiences", () => {
+    assert.deepEqual(
+        evaluation.results.map((result) => result.gate),
+        [
+            "release-asset-checksum",
+            "exact-remote-install-and-lock",
+            "frozen-second-machine-restore",
+            "audit-and-drift-detection",
+            "repair",
+            "update-and-rollback",
+            "uninstall-and-context-preservation",
+            "public-safe-engineering-fixture",
+        ],
+    );
+    assert(evaluation.results.every((result) => result.status === "PASS"));
+    assert.notEqual(
+        evaluation.publicFixture.oldSkillSha256,
+        evaluation.publicFixture.newSkillSha256,
+    );
+    assert.match(evaluation.publicFixture.oldRevision, /^[0-9a-f]{40}$/);
+    assert.match(evaluation.publicFixture.newRevision, /^[0-9a-f]{40}$/);
+    assert.match(evaluation.engineeringFixture.revision, /^[0-9a-f]{40}$/);
+    assertHashes(evaluation.publicFixture.projectContextSha256);
+    assertHashes(evaluation.engineeringFixture.projectContextSha256);
+    assert.equal(
+        evaluation.publicFixture.projectContextSha256[
+            ".agents/skills/local-context/SKILL.md"
+        ],
+        evaluation.engineeringFixture.projectContextSha256[
+            ".agents/skills/local-context/SKILL.md"
+        ],
+    );
+});
+
+test("APM evaluation keeps unresolved ownership and support boundaries explicit", () => {
+    for (const expected of [
+        "AI.Distribution",
+        "namespace",
+        "policy fetch failure",
+        "deployed host files",
+        "Pi exact package settings",
+        "pre-1.0",
+        "Workflows#73",
+    ])
+        assert(
+            evaluation.adoptionGates.some((gate) => gate.includes(expected)),
+            expected,
+        );
+    assert(
+        evaluation.observations.some((observation) =>
+            observation.includes("shared host directories"),
+        ),
+    );
+    assert(
+        evaluation.observations.some((observation) =>
+            observation.includes("no Git remote"),
+        ),
+    );
+});
+
+test("managed adoption documentation reflects the evidence decision", () => {
+    const documentation = readFileSync(
+        "Documentation/ai-distribution-and-subscriptions.md",
+        "utf8",
+    );
+    assert.match(documentation, /## Managed multi-tool installation/);
+    assert.match(documentation, /optional managed-team path/);
+    assert.match(documentation, /\(APM\) 0\.28\.0/);
+    assert.match(documentation, /does not support Pi/);
+    assert.match(documentation, /AI\.Distribution/);
+});


### PR DESCRIPTION
# Summary

Tests whether Cratis should reuse Microsoft Agent Package Manager for managed multi-tool subscriptions instead of building a custom resolver, lockfile, drift scanner, and uninstall system.

The evidence recommends APM as an optional managed-team path after a real AI.Distribution canary. Native marketplaces remain the easiest individual experience, and Pi keeps its native exact package path.

## Added

- Records checksum-bound APM 0.28.0 install, frozen restore, audit, repair, update, rollback, uninstall, and context-preservation evidence (#190)
- Adds tested adoption gates for immutable distribution packages, namespace collisions, organization policy, deployed-file ownership, Pi alignment, and pre-1.0 upgrades (#190)

## Changed

- Documents when managed teams may use APM and why it does not yet replace native marketplaces, Pi, or `.cratis/ai.json` (#190)
- Directs Workflows#73 to reuse proven package resolution and drift behavior rather than rebuilding it (#190)
