### PR TITLE
Make automatic releases safe and truthful

### DIFF
--- a/.github/workflows/release-approved-ai-profiles.yml
+++ b/.github/workflows/release-approved-ai-profiles.yml
@@ -11,12 +11,6 @@ on:
     branches: ["main"]
     paths:
       - "distribution/releases/*.json"
-  workflow_dispatch:
-    inputs:
-      request:
-        description: Release request path under distribution/releases
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -50,27 +44,22 @@ jobs:
         id: request
         env:
           EVENT_NAME: ${{ github.event_name }}
-          INPUT_REQUEST: ${{ inputs.request }}
           PULL_REQUEST_BASE: ${{ github.event.pull_request.base.sha }}
           PUSH_BEFORE: ${{ github.event.before }}
         run: |
           set -euo pipefail
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            request="$INPUT_REQUEST"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            base="$PULL_REQUEST_BASE"
           else
-            if [ "$EVENT_NAME" = "pull_request" ]; then
-              base="$PULL_REQUEST_BASE"
-            else
-              base="$PUSH_BEFORE"
-            fi
-            mapfile -t requests < <(
-              git diff --name-only "$base" "$GITHUB_SHA" -- \
-                'distribution/releases/*.json' |
-                grep -E '^distribution/releases/v[^/]+\.json$' || true
-            )
-            test "${#requests[@]}" -eq 1
-            request="${requests[0]}"
+            base="$PUSH_BEFORE"
           fi
+          mapfile -t requests < <(
+            git diff --name-only "$base" "$GITHUB_SHA" -- \
+              'distribution/releases/*.json' |
+              grep -E '^distribution/releases/v[^/]+\.json$' || true
+          )
+          test "${#requests[@]}" -eq 1
+          request="${requests[0]}"
           test -f "$request"
           node tooling/validate-catalogs.mjs
           node tooling/release-request-validation.mjs "$request" \
@@ -108,13 +97,16 @@ jobs:
 
       - name: Generate root-native profile artifacts
         env:
+          EVENT_NAME: ${{ github.event_name }}
           PROFILE: ${{ matrix.profile }}
           VERSION: ${{ needs.discover.outputs.version }}
         run: |
           set -euo pipefail
           candidate="$RUNNER_TEMP/release-$PROFILE"
+          mode=()
+          if [ "$EVENT_NAME" = "push" ]; then mode=(release); fi
           node tooling/generate-approved-profile-release.mjs \
-            "$candidate" "$PROFILE" "$VERSION"
+            "$candidate" "$PROFILE" "$VERSION" "${mode[@]}"
           mkdir -p "$candidate/assets"
           for root in "$candidate"/harnesses/*; do
             harness=$(basename "$root")
@@ -127,7 +119,12 @@ jobs:
                 -C "$root" .
             fi
           done
-          sha256sum "$candidate"/assets/* > "$candidate/assets/SHA256SUMS"
+          cp "$candidate/release-instructions.md" "$candidate/assets/"
+          cp "$candidate/support-matrix.json" "$candidate/assets/"
+          (
+            cd "$candidate/assets"
+            sha256sum ./* > SHA256SUMS
+          )
           node --test tooling/specs/approved-profile-release.spec.mjs
 
       - name: Upload verified profile candidate
@@ -139,7 +136,7 @@ jobs:
           retention-days: 7
 
   canary:
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push'
     needs: [discover, verify]
     strategy:
       fail-fast: true
@@ -175,30 +172,37 @@ jobs:
         with:
           global-json-file: consumer/global.json
 
-      - name: Install Pi for package lifecycle validation
-        if: matrix.canary.canaryId == 'samples-chronicle-backend'
-        run: npm install --global @earendil-works/pi-coding-agent@0.84.2
-
       - name: Run Samples Chronicle Backend canary
         if: matrix.canary.canaryId == 'samples-chronicle-backend'
-        env:
-          PROFILE: ${{ matrix.canary.profileId }}
         run: |
           set -euo pipefail
+          (
+            cd "$RUNNER_TEMP/candidate/assets"
+            sha256sum -c SHA256SUMS
+          )
           tarball=$(find "$RUNNER_TEMP/candidate/assets" -maxdepth 1 \
             -type f -name '*.tgz' -print -quit)
           test -n "$tarball"
           mkdir -p "$RUNNER_TEMP/package" "$RUNNER_TEMP/pi-home"
           tar -xzf "$tarball" -C "$RUNNER_TEMP/package"
           package_root="$RUNNER_TEMP/package/package"
-          HOME="$RUNNER_TEMP/pi-home" pi install "$package_root"
-          HOME="$RUNNER_TEMP/pi-home" pi list | grep -F "$package_root"
+          pi_cmd() {
+            npm exec --yes \
+              --package=@earendil-works/pi-coding-agent@0.84.2 -- \
+              pi "$@"
+          }
+          HOME="$RUNNER_TEMP/pi-home" pi_cmd install "$package_root"
+          HOME="$RUNNER_TEMP/pi-home" pi_cmd list | grep -F "$package_root"
           dotnet build consumer/Chronicle/Backend/Backend.csproj \
             --configuration Debug --nologo
           dotnet test consumer/Chronicle/Backend/Backend.Specs/Backend.Specs.csproj \
             --configuration Debug --nologo
-          HOME="$RUNNER_TEMP/pi-home" pi remove "$package_root"
-          HOME="$RUNNER_TEMP/pi-home" pi list | grep -F 'No packages installed'
+          HOME="$RUNNER_TEMP/pi-home" pi_cmd remove "$package_root"
+          HOME="$RUNNER_TEMP/pi-home" pi_cmd list | grep -F 'No packages installed'
+          HOME="$RUNNER_TEMP/pi-home" pi_cmd install "$package_root"
+          HOME="$RUNNER_TEMP/pi-home" pi_cmd list | grep -F "$package_root"
+          HOME="$RUNNER_TEMP/pi-home" pi_cmd remove "$package_root"
+          HOME="$RUNNER_TEMP/pi-home" pi_cmd list | grep -F 'No packages installed'
           test -z "$(git -C consumer status --porcelain)"
 
       - name: Reject unknown canary
@@ -208,11 +212,14 @@ jobs:
           exit 1
 
   distribute:
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push'
     needs: [discover, verify, canary]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: distribution-canary
+    outputs:
+      branch: ${{ steps.distribution.outputs.branch }}
+      pull_request: ${{ steps.distribution.outputs.pull_request }}
     steps:
       - name: Check out release metadata
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -237,7 +244,8 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      - name: Create immutable distribution release and index PR
+      - name: Create draft distribution release and index PR
+        id: distribution
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REQUEST: ${{ needs.discover.outputs.request }}
@@ -248,6 +256,23 @@ jobs:
           gh repo clone Cratis/AI.Distribution "$RUNNER_TEMP/AI.Distribution"
           branch="generated/release-$VERSION-${GITHUB_SHA:0:12}"
           destination="$RUNNER_TEMP/AI.Distribution/releases/$VERSION"
+          pr_number=""
+          cleanup() {
+            status=$?
+            if [ "$status" -ne 0 ]; then
+              gh release delete "v$VERSION" --repo Cratis/AI.Distribution \
+                --yes --cleanup-tag || true
+              if [ -n "$pr_number" ]; then
+                gh pr close "$pr_number" --repo Cratis/AI.Distribution \
+                  --delete-branch || true
+              else
+                git -C "$RUNNER_TEMP/AI.Distribution" push origin \
+                  --delete "$branch" || true
+              fi
+            fi
+            exit "$status"
+          }
+          trap cleanup EXIT
           git -C "$RUNNER_TEMP/AI.Distribution" checkout -b "$branch"
           test ! -e "$destination"
           mkdir -p "$destination/profiles"
@@ -265,23 +290,37 @@ jobs:
             --message "Generate Cratis AI release $VERSION"
           git -C "$RUNNER_TEMP/AI.Distribution" push origin "$branch"
           mapfile -t assets < <(find "$destination/profiles" -path '*/assets/*' \
-            -type f ! -name SHA256SUMS | sort)
+            -type f | sort)
+          notes="$RUNNER_TEMP/release-notes.md"
+          {
+            echo "Generated from the approved Cratis/AI release request at $GITHUB_SHA."
+            echo
+            echo "The release remains draft until npm publication succeeds."
+            echo
+            find "$destination/profiles" -name release-instructions.md \
+              -type f -print0 | sort -z | xargs -0 -r cat
+          } > "$notes"
           gh release create "v$VERSION" "${assets[@]}" \
             --repo Cratis/AI.Distribution \
             --target "$branch" \
             --draft \
             --title "Cratis AI $VERSION" \
-            --notes "Automatically generated from approved Cratis/AI release PR at $GITHUB_SHA. Published only after npm succeeds."
+            --notes-file "$notes"
           pr_url=$(gh pr create \
             --repo Cratis/AI.Distribution \
             --base main \
             --head "$branch" \
             --title "Index Cratis AI release $VERSION" \
-            --body "Automatically generated from the merged Cratis/AI release request at $GITHUB_SHA.")
-          gh pr merge "$pr_url" --repo Cratis/AI.Distribution --auto --squash
+            --body "Generated from the merged Cratis/AI release request at $GITHUB_SHA. Merge only after npm publication succeeds.")
+          pr_number=${pr_url##*/}
+          {
+            echo "branch=$branch"
+            echo "pull_request=$pr_number"
+          } >> "$GITHUB_OUTPUT"
+          trap - EXIT
 
   publish-npm:
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push'
     needs: [discover, verify, canary, distribute]
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -302,22 +341,58 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
-      - name: Publish exact profile packages
+      - name: Publish the exact profile package
         env:
           VERSION: ${{ needs.discover.outputs.version }}
         run: |
           set -euo pipefail
-          npm install --global npm@11.5.1
+          npm_version=$(npm --version)
+          node -e '
+            const [major, minor, patch] = process.argv[1].split(".").map(Number);
+            if (major < 11 || (major === 11 && minor < 5) ||
+                (major === 11 && minor === 5 && patch < 1)) process.exit(1);
+          ' "$npm_version"
           if [[ "$VERSION" == *-* ]]; then tag=preview; else tag=latest; fi
-          for artifact in "$RUNNER_TEMP"/profiles/release-*; do
-            npm publish "$artifact/harnesses/pi" \
-              --access public --provenance --tag "$tag"
-          done
+          mapfile -t artifacts < <(find "$RUNNER_TEMP/profiles" -maxdepth 1 \
+            -type d -name 'release-*' | sort)
+          test "${#artifacts[@]}" -eq 1
+          npm publish "${artifacts[0]}/harnesses/pi" \
+            --access public --provenance --tag "$tag"
 
-  promote-and-follow-up:
-    if: github.event_name != 'pull_request'
+  cleanup-failed-publication:
+    if: ${{ always() && github.event_name == 'push' && needs.distribute.result == 'success' && needs['publish-npm'].result == 'failure' }}
     needs: [discover, distribute, publish-npm]
     runs-on: ubuntu-latest
+    environment: distribution-canary
+    steps:
+      - name: Create repository-scoped distribution token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AI_DISTRIBUTION_APP_ID }}
+          private-key: ${{ secrets.AI_DISTRIBUTION_APP_PRIVATE_KEY }}
+          owner: Cratis
+          repositories: AI.Distribution
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Remove unpublished draft state
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ needs.discover.outputs.version }}
+          PR_NUMBER: ${{ needs.distribute.outputs.pull_request }}
+        run: |
+          set -euo pipefail
+          gh release delete "v$VERSION" --repo Cratis/AI.Distribution \
+            --yes --cleanup-tag
+          gh pr close "$PR_NUMBER" --repo Cratis/AI.Distribution \
+            --delete-branch
+
+  promote-and-follow-up:
+    if: github.event_name == 'push'
+    needs: [discover, distribute, publish-npm]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: distribution-canary
     permissions:
       contents: read
@@ -332,15 +407,42 @@ jobs:
           owner: Cratis
           repositories: AI.Distribution
           permission-contents: write
+          permission-pull-requests: write
 
-      - name: Publish GitHub release and record rollout handoff
+      - name: Publish GitHub release and enable index merge
         env:
           DISTRIBUTION_TOKEN: ${{ steps.app-token.outputs.token }}
           ISSUE_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.discover.outputs.version }}
+          PR_NUMBER: ${{ needs.distribute.outputs.pull_request }}
         run: |
           set -euo pipefail
+          GH_TOKEN="$DISTRIBUTION_TOKEN" gh pr merge "$PR_NUMBER" \
+            --repo Cratis/AI.Distribution --auto --merge
+          for _ in {1..60}; do
+            state=$(GH_TOKEN="$DISTRIBUTION_TOKEN" gh pr view "$PR_NUMBER" \
+              --repo Cratis/AI.Distribution --json state --jq .state)
+            if [ "$state" = "MERGED" ]; then break; fi
+            test "$state" = "OPEN"
+            sleep 10
+          done
+          test "$state" = "MERGED"
           GH_TOKEN="$DISTRIBUTION_TOKEN" gh release edit "v$VERSION" \
             --repo Cratis/AI.Distribution --draft=false
           GH_TOKEN="$ISSUE_TOKEN" gh issue comment 181 --repo Cratis/AI \
-            --body "Release $VERSION generated, canaried, distributed, npm-published, and promoted automatically. Workflows#73 must fan out subscriber update PRs; AI#147 tracks marketplaces that require one-time human listing approval."
+            --body "Release $VERSION generated, canaried, npm-published, and promoted. Subscriber updates remain disabled until Workflows#73 is implemented; marketplace submission remains the manual AI#147 handoff."
+
+  record-promotion-failure:
+    if: ${{ always() && github.event_name == 'push' && needs['publish-npm'].result == 'success' && needs['promote-and-follow-up'].result == 'failure' }}
+    needs: [discover, publish-npm, promote-and-follow-up]
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Record irreversible partial publication
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.discover.outputs.version }}
+        run: |
+          gh issue comment 181 --repo Cratis/AI \
+            --body "Release $VERSION was published to npm, but distribution promotion failed. The npm version is immutable and was not rolled back. Keep the GitHub release draft and generated index PR for explicit recovery."

--- a/Documentation/ai-distribution-and-subscriptions.md
+++ b/Documentation/ai-distribution-and-subscriptions.md
@@ -330,9 +330,12 @@ a marketplace.
 A deliberately identified release PR is the recurring human approval. It adds
 one immutable `distribution/releases/v<version>.json` request. Pull-request CI
 materializes and verifies every requested profile; merging that PR to `main`
-automatically generates distribution/GitHub assets, runs canaries, publishes npm
-through trusted OIDC, promotes or stops/rolls back, and hands subscriber updates
-to Workflows. See [Release Cratis AI](./releasing-cratis-ai.md).
+automatically generates distribution/GitHub assets, runs canaries, publishes one
+exact npm profile through trusted OIDC, and promotes only after publication
+succeeds. Unpublished draft state is cleaned up; an immutable npm version is
+never described as rolled back. Subscriber and marketplace delivery remain
+disabled handoffs until their separate implementation gates pass. See
+[Release Cratis AI](./releasing-cratis-ai.md).
 
 All profile packages use SemVer and one atomic release train. A release changes
 shared behavior only through a reviewed `Cratis/AI` commit and records:
@@ -343,7 +346,10 @@ shared behavior only through a reviewed `Cratis/AI` commit and records:
 - package/profile inventory;
 - tested harness versions;
 - checksums and provenance;
-- canary, update, rollback, and uninstall results.
+- canary and reinstall recovery results;
+- truthful generated/static/host-tested support status; and
+- update, rollback, and uninstall evidence when those lifecycle paths have
+  actually run for the exact release.
 
 A patch release corrects behavior without changing profile intent. A minor
 release adds backward-compatible skills or profiles. A major release removes,

--- a/Documentation/examples/ai-release/v0.1.0-preview.1.json
+++ b/Documentation/examples/ai-release/v0.1.0-preview.1.json
@@ -17,8 +17,9 @@
     "npmPublish": true,
     "canary": true,
     "autoPromote": true,
-    "autoRollback": true,
-    "subscriberUpdates": true,
-    "marketplaces": "automatic-where-supported-submit-otherwise"
+    "failureCleanup": true,
+    "autoRollback": false,
+    "subscriberUpdates": false,
+    "marketplaces": "manual-handoff"
   }
 }

--- a/Documentation/releasing-cratis-ai.md
+++ b/Documentation/releasing-cratis-ai.md
@@ -34,15 +34,24 @@ Create `distribution/releases/v<version>.json`:
     "npmPublish": true,
     "canary": true,
     "autoPromote": true,
-    "autoRollback": true,
-    "subscriberUpdates": true,
-    "marketplaces": "automatic-where-supported-submit-otherwise"
+    "failureCleanup": true,
+    "autoRollback": false,
+    "subscriberUpdates": false,
+    "marketplaces": "manual-handoff"
   }
 }
 ```
 
 The filename and `version` must match. Each profile has exactly one registered
-canary. Requests are append-only and version-unique.
+canary. Until atomic multi-package npm publication exists, one request contains
+exactly one profile. Requests are append-only and version-unique.
+
+The request may claim only automation recorded in
+[`release-automation-capabilities.json`](../distribution/release-automation-capabilities.json).
+The first preview cleans up unpublished draft state automatically, but it does
+not claim that an immutable npm version can be rolled back, and subscriber or
+marketplace automation remains disabled until its own implementation and canary
+exist.
 
 ## 3. Open the release PR
 
@@ -67,6 +76,7 @@ Review:
 - package versions;
 - generated host roots;
 - provenance, SBOM, and checksums;
+- generated lifecycle instructions and the generated/static/host-tested support matrix;
 - selected canaries;
 - release notes and known limitations.
 
@@ -82,10 +92,10 @@ After merge, `Release Approved AI Profiles` automatically:
 4. creates the immutable `Cratis/AI.Distribution` release branch and GitHub
    release;
 5. publishes profile Pi/npm packages through trusted OIDC;
-6. opens/auto-merges the generated distribution index PR when App policy allows;
-7. hands the release to Workflows#73 for subscriber update pull requests;
-8. updates marketplaces automatically where supported and records one-time
-   manual vendor submissions under AI#147.
+6. enables the generated distribution index PR for merge only after npm succeeds;
+7. publishes the draft GitHub release; and
+8. records that subscriber updates and marketplace submissions remain disabled
+   handoffs until Workflows#73 and AI#147 complete their own gates.
 
 No developer-machine token or manual `npm publish` command is part of the
 release path.
@@ -95,12 +105,14 @@ release path.
 - PR validation failure: fix the release PR; nothing was released.
 - Canary failure: publication jobs do not run; the current stable release stays
   unchanged.
-- Distribution/npm failure: the workflow fails visibly; do not advance
-  subscriber pins.
-- Subscriber failure: Workflows restores the previous exact version and leaves
-  the failed repository unmerged.
-- Marketplace failure: npm/GitHub release remains inspectable; the failed host
-  is not marked supported.
+- Distribution failure before npm: the draft release, generated index PR, and
+  branch are removed automatically.
+- npm failure: the unpublished draft release and generated index PR are removed.
+- Promotion failure after npm succeeds: npm is immutable and is **not** described
+  as rolled back. The draft release and index PR remain for explicit recovery,
+  and the failure is recorded on AI#181.
+- Subscriber and marketplace delivery are disabled for this preview and cannot
+  advance automatically.
 
 Never rewrite or reuse a release request version. Correct a released defect with
 a new SemVer version.

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "c56d5ee1188eac0065946ef9c13153adc9243110cfcc96bc8c2cf3067b6e878c",
+  "indexDigest": "39c0e1b82b43c60521a95a7237b989132b0f33fe6e6456cbc44de46f9cf84bf8",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -544,6 +544,10 @@
     },
     {
       "path": "distribution/release-approvals.json",
+      "status": "added"
+    },
+    {
+      "path": "distribution/release-automation-capabilities.json",
       "status": "added"
     },
     {
@@ -3583,8 +3587,8 @@
       "evidenceIds": [
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 27,
-      "expectedPathsDigest": "4125e521908692f5e040a30d2c62c8c5dfe8a79d5d0d294fb0a3dc4c28d8ac36"
+      "expectedPathCount": 28,
+      "expectedPathsDigest": "37938651506109f6e867144bb871a36874b2afd7f7566df3bf3a2b15f95505aa"
     },
     {
       "excludePathPatterns": [],

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "0fac9898b905efbf9dd66cfa52252fa910ef035e84f23f150e4e7f7a3fa3622c",
+  "indexDigest": "c56d5ee1188eac0065946ef9c13153adc9243110cfcc96bc8c2cf3067b6e878c",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/distribution/generated-repository-contract.json
+++ b/distribution/generated-repository-contract.json
@@ -85,10 +85,12 @@
     "githubReleaseAutomatic": true,
     "npmTrustedPublishAutomatic": true,
     "canaryRequiredBeforePublication": true,
+    "maxProfilesPerRelease": 1,
     "automaticPromotion": true,
-    "automaticRollback": true,
-    "subscriberUpdatePullRequests": true,
-    "marketplaces": "automatic-where-supported-submit-otherwise"
+    "failureCleanupBeforePublication": true,
+    "automaticRollback": false,
+    "subscriberUpdatePullRequests": false,
+    "marketplaces": "manual-handoff"
   },
   "publicationEligible": false,
   "promotionEligible": false,

--- a/distribution/release-automation-capabilities.json
+++ b/distribution/release-automation-capabilities.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": "1.0.0",
+  "releaseTrigger": "merged-validated-request-on-main",
+  "maxProfilesPerRelease": 1,
+  "automation": {
+    "generatedDistribution": true,
+    "githubRelease": true,
+    "npmPublish": true,
+    "canary": true,
+    "autoPromote": true,
+    "failureCleanup": true,
+    "autoRollback": false,
+    "subscriberUpdates": false,
+    "marketplaces": "manual-handoff"
+  },
+  "recovery": {
+    "beforeNpmPublication": "Delete the draft GitHub release, close the generated index pull request, and delete its branch.",
+    "afterNpmPublication": "Keep the immutable npm package, draft release, and index pull request for explicit recovery; never claim the npm version was rolled back.",
+    "subscriberUpdates": "Disabled until Cratis/Workflows#73 is implemented and canaried.",
+    "marketplaces": "Manual publisher-account and vendor-review handoff remains tracked by Cratis/AI#147."
+  }
+}

--- a/distribution/release-request.schema.json
+++ b/distribution/release-request.schema.json
@@ -60,6 +60,7 @@
         "npmPublish",
         "canary",
         "autoPromote",
+        "failureCleanup",
         "autoRollback",
         "subscriberUpdates",
         "marketplaces"
@@ -69,11 +70,12 @@
         "githubRelease": { "const": true },
         "npmPublish": { "const": true },
         "canary": { "const": true },
-        "autoPromote": { "const": true },
-        "autoRollback": { "const": true },
-        "subscriberUpdates": { "const": true },
+        "autoPromote": { "type": "boolean" },
+        "failureCleanup": { "type": "boolean" },
+        "autoRollback": { "type": "boolean" },
+        "subscriberUpdates": { "type": "boolean" },
         "marketplaces": {
-          "const": "automatic-where-supported-submit-otherwise"
+          "enum": ["manual-handoff", "automatic-where-supported-submit-otherwise"]
         }
       }
     }

--- a/distribution/releases/README.md
+++ b/distribution/releases/README.md
@@ -7,16 +7,21 @@ approval required by that request.
 Pull-request validation generates all requested profile artifacts. Merging the
 release PR to `main` is the recurring human release approval and triggers:
 
-1. generated distribution and GitHub release assets;
-2. npm trusted publication;
-3. required canaries;
-4. automatic promotion or rollback;
-5. subscriber update pull requests;
-6. automatic marketplace updates where supported and submission preparation
-   where a vendor requires human review.
+1. exact generated distribution candidates;
+2. required pre-publication canary and checksum verification;
+3. a draft GitHub release and unmerged distribution index pull request;
+4. one exact npm profile publication; and
+5. GitHub release promotion plus index auto-merge only after npm succeeds.
+
+The current implementation cleans up unpublished draft state automatically. It
+does not claim to roll back an immutable npm version. Subscriber updates and
+marketplace delivery remain disabled handoffs until Workflows#73 and AI#147
+complete their implementation, canary, and account gates.
 
 External App credentials, npm trusted-publisher registration, initial canary
 scope, and one-time vendor account/listing approvals are tracked in AI#181.
 
-Do not add a request until its profiles are fully approved. Release request files
-are append-only and version-unique.
+Do not add a request until its profile is fully approved. One request contains
+one profile until atomic multi-package npm publication exists. Request automation
+must exactly match `distribution/release-automation-capabilities.json`. Release
+request files are append-only and version-unique.

--- a/distribution/rollout-policy.json
+++ b/distribution/rollout-policy.json
@@ -36,9 +36,11 @@
     "requestRoot": "distribution/releases",
     "mergeToMainIsApproval": true,
     "canaryBeforePublication": true,
+    "maxProfilesPerRelease": 1,
     "automaticPromotion": true,
-    "automaticRollback": true,
-    "subscriberUpdates": true
+    "failureCleanupBeforePublication": true,
+    "automaticRollback": false,
+    "subscriberUpdates": false
   },
   "promotion": {
     "stableEnabled": false,

--- a/tooling/generate-approved-profile-release.mjs
+++ b/tooling/generate-approved-profile-release.mjs
@@ -59,6 +59,79 @@ function exactSemVer(version) {
     );
 }
 
+export function buildReleaseSupportMatrix(plan, harnesses) {
+    return {
+        schemaVersion: "1.0.0",
+        profileId: plan.profileId,
+        version: plan.version,
+        definitions: {
+            generated: "The canonical approved skill bytes are present in the host package.",
+            staticallyValidated:
+                "Manifest shape, file inventory, safety boundaries, and canonical byte parity passed repository specifications.",
+            hostTested:
+                "The named host version completed install, discovery, update or reinstall, and removal evidence for this exact release.",
+        },
+        hosts: harnesses.map((harness) => ({
+            harness,
+            generated: true,
+            staticallyValidated: true,
+            hostTested: false,
+            releaseCanary:
+                harness === "pi" ? "required-before-publication" : "not-run",
+            support: "generated-not-yet-supported-by-this-release",
+        })),
+        claim: "Generation and static validation do not by themselves establish host support.",
+    };
+}
+
+export function buildReleaseInstructions(plan, harnesses) {
+    const archiveLines = harnesses
+        .filter((harness) => harness !== "pi")
+        .map(
+            (harness) =>
+                `- ${harness}: \`cratis-ai-${plan.profileId}-${plan.version}-${harness}.tar.gz\``,
+        );
+    return [
+        `# ${plan.displayName} ${plan.version}`,
+        "",
+        plan.description,
+        "",
+        "## Verify downloads",
+        "",
+        "Download `SHA256SUMS` with the selected artifacts, place them in one directory, and run:",
+        "",
+        "```bash",
+        "sha256sum -c SHA256SUMS",
+        "```",
+        "",
+        "## Pi",
+        "",
+        "Install the exact profile package in project scope:",
+        "",
+        "```bash",
+        `pi install -l npm:${plan.packageName}@${plan.version}`,
+        "pi list",
+        "```",
+        "",
+        "Remove the exact package source:",
+        "",
+        "```bash",
+        `pi remove npm:${plan.packageName}@${plan.version}`,
+        "```",
+        "",
+        "Update or roll back by changing both the project subscription and package source to another exact version, then rerun the repository gates.",
+        "",
+        "## Other hosts",
+        "",
+        "Use the root-native archive for the selected host. Review `support-matrix.json` before treating a generated wrapper as supported:",
+        "",
+        ...archiveLines,
+        "",
+        "Install, update, and remove through that host's native local-plugin or marketplace flow. Do not point a host at the mixed Cratis/AI authoring repository.",
+        "",
+    ].join("\n");
+}
+
 export function buildApprovedProfileReleasePlan({
     profileId,
     version,
@@ -290,6 +363,7 @@ export function generateApprovedProfileRelease({
     outputRoot,
     profileId,
     version,
+    releaseMode = false,
 } = {}) {
     if (!outputRoot || !profileId || !version)
         throw new Error("outputRoot, profileId, and version are required");
@@ -318,6 +392,15 @@ export function generateApprovedProfileRelease({
             description: plan.description,
             skills,
         });
+        writeJson(
+            join(root, "support-matrix.json"),
+            buildReleaseSupportMatrix(plan, adapterManifest.harnesses),
+        );
+        writeFileSync(
+            join(root, "release-instructions.md"),
+            buildReleaseInstructions(plan, adapterManifest.harnesses),
+            { flag: "wx" },
+        );
         const sourceCommit = execFileSync("git", ["rev-parse", "HEAD"], {
             cwd: repositoryRoot,
             encoding: "utf8",
@@ -358,7 +441,7 @@ export function generateApprovedProfileRelease({
                 contentDigest: source.contentDigest,
                 approval: target.approval,
             })),
-            publicationEligible: false,
+            publicationEligible: releaseMode,
             promotionEligible: false,
         });
         const payloadFiles = walkFiles(root)
@@ -369,7 +452,9 @@ export function generateApprovedProfileRelease({
             });
         const releaseManifest = {
             schemaVersion: "1.0.0",
-            state: "APPROVED_PROFILE_RELEASE_CANDIDATE",
+            state: releaseMode
+                ? "APPROVED_PROFILE_RELEASE"
+                : "APPROVED_PROFILE_RELEASE_CANDIDATE",
             profileId,
             profileDisplayName: plan.displayName,
             profileDescription: plan.description,
@@ -381,7 +466,9 @@ export function generateApprovedProfileRelease({
             harnessRoots: adapterManifest.roots,
             files: payloadFiles,
             checksumFile: "SHA256SUMS",
-            publicationEligible: false,
+            instructionsFile: "release-instructions.md",
+            supportMatrixFile: "support-matrix.json",
+            publicationEligible: releaseMode,
             promotionEligible: false,
         };
         writeJson(join(root, "release-manifest.json"), releaseManifest);
@@ -404,10 +491,10 @@ export function generateApprovedProfileRelease({
 }
 
 function main() {
-    const [outputRoot, profileId, version] = process.argv.slice(2);
+    const [outputRoot, profileId, version, mode] = process.argv.slice(2);
     if (!outputRoot || !profileId || !version) {
         process.stderr.write(
-            "Usage: node tooling/generate-approved-profile-release.mjs <output> <profile-id> <exact-version>\n",
+            "Usage: node tooling/generate-approved-profile-release.mjs <output> <profile-id> <exact-version> [release]\n",
         );
         process.exitCode = 1;
         return;
@@ -416,6 +503,7 @@ function main() {
         outputRoot,
         profileId,
         version,
+        releaseMode: mode === "release",
     });
     process.stdout.write(
         `Generated approved profile release ${manifest.profileId}@${manifest.version}.\n`,

--- a/tooling/passive-profile-adapters.mjs
+++ b/tooling/passive-profile-adapters.mjs
@@ -330,6 +330,11 @@ export function generatePassiveProfileAdapters({
         description,
         private: piPrivate,
         license: "MIT",
+        repository: {
+            type: "git",
+            url: "https://github.com/Cratis/AI",
+        },
+        homepage: "https://cratis.io/ai",
         files: ["skills"],
         keywords: ["pi-package", "cratis"],
         pi: { skills: ["./skills"] },

--- a/tooling/release-request-validation.mjs
+++ b/tooling/release-request-validation.mjs
@@ -36,13 +36,17 @@ function repositoryInputs(repositoryRoot, errors) {
         "catalog/v2/authoring-contracts.json",
     )?.contracts;
     const artifacts = read("catalog/v2/artifacts.json")?.artifacts;
+    const releaseAutomationCapabilities = read(
+        "distribution/release-automation-capabilities.json",
+    );
     if (
         !profileCatalog ||
         !targets ||
         !sources ||
         !sourceContracts ||
         !authoringContracts ||
-        !artifacts
+        !artifacts ||
+        !releaseAutomationCapabilities
     )
         return null;
     return {
@@ -52,6 +56,7 @@ function repositoryInputs(repositoryRoot, errors) {
         sourceContracts,
         authoringContracts,
         artifacts,
+        releaseAutomationCapabilities,
     };
 }
 
@@ -62,6 +67,29 @@ export function validateReleaseRequest(request, relativePath, inputs, schema) {
         errors.push(
             `${relativePath}: filename must be v${request.version}.json`,
         );
+    const automationCapabilities = inputs?.releaseAutomationCapabilities;
+    if (
+        automationCapabilities &&
+        (request.profiles?.length ?? 0) >
+            automationCapabilities.maxProfilesPerRelease
+    )
+        errors.push(
+            `${relativePath}: release exceeds the implemented profile publication limit`,
+        );
+    if (automationCapabilities) {
+        const implemented = automationCapabilities.automation;
+        const requested = request.automation ?? {};
+        for (const [capability, value] of Object.entries(implemented))
+            if (requested[capability] !== value)
+                errors.push(
+                    `${relativePath}: automation ${capability} must match implemented value ${JSON.stringify(value)}`,
+                );
+        for (const capability of Object.keys(requested))
+            if (!Object.hasOwn(implemented, capability))
+                errors.push(
+                    `${relativePath}: automation ${capability} is not implemented`,
+                );
+    }
     const knownCanaries = new Set(["samples-chronicle-backend"]);
     const canaryProfiles =
         request.canaries?.map((canary) => canary.profileId) ?? [];
@@ -108,14 +136,13 @@ export function validateReleaseRequests(
     );
     const inputs = repositoryInputs(repositoryRoot, errors);
     const releasesRoot = join(repositoryRoot, "distribution/releases");
-    const relativePaths = onlyPath
-        ? [onlyPath]
-        : existsSync(releasesRoot)
-          ? readdirSync(releasesRoot)
-                .filter((name) => name.endsWith(".json"))
-                .sort()
-                .map((name) => `distribution/releases/${name}`)
-          : [];
+    let relativePaths = [];
+    if (onlyPath) relativePaths = [onlyPath];
+    else if (existsSync(releasesRoot))
+        relativePaths = readdirSync(releasesRoot)
+            .filter((name) => name.endsWith(".json"))
+            .sort()
+            .map((name) => `distribution/releases/${name}`);
     const requests = [];
     for (const relativePath of relativePaths) {
         if (!/^distribution\/releases\/v[^/]+\.json$/.test(relativePath)) {

--- a/tooling/specs/apm-managed-install-evaluation.spec.mjs
+++ b/tooling/specs/apm-managed-install-evaluation.spec.mjs
@@ -6,16 +6,14 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 const evaluation = JSON.parse(
-    readFileSync(
-        "distribution/apm-managed-install-evaluation.json",
-        "utf8",
-    ),
+    readFileSync("distribution/apm-managed-install-evaluation.json", "utf8"),
 );
 
 const sha256Pattern = /^[0-9a-f]{64}$/;
 
 function assertHashes(values) {
-    for (const value of Object.values(values)) assert.match(value, sha256Pattern);
+    for (const value of Object.values(values))
+        assert.match(value, sha256Pattern);
 }
 
 test("APM evaluation records a bounded optional-path decision", () => {
@@ -27,7 +25,10 @@ test("APM evaluation records a bounded optional-path decision", () => {
     assert.equal(evaluation.tool.version, "0.28.0");
     assert.equal(evaluation.tool.buildRevision, "e041462");
     assert.match(evaluation.tool.assetSha256, sha256Pattern);
-    assert.match(evaluation.decision.individualDevelopers, /native Cratis marketplace/);
+    assert.match(
+        evaluation.decision.individualDevelopers,
+        /native Cratis marketplace/,
+    );
     assert.match(evaluation.decision.managedTeams, /optional exact-lock/);
     assert.match(evaluation.decision.pi, /does not support Pi/);
     assert.match(evaluation.decision.customInstaller, /Do not build/);

--- a/tooling/specs/approved-profile-release.spec.mjs
+++ b/tooling/specs/approved-profile-release.spec.mjs
@@ -8,6 +8,8 @@ import { join } from "node:path";
 import test from "node:test";
 import {
     buildApprovedProfileReleasePlan,
+    buildReleaseInstructions,
+    buildReleaseSupportMatrix,
     generateApprovedProfileRelease,
 } from "../generate-approved-profile-release.mjs";
 import {
@@ -146,6 +148,32 @@ test("approved plan requires every authority security and evidence gate", () => 
     );
     assert.equal(plan.publicationEligible, false);
     assert.equal(plan.promotionEligible, false);
+    const support = buildReleaseSupportMatrix(plan, passiveHarnesses);
+    assert.equal(support.hosts.length, passiveHarnesses.length);
+    assert(
+        support.hosts.every(
+            (host) =>
+                host.generated === true &&
+                host.staticallyValidated === true &&
+                host.hostTested === false &&
+                host.support === "generated-not-yet-supported-by-this-release",
+        ),
+    );
+    assert.equal(
+        support.hosts.find((host) => host.harness === "pi").releaseCanary,
+        "required-before-publication",
+    );
+    const instructions = buildReleaseInstructions(plan, passiveHarnesses);
+    assert.match(
+        instructions,
+        /pi install -l npm:@cratis\/ai-fundamentals@1\.0\.0-preview\.1\+build\.7/,
+    );
+    assert.match(instructions, /sha256sum -c SHA256SUMS/);
+    assert.match(instructions, /support-matrix\.json/);
+    assert.match(
+        instructions,
+        /cratis-ai-public-fundamentals-1\.0\.0-preview\.1\+build\.7-agent-plugin\.tar\.gz/,
+    );
 
     const source = inputs.sources.find(
         (candidate) => candidate.id === "add-concept",
@@ -366,6 +394,11 @@ test("passive adapter materializer emits one install root per harness", () => {
         assert.equal(piPackage.name, "@cratis/ai-example");
         assert.equal(piPackage.version, "1.2.3-preview.1");
         assert.equal(piPackage.private, false);
+        assert.deepEqual(piPackage.repository, {
+            type: "git",
+            url: "https://github.com/Cratis/AI",
+        });
+        assert.equal(piPackage.homepage, "https://cratis.io/ai");
         assert.deepEqual(piPackage.pi, { skills: ["./skills"] });
         assert.equal(piPackage.scripts, undefined);
         assert.equal(piPackage.dependencies, undefined);

--- a/tooling/specs/distribution-rollout.spec.mjs
+++ b/tooling/specs/distribution-rollout.spec.mjs
@@ -45,8 +45,14 @@ test("rollout policy keeps production promotion and retirement blocked", () => {
     assert.equal(policy.canary.productionTargetsEnabled, false);
     assert.equal(policy.releaseOnMergeAutomation.mergeToMainIsApproval, true);
     assert.equal(policy.releaseOnMergeAutomation.canaryBeforePublication, true);
+    assert.equal(policy.releaseOnMergeAutomation.maxProfilesPerRelease, 1);
     assert.equal(policy.releaseOnMergeAutomation.automaticPromotion, true);
-    assert.equal(policy.releaseOnMergeAutomation.automaticRollback, true);
+    assert.equal(
+        policy.releaseOnMergeAutomation.failureCleanupBeforePublication,
+        true,
+    );
+    assert.equal(policy.releaseOnMergeAutomation.automaticRollback, false);
+    assert.equal(policy.releaseOnMergeAutomation.subscriberUpdates, false);
     assert.equal(policy.promotion.stableEnabled, false);
     assert.equal(policy.promotion.publicationEnabled, false);
     assert.equal(policy.legacyRetirement.enabled, false);

--- a/tooling/specs/generated-distribution-repository.spec.mjs
+++ b/tooling/specs/generated-distribution-repository.spec.mjs
@@ -87,8 +87,12 @@ test("generated repository contract keeps remote authority and production blocke
     );
     assert.equal(contract.releaseOnMerge.mergeToMainIsReleaseApproval, true);
     assert.equal(contract.releaseOnMerge.canaryRequiredBeforePublication, true);
+    assert.equal(contract.releaseOnMerge.maxProfilesPerRelease, 1);
     assert.equal(contract.releaseOnMerge.automaticPromotion, true);
-    assert.equal(contract.releaseOnMerge.automaticRollback, true);
+    assert.equal(contract.releaseOnMerge.failureCleanupBeforePublication, true);
+    assert.equal(contract.releaseOnMerge.automaticRollback, false);
+    assert.equal(contract.releaseOnMerge.subscriberUpdatePullRequests, false);
+    assert.equal(contract.releaseOnMerge.marketplaces, "manual-handoff");
     assert.equal(
         contract.productionMaterialization.artifactTopology,
         "one-profile-one-harness-root-asset",

--- a/tooling/specs/release-request.spec.mjs
+++ b/tooling/specs/release-request.spec.mjs
@@ -22,6 +22,9 @@ function approvedInputs() {
         authoringContracts: readJson("catalog/v2/authoring-contracts.json")
             .contracts,
         artifacts: readJson("catalog/v2/artifacts.json").artifacts,
+        releaseAutomationCapabilities: readJson(
+            "distribution/release-automation-capabilities.json",
+        ),
     });
     const profile = inputs.profileCatalog.publicProfiles.find(
         (candidate) => candidate.id === "public-fundamentals",
@@ -63,6 +66,23 @@ function approvedInputs() {
     return inputs;
 }
 
+test("release request example matches implemented automation exactly", () => {
+    const request = readJson(
+        "Documentation/examples/ai-release/v0.1.0-preview.1.json",
+    );
+    const capabilities = readJson(
+        "distribution/release-automation-capabilities.json",
+    );
+    assert.equal(capabilities.releaseTrigger, "merged-validated-request-on-main");
+    assert.equal(capabilities.maxProfilesPerRelease, 1);
+    assert.deepEqual(request.automation, capabilities.automation);
+    assert.equal(capabilities.automation.failureCleanup, true);
+    assert.equal(capabilities.automation.autoRollback, false);
+    assert.equal(capabilities.automation.subscriberUpdates, false);
+    assert.equal(capabilities.automation.marketplaces, "manual-handoff");
+    assert.match(capabilities.recovery.afterNpmPublication, /never claim/);
+});
+
 test("repository has no release request before owner approval", () => {
     const result = validateReleaseRequests();
     assert.deepEqual(result.errors, []);
@@ -86,11 +106,38 @@ test("approved release request resolves every requested profile", () => {
     assert.equal(result.plans[0].profileId, "public-fundamentals");
 });
 
+test("release request limits publication to one profile until atomic npm publication exists", () => {
+    const request = readJson(
+        "Documentation/examples/ai-release/v0.1.0-preview.1.json",
+    );
+    request.profiles.push("public-arc");
+    request.canaries.push({
+        profileId: "public-arc",
+        canaryId: "samples-chronicle-backend",
+    });
+    const schema = readJson("distribution/release-request.schema.json");
+    const result = validateReleaseRequest(
+        request,
+        "distribution/releases/v0.1.0-preview.1.json",
+        approvedInputs(),
+        schema,
+    );
+    assert(
+        result.errors.some((error) =>
+            error.includes("implemented profile publication limit"),
+        ),
+    );
+});
+
 test("release request rejects partial automation and canary drift", () => {
     const request = readJson(
         "Documentation/examples/ai-release/v0.1.0-preview.1.json",
     );
-    request.automation.npmPublish = false;
+    request.automation.failureCleanup = false;
+    request.automation.autoRollback = true;
+    request.automation.subscriberUpdates = true;
+    request.automation.marketplaces =
+        "automatic-where-supported-submit-otherwise";
     request.canaries = [];
     const schema = readJson("distribution/release-request.schema.json");
     const result = validateReleaseRequest(
@@ -99,9 +146,18 @@ test("release request rejects partial automation and canary drift", () => {
         approvedInputs(),
         schema,
     );
-    assert(
-        result.errors.some((error) => error.includes("expected constant true")),
-    );
+    for (const capability of [
+        "failureCleanup",
+        "autoRollback",
+        "subscriberUpdates",
+        "marketplaces",
+    ])
+        assert(
+            result.errors.some((error) =>
+                error.includes(`automation ${capability} must match`),
+            ),
+            capability,
+        );
     assert(
         result.errors.some((error) =>
             error.includes("every profile needs exactly one named canary"),

--- a/tooling/specs/workflow-safety.spec.mjs
+++ b/tooling/specs/workflow-safety.spec.mjs
@@ -33,7 +33,7 @@ test("verification workflow covers every release-relevant source", () => {
     }
 });
 
-test("merged release request automatically generates canaries publishes and distributes", () => {
+test("merged release request publishes one profile with truthful cleanup and recovery", () => {
     const workflow = readFileSync(
         ".github/workflows/release-approved-ai-profiles.yml",
         "utf8",
@@ -44,25 +44,44 @@ test("merged release request automatically generates canaries publishes and dist
         "distribution/releases/*.json",
         "release-request-validation.mjs",
         "generate-approved-profile-release.mjs",
+        'if [ "$EVENT_NAME" = "push" ]; then mode=(release); fi',
+        "release-instructions.md",
+        "support-matrix.json",
+        "sha256sum -c SHA256SUMS",
         "needs: [discover, verify]",
         "needs: [discover, verify, canary]",
         "needs: [discover, verify, canary, distribute]",
         "needs: [discover, distribute, publish-npm]",
         "samples-chronicle-backend",
+        "trap cleanup EXIT",
+        'gh release delete "v$VERSION"',
+        "cleanup-failed-publication:",
+        "record-promotion-failure:",
         "gh release create",
+        "--notes-file",
         "--draft",
         'gh release edit "v$VERSION"',
         "--draft=false",
+        "npm_version=$(npm --version)",
+        "--package=@earendil-works/pi-coding-agent@0.84.2",
+        'test "${#artifacts[@]}" -eq 1',
         "npm publish",
         "--provenance",
         "id-token: write",
-        'gh pr merge "$pr_url" --repo Cratis/AI.Distribution --auto --squash',
-        "Workflows#73",
-        "AI#147",
+        'gh pr merge "$PR_NUMBER"',
+        "--repo Cratis/AI.Distribution --auto --merge",
+        'test "$state" = "MERGED"',
+        "Subscriber updates remain disabled until Workflows#73",
+        "npm version is immutable and was not rolled back",
     ])
         assert(workflow.includes(required), required);
     for (const forbidden of [
+        "workflow_dispatch:",
+        "INPUT_REQUEST",
         "NPM_TOKEN",
+        "npm install --global",
+        "! -name SHA256SUMS",
+        "--auto --squash",
         "push --force",
         "push -f",
         "direct push to main",


### PR DESCRIPTION
# Summary

Makes the first automatic Cratis AI release match what the workflow can safely guarantee. It removes unsupported automation claims, publishes practical verification/support information, and keeps incomplete distribution state from reaching users.

## Added

- Adds a machine-readable contract for currently implemented release automation and recovery behavior (#187)
- Adds exact lifecycle instructions and generated/static/host-tested support information to every profile release (#187)
- Adds cleanup for failed draft distribution and records immutable partial publication failures (#187)

## Changed

- Restricts normal production release to a validated request merged to `main`; manual workflow dispatch can no longer bypass that approval (#187)
- Limits releases to one npm profile until atomic multi-package publication exists (#187)
- Includes `SHA256SUMS`, instructions, and support data in GitHub release assets and verifies checksums in the canary (#187)
- Defers distribution index merge and public GitHub release promotion until npm succeeds (#187)
- Describes npm publication truthfully: unpublished draft state is cleaned up, but an immutable npm version is never called rolled back (#187)
- Keeps subscriber and marketplace automation disabled until Workflows#73 and AI#147 complete their own implementation and canary gates (#187)
