### PR TITLE
Consolidate compatible host packages

### DIFF
--- a/Documentation/adopting-cratis-ai.md
+++ b/Documentation/adopting-cratis-ai.md
@@ -118,8 +118,8 @@ identity and skill layout. Do not point a host at the mixed `Cratis/AI` source
 repository or the multi-profile distribution root.
 
 The release page supplies exact Agent Plugin, Claude, Codex, Copilot, Cursor,
-Gemini, Grok, DeepSeek Harness, Kiro, Junie, and Agent Skills commands after
-each host is actually tested.
+Gemini, Grok, Deep Code, preview DeepSeek Harness, Kiro, Junie, and Agent Skills
+commands after each host is actually tested.
 
 ## 6. Verify adoption
 

--- a/Documentation/ai-distribution-and-subscriptions.md
+++ b/Documentation/ai-distribution-and-subscriptions.md
@@ -260,10 +260,11 @@ The same approved skill bytes are wrapped idiomatically for each host:
 | GitHub Copilot / VS Code | Copilot marketplace around the portable Agent Plugin |
 | Cursor | Cursor marketplace around the portable Agent Plugin |
 | Gemini CLI | Gemini extension |
-| Grok Build | `.grok/skills/<name>/SKILL.md` and Claude compatibility |
-| DeepSeek Harness | `.dsh/skills/<name>/SKILL.md` while upstream remains preview |
+| Grok Build | Claude-compatible Cratis marketplace and plugin |
+| Deep Code | `.deepcode/skills/<name>/SKILL.md` from the current official contract |
+| DeepSeek Harness | `.dsh/skills/<name>/SKILL.md` as a separately labeled preview contract |
 | Kiro | The same portable Agent Plugin installed as a Power |
-| Junie | Junie extension |
+| Junie | The same Claude-compatible Cratis marketplace and plugin |
 | Pi | Versioned npm/Git Pi package |
 
 Release documentation distinguishes **generated**, **statically validated**, and
@@ -291,10 +292,13 @@ copilot plugin install engineering-chronicle@cratis
 # Gemini CLI local verification before remote publication
 gemini extensions link <extracted-gemini-root>
 
-# Grok Build project skills
-cp -R <extracted-grok-root>/.grok/skills .grok/
+# Grok Build uses the extracted Claude-compatible marketplace
+# through Grok's Marketplace UI
 
-# DeepSeek Harness project skills
+# Deep Code project skills
+cp -R <extracted-deepcode-root>/.deepcode/skills .deepcode/
+
+# Preview DeepSeek Harness project skills
 cp -R <extracted-deepseek-root>/.dsh/skills .dsh/
 ```
 

--- a/README.md
+++ b/README.md
@@ -112,9 +112,10 @@ packages exist. See the [Pi package workflow](Documentation/ai-distribution-and-
 
 The generator now emits a portable Agent Plugins 1.0 package for compatible
 hosts alongside Agent Skills and native adapters for Claude Code, Codex, GitHub
-Copilot, Cursor, Gemini CLI, Grok Build, DeepSeek Harness, Kiro, Junie, and
-Pi/npm. Copilot, Cursor, Kiro, and VS Code share the same portable plugin
-identity and skill layout rather than separate skill instructions.
+Copilot, Cursor, Gemini CLI, Grok Build, Deep Code, preview DeepSeek Harness,
+Kiro, Junie, and Pi/npm. Copilot, Cursor, Kiro, and VS Code share the same
+portable plugin identity. Claude, Grok, and Junie share one Claude-compatible
+marketplace package rather than separate skill instructions.
 
 Documentation and release records distinguish:
 

--- a/catalog/ecosystem-versions.json
+++ b/catalog/ecosystem-versions.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "verifiedOn": "2026-08-22",
+  "verifiedOn": "2026-08-24",
   "policy": "official-sources-only",
   "ecosystems": [
     {
@@ -347,6 +347,19 @@
       "sources": [
         { "url": "https://zed.dev/docs/ai/skills", "kind": "official-documentation", "verifiedOn": "2026-08-20" },
         { "url": "https://cli.github.com/manual/gh_skill_install", "kind": "official-documentation", "verifiedOn": "2026-08-20" }
+      ]
+    },
+    {
+      "id": "deepseek-deepcode-skills",
+      "status": "current",
+      "version": "current-documentation-2026-08-24",
+      "facts": [
+        "Deep Code discovers user skills from ~/.agents/skills/<name>/SKILL.md and project skills from .deepcode/skills/<name>/SKILL.md.",
+        "Skills are selected through the slash-command picker or direct skill-name invocation.",
+        "The Deep Code contract is distinct from the developer-preview DeepSeek Harness .dsh contract."
+      ],
+      "sources": [
+        { "url": "https://api-docs.deepseek.com/quick_start/agent_integrations/deepcode", "kind": "official-documentation", "verifiedOn": "2026-08-24" }
       ]
     },
     {

--- a/catalog/generated/human-catalog/catalog.json
+++ b/catalog/generated/human-catalog/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractVersion": 1,
   "disclaimer": "Catalog inclusion, evaluation evidence, bundle generation, or publication does not grant runtime permission or approval.",
-  "inputDigest": "f645a4572bd5b50775a1fef0a23abf4f353429efcd46a3e88ee4e13e8fe5f996",
+  "inputDigest": "8d29dcca0cce41fc42d1ee73a34ff7e2687416f4887cae49cb9122245bad514a",
   "profiles": [
     {
       "id": "public-application",

--- a/catalog/generated/human-catalog/manifest.json
+++ b/catalog/generated/human-catalog/manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "contractVersion": 1,
-  "inputDigest": "f645a4572bd5b50775a1fef0a23abf4f353429efcd46a3e88ee4e13e8fe5f996",
+  "inputDigest": "8d29dcca0cce41fc42d1ee73a34ff7e2687416f4887cae49cb9122245bad514a",
   "files": [
     {
       "path": "CATALOG.md",
@@ -11,7 +11,7 @@
     {
       "path": "catalog.json",
       "size": 129922,
-      "sha256": "af4eb28fef9db5aaaef36e95fcd615a96d1c693e41eb4cb136766bbf96357c98"
+      "sha256": "6deef2ed34cd09ecfcc294aa5ffd52bed65ec832e8b546270970ff5d1420bced"
     }
   ]
 }

--- a/catalog/v2/evidence.json
+++ b/catalog/v2/evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "asOf": "2026-08-23",
+  "asOf": "2026-08-24",
   "generatedBy": "tooling/generate-catalog-v2.mjs",
   "evidence": [
     {
@@ -623,6 +623,15 @@
       "verifiedOn": "2026-08-20",
       "expiresOn": "2026-11-18",
       "applicableVersion": "current-documentation-2026-08-20",
+      "confidence": "high"
+    },
+    {
+      "id": "deepseek-deepcode-skills-source-1",
+      "officialUrl": "https://api-docs.deepseek.com/quick_start/agent_integrations/deepcode",
+      "sourceKind": "official-documentation",
+      "verifiedOn": "2026-08-24",
+      "expiresOn": "2026-11-18",
+      "applicableVersion": "current-documentation-2026-08-24",
       "confidence": "high"
     },
     {
@@ -1601,6 +1610,30 @@
       "evidenceIds": [
         "zed-skills-source-1",
         "zed-skills-source-2"
+      ]
+    },
+    {
+      "id": "deepseek-deepcode-skills-fact-1",
+      "ecosystemId": "deepseek-deepcode-skills",
+      "fact": "Deep Code discovers user skills from ~/.agents/skills/<name>/SKILL.md and project skills from .deepcode/skills/<name>/SKILL.md.",
+      "evidenceIds": [
+        "deepseek-deepcode-skills-source-1"
+      ]
+    },
+    {
+      "id": "deepseek-deepcode-skills-fact-2",
+      "ecosystemId": "deepseek-deepcode-skills",
+      "fact": "Skills are selected through the slash-command picker or direct skill-name invocation.",
+      "evidenceIds": [
+        "deepseek-deepcode-skills-source-1"
+      ]
+    },
+    {
+      "id": "deepseek-deepcode-skills-fact-3",
+      "ecosystemId": "deepseek-deepcode-skills",
+      "fact": "The Deep Code contract is distinct from the developer-preview DeepSeek Harness .dsh contract.",
+      "evidenceIds": [
+        "deepseek-deepcode-skills-source-1"
       ]
     },
     {

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "39c0e1b82b43c60521a95a7237b989132b0f33fe6e6456cbc44de46f9cf84bf8",
+  "indexDigest": "f44dfcbc6fd2c24ecfebaafa66128e959cc482b5847a61904b1c215b6e294b99",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/distribution/artifact-matrix.json
+++ b/distribution/artifact-matrix.json
@@ -94,11 +94,23 @@
       "requirementId": "grok-build-skills",
       "state": "FIXTURE_GENERATION_ENABLED",
       "outputRoot": "grok",
-      "packageKind": "NATIVE_GROK_AGENT_SKILLS",
+      "packageKind": "CLAUDE_COMPATIBLE_SKILLS_MARKETPLACE",
+      "smokeGates": [
+        "marketplace-manifest-parse",
+        "canonical-byte-parity",
+        "grok-marketplace-smoke-when-available"
+      ]
+    },
+    {
+      "id": "deepseek-deepcode",
+      "requirementId": "deepseek-deepcode-skills",
+      "state": "FIXTURE_GENERATION_ENABLED",
+      "outputRoot": "deepcode",
+      "packageKind": "NATIVE_DEEPCODE_AGENT_SKILLS",
       "smokeGates": [
         "exact-skill-inventory",
         "canonical-byte-parity",
-        "grok-inspect-when-available"
+        "direct-install-remove"
       ]
     },
     {
@@ -165,9 +177,9 @@
       "requirementId": "junie-marketplace",
       "state": "FIXTURE_GENERATION_ENABLED",
       "outputRoot": "junie",
-      "packageKind": "SKILLS_ONLY_JUNIE_EXTENSION",
+      "packageKind": "CLAUDE_COMPATIBLE_SKILLS_MARKETPLACE",
       "smokeGates": [
-        "extension-manifest-parse",
+        "marketplace-manifest-parse",
         "canonical-byte-parity",
         "junie-host-smoke-pending"
       ]

--- a/distribution/marketplace-requirements.json
+++ b/distribution/marketplace-requirements.json
@@ -193,23 +193,48 @@
         "https://docs.x.ai/build/features/skills-plugins-marketplaces"
       ],
       "requiredRoots": [
-        ".grok/skills/<skill-name>/SKILL.md"
+        ".claude-plugin/marketplace.json",
+        "plugins/cratis/.claude-plugin/plugin.json",
+        "plugins/cratis/skills/<skill-name>/SKILL.md"
       ],
       "installCommands": [
-        "Copy reviewed skills to .grok/skills or ~/.grok/skills",
-        "Use the generated Claude marketplace through Grok's Claude Code compatibility"
+        "Add the generated Claude-compatible marketplace through Grok's Marketplace UI"
+      ],
+      "updateCommands": [
+        "Refresh the configured marketplace and update the Cratis plugin"
+      ],
+      "uninstallCommands": [
+        "Remove the Cratis plugin through Grok's extensions UI"
+      ],
+      "constraints": [
+        "Grok Build is xAI's coding agent and discovers project .grok/skills, user ~/.grok/skills, configured skill paths, and enabled plugin skills.",
+        "Grok skills are folders containing SKILL.md with YAML frontmatter and may include references and assets.",
+        "Grok supports Claude Code marketplaces, plugins, and skills without extra configuration, so Cratis reuses that package instead of maintaining a divergent Grok copy.",
+        "Generated passive Cratis output contains skills only and does not add hooks, MCP servers, agents, or executable scripts."
+      ]
+    },
+    {
+      "id": "deepseek-deepcode-skills",
+      "status": "VERIFIED",
+      "sourceUrls": [
+        "https://api-docs.deepseek.com/quick_start/agent_integrations/deepcode"
+      ],
+      "requiredRoots": [
+        ".deepcode/skills/<skill-name>/SKILL.md"
+      ],
+      "installCommands": [
+        "Copy reviewed skills to <project>/.deepcode/skills or install them under ~/.agents/skills"
       ],
       "updateCommands": [
         "Replace the installed skill with bytes from a newer immutable Cratis release"
       ],
       "uninstallCommands": [
-        "Remove the installed skill folder from .grok/skills or ~/.grok/skills"
+        "Remove the installed skill folder from the selected Deep Code skills root"
       ],
       "constraints": [
-        "Grok Build is xAI's coding agent and discovers project .grok/skills, user ~/.grok/skills, configured skill paths, and enabled plugin skills.",
-        "Grok skills are folders containing SKILL.md with YAML frontmatter and may include references and assets.",
-        "Grok also supports Claude Code marketplaces, plugins, and skills without extra configuration.",
-        "Generated passive Cratis output contains skills only and does not add hooks, MCP servers, agents, or executable scripts."
+        "Deep Code officially discovers project .deepcode/skills and user ~/.agents/skills.",
+        "This direct Agent Skills package is separate from the preview DeepSeek Harness .dsh contract.",
+        "Generated Cratis output contains passive skills only."
       ]
     },
     {
@@ -337,23 +362,27 @@
       "id": "junie-marketplace",
       "status": "VERIFIED",
       "sourceUrls": [
-        "https://junie.jetbrains.com/docs/agent-skills.html",
-        "https://github.com/JetBrains/junie-extensions"
+        "https://junie.jetbrains.com/docs/junie-cli-extensions.html",
+        "https://junie.jetbrains.com/docs/agent-skills.html"
       ],
       "requiredRoots": [
-        "extensions/cratis/extension.json",
-        "extensions/cratis/skills/<skill-name>/SKILL.md"
+        ".claude-plugin/marketplace.json",
+        "plugins/cratis/.claude-plugin/plugin.json",
+        "plugins/cratis/skills/<skill-name>/SKILL.md"
       ],
       "installCommands": [
-        "Copy a reviewed skill folder to .junie/skills or ~/.junie/skills"
+        "/extensions marketplace add <generated-marketplace>",
+        "/extensions install cratis"
       ],
-      "updateCommands": [],
+      "updateCommands": [
+        "Use Update for the installed Cratis extension"
+      ],
       "uninstallCommands": [
-        "Remove the copied skill folder from its Junie skill location"
+        "Remove the Cratis extension from Junie's Installed extensions view"
       ],
       "constraints": [
-        "Junie extensions use extension.json with name and description and may contain skills/<skill-name>/SKILL.md.",
-        "Junie also discovers trusted project and user .agents/skills locations.",
+        "Junie accepts the Claude .claude-plugin/marketplace.json format, so Cratis reuses that package instead of maintaining a divergent extension.json contract.",
+        "Junie also discovers trusted project and user Agent Skills locations.",
         "Users must review and trust extension contents; passive Cratis output omits scripts, agents, guidelines, and MCP servers."
       ]
     }

--- a/distribution/profile-subscription.schema.json
+++ b/distribution/profile-subscription.schema.json
@@ -73,6 +73,7 @@
           "codex",
           "copilot",
           "cursor",
+          "deepcode",
           "deepseek-harness",
           "gemini",
           "grok",

--- a/tooling/catalog-validation.mjs
+++ b/tooling/catalog-validation.mjs
@@ -594,6 +594,7 @@ function validateEcosystems(registry) {
         "junie-extensions",
         "opencode-skills",
         "zed-skills",
+        "deepseek-deepcode-skills",
         "deepseek-harness-skills",
         "npm-cratis-scope",
         "npm-trusted-publishing",

--- a/tooling/generate-catalog-v2.mjs
+++ b/tooling/generate-catalog-v2.mjs
@@ -1789,7 +1789,7 @@ for (const ecosystem of v1Ecosystems.ecosystems) {
 }
 writeJson("evidence.json", {
     schemaVersion: 2,
-    asOf: "2026-08-23",
+    asOf: "2026-08-24",
     generatedBy: "tooling/generate-catalog-v2.mjs",
     evidence,
     ecosystemFacts,

--- a/tooling/generate-distribution-fixture.mjs
+++ b/tooling/generate-distribution-fixture.mjs
@@ -17,7 +17,11 @@ import {
 } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { createAgentPluginManifest } from "./passive-profile-adapters.mjs";
+import {
+    createAgentPluginManifest,
+    createClaudeMarketplace,
+    createClaudePluginManifest,
+} from "./passive-profile-adapters.mjs";
 import { materializeFixtureArtifact } from "./public-artifact-materializer.mjs";
 
 const defaultRepositoryRoot = resolve(
@@ -34,6 +38,7 @@ const generatedTargets = [
     "codex",
     "copilot",
     "cursor",
+    "deepcode",
     "deepseek",
     "gemini",
     "grok",
@@ -264,31 +269,21 @@ export function generateDistributionFixture({
 
         const claudeRoot = join(root, "claude");
         copyCanonicalSkill(canonicalRoot, join(claudeRoot, "plugins/cratis"));
-        writeJson(join(claudeRoot, ".claude-plugin/marketplace.json"), {
-            name: "cratis",
-            owner: { name: "Cratis" },
-            metadata: {
-                description: "Cratis skills-only fixture marketplace",
-                version,
-            },
-            plugins: [
-                {
-                    name: "cratis",
-                    description: "Passive Cratis skills fixture.",
-                    version,
-                    source: "./plugins/cratis",
-                    strict: true,
-                },
-            ],
-        });
         writeJson(
-            join(claudeRoot, "plugins/cratis/.claude-plugin/plugin.json"),
-            {
+            join(claudeRoot, ".claude-plugin/marketplace.json"),
+            createClaudeMarketplace({
                 name: "cratis",
                 version,
-                description: "Passive Cratis skills fixture.",
-                author: { name: "Cratis" },
-            },
+                description: portableDescription,
+            }),
+        );
+        writeJson(
+            join(claudeRoot, "plugins/cratis/.claude-plugin/plugin.json"),
+            createClaudePluginManifest({
+                name: "cratis",
+                version,
+                description: portableDescription,
+            }),
         );
 
         const codexRoot = join(root, "codex");
@@ -370,6 +365,9 @@ export function generateDistributionFixture({
             }),
         );
 
+        const deepCodeRoot = join(root, "deepcode/.deepcode");
+        copyCanonicalSkill(canonicalRoot, deepCodeRoot);
+
         const deepSeekRoot = join(root, "deepseek/.dsh");
         copyCanonicalSkill(canonicalRoot, deepSeekRoot);
 
@@ -381,8 +379,32 @@ export function generateDistributionFixture({
             description: "Passive Cratis skills fixture.",
         });
 
-        const grokRoot = join(root, "grok/.grok");
-        copyCanonicalSkill(canonicalRoot, grokRoot);
+        for (const harness of ["grok", "junie"]) {
+            const compatibleRoot = join(root, harness);
+            copyCanonicalSkill(
+                canonicalRoot,
+                join(compatibleRoot, "plugins/cratis"),
+            );
+            writeJson(
+                join(compatibleRoot, ".claude-plugin/marketplace.json"),
+                createClaudeMarketplace({
+                    name: "cratis",
+                    version,
+                    description: portableDescription,
+                }),
+            );
+            writeJson(
+                join(
+                    compatibleRoot,
+                    "plugins/cratis/.claude-plugin/plugin.json",
+                ),
+                createClaudePluginManifest({
+                    name: "cratis",
+                    version,
+                    description: portableDescription,
+                }),
+            );
+        }
 
         const kiroRoot = join(root, "kiro");
         copyCanonicalSkill(canonicalRoot, kiroRoot);
@@ -394,13 +416,6 @@ export function generateDistributionFixture({
                 description: portableDescription,
             }),
         );
-
-        const junieRoot = join(root, "junie/extensions/cratis");
-        copyCanonicalSkill(canonicalRoot, junieRoot);
-        writeJson(join(junieRoot, "extension.json"), {
-            name: "cratis",
-            description: "Passive Cratis skills fixture.",
-        });
 
         const piPackageRoot = join(root, "pi/package");
         copyCanonicalSkill(canonicalRoot, piPackageRoot);
@@ -424,6 +439,7 @@ export function generateDistributionFixture({
                     supportedHarnessOutputs: [
                         "claude",
                         "copilot",
+                        "deepcode",
                         "deepseek",
                         "pi",
                     ],
@@ -509,10 +525,11 @@ export function validateDistributionFixture(outputRoot) {
         "codex/plugins/cratis",
         "copilot/plugins/cratis",
         "cursor/plugins/cratis",
+        "deepcode/.deepcode",
         "deepseek/.dsh",
         "gemini",
-        "grok/.grok",
-        "junie/extensions/cratis",
+        "grok/plugins/cratis",
+        "junie/plugins/cratis",
         "kiro",
         "pi/package",
     ];
@@ -538,6 +555,7 @@ export function validateDistributionFixture(outputRoot) {
                 supportedHarnessOutputs: [
                     "claude",
                     "copilot",
+                    "deepcode",
                     "deepseek",
                     "pi",
                 ],
@@ -655,12 +673,45 @@ function smokeDirectSkillFixture(
     return { installed: true, removed: true };
 }
 
+function smokeClaudeCompatiblePluginFixture(
+    outputRoot,
+    temporaryRoot,
+    sourceRoot,
+    installedRoot,
+) {
+    const source = join(outputRoot, sourceRoot, "plugins/cratis");
+    const installed = join(temporaryRoot, installedRoot, "cratis");
+    mkdirSync(dirname(installed), { recursive: true });
+    cpSync(source, installed, { recursive: true, errorOnExist: true });
+    const sourceSkill = readFileSync(
+        join(source, "skills/cratis-fundamentals-concept/SKILL.md"),
+    );
+    const installedSkill = readFileSync(
+        join(installed, "skills/cratis-fundamentals-concept/SKILL.md"),
+    );
+    if (!sourceSkill.equals(installedSkill))
+        throw new Error("Claude-compatible plugin install changed canonical bytes");
+    rmSync(installed, { recursive: true, force: false });
+    if (existsSync(installed))
+        throw new Error("Claude-compatible plugin uninstall left content");
+    return { installed: true, removed: true };
+}
+
 export function smokeGrokDistributionFixture(outputRoot, temporaryRoot) {
+    return smokeClaudeCompatiblePluginFixture(
+        outputRoot,
+        temporaryRoot,
+        "grok",
+        ".grok/plugins",
+    );
+}
+
+export function smokeDeepCodeDistributionFixture(outputRoot, temporaryRoot) {
     return smokeDirectSkillFixture(
         outputRoot,
         temporaryRoot,
-        "grok/.grok",
-        ".grok/skills",
+        "deepcode/.deepcode",
+        ".deepcode/skills",
     );
 }
 

--- a/tooling/generate-engineering-distribution-fixture.mjs
+++ b/tooling/generate-engineering-distribution-fixture.mjs
@@ -17,7 +17,11 @@ import {
 } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { createAgentPluginManifest } from "./passive-profile-adapters.mjs";
+import {
+    createAgentPluginManifest,
+    createClaudeMarketplace,
+    createClaudePluginManifest,
+} from "./passive-profile-adapters.mjs";
 import { materializeFixtureArtifact } from "./public-artifact-materializer.mjs";
 
 const defaultRepositoryRoot = resolve(
@@ -38,6 +42,7 @@ const generatedTargets = [
     "codex",
     "copilot",
     "cursor",
+    "deepcode",
     "deepseek",
     "gemini",
     "grok",
@@ -251,37 +256,24 @@ export function generateEngineeringDistributionFixture({
 
         const claudeRoot = join(root, "claude");
         copyCanonical(canonicalRoot, join(claudeRoot, `plugins/${pluginName}`));
-        writeJson(join(claudeRoot, ".claude-plugin/marketplace.json"), {
-            name: pluginName,
-            owner: { name: "Cratis" },
-            metadata: {
-                description:
-                    "Fixture-only Cratis engineering skills marketplace",
+        writeJson(
+            join(claudeRoot, ".claude-plugin/marketplace.json"),
+            createClaudeMarketplace({
+                name: pluginName,
                 version,
-            },
-            plugins: [
-                {
-                    name: pluginName,
-                    description:
-                        "Fixture-only passive Cratis engineering documentation skill.",
-                    version,
-                    source: `./plugins/${pluginName}`,
-                    strict: true,
-                },
-            ],
-        });
+                description: portableDescription,
+            }),
+        );
         writeJson(
             join(
                 claudeRoot,
                 `plugins/${pluginName}/.claude-plugin/plugin.json`,
             ),
-            {
+            createClaudePluginManifest({
                 name: pluginName,
                 version,
-                description:
-                    "Fixture-only passive Cratis engineering documentation skill.",
-                author: { name: "Cratis" },
-            },
+                description: portableDescription,
+            }),
         );
 
         const codexRoot = join(root, "codex");
@@ -377,6 +369,9 @@ export function generateEngineeringDistributionFixture({
             }),
         );
 
+        const deepCodeRoot = join(root, "deepcode/.deepcode");
+        copyCanonical(canonicalRoot, deepCodeRoot);
+
         const deepSeekRoot = join(root, "deepseek/.dsh");
         copyCanonical(canonicalRoot, deepSeekRoot);
 
@@ -389,8 +384,32 @@ export function generateEngineeringDistributionFixture({
                 "Fixture-only passive Cratis engineering documentation skill.",
         });
 
-        const grokRoot = join(root, "grok/.grok");
-        copyCanonical(canonicalRoot, grokRoot);
+        for (const harness of ["grok", "junie"]) {
+            const compatibleRoot = join(root, harness);
+            copyCanonical(
+                canonicalRoot,
+                join(compatibleRoot, `plugins/${pluginName}`),
+            );
+            writeJson(
+                join(compatibleRoot, ".claude-plugin/marketplace.json"),
+                createClaudeMarketplace({
+                    name: pluginName,
+                    version,
+                    description: portableDescription,
+                }),
+            );
+            writeJson(
+                join(
+                    compatibleRoot,
+                    `plugins/${pluginName}/.claude-plugin/plugin.json`,
+                ),
+                createClaudePluginManifest({
+                    name: pluginName,
+                    version,
+                    description: portableDescription,
+                }),
+            );
+        }
 
         const kiroRoot = join(root, "kiro");
         copyCanonical(canonicalRoot, kiroRoot);
@@ -402,14 +421,6 @@ export function generateEngineeringDistributionFixture({
                 description: portableDescription,
             }),
         );
-
-        const junieRoot = join(root, `junie/extensions/${pluginName}`);
-        copyCanonical(canonicalRoot, junieRoot);
-        writeJson(join(junieRoot, "extension.json"), {
-            name: pluginName,
-            description:
-                "Fixture-only passive Cratis engineering documentation skill.",
-        });
 
         const piRoot = join(root, "pi/package");
         copyCanonical(canonicalRoot, piRoot);
@@ -510,10 +521,11 @@ export function validateEngineeringDistributionFixture(outputRoot) {
         `codex/plugins/${pluginName}`,
         `copilot/plugins/${pluginName}`,
         `cursor/plugins/${pluginName}`,
+        "deepcode/.deepcode",
         "deepseek/.dsh",
         "gemini",
-        "grok/.grok",
-        `junie/extensions/${pluginName}`,
+        `grok/plugins/${pluginName}`,
+        `junie/plugins/${pluginName}`,
         "kiro",
         "pi/package",
     ];
@@ -727,12 +739,49 @@ function smokeDirectEngineeringSkill(
     return { installed: true, removed: true };
 }
 
+function smokeClaudeCompatibleEngineeringPlugin(
+    outputRoot,
+    temporaryRoot,
+    sourceRoot,
+    installedRoot,
+) {
+    const source = join(outputRoot, sourceRoot, `plugins/${pluginName}`);
+    const installed = join(temporaryRoot, installedRoot, pluginName);
+    mkdirSync(dirname(installed), { recursive: true });
+    cpSync(source, installed, { recursive: true, errorOnExist: true });
+    const sourceSkill = readFileSync(
+        join(source, `skills/${skillName}/SKILL.md`),
+    );
+    const installedSkill = readFileSync(
+        join(installed, `skills/${skillName}/SKILL.md`),
+    );
+    if (!sourceSkill.equals(installedSkill))
+        throw new Error(
+            "Claude-compatible engineering plugin install changed bytes",
+        );
+    rmSync(installed, { recursive: true, force: false });
+    if (existsSync(installed))
+        throw new Error(
+            "Claude-compatible engineering plugin uninstall left content",
+        );
+    return { installed: true, removed: true };
+}
+
 export function smokeGrokEngineeringFixture(outputRoot, temporaryRoot) {
+    return smokeClaudeCompatibleEngineeringPlugin(
+        outputRoot,
+        temporaryRoot,
+        "grok",
+        ".grok/plugins",
+    );
+}
+
+export function smokeDeepCodeEngineeringFixture(outputRoot, temporaryRoot) {
     return smokeDirectEngineeringSkill(
         outputRoot,
         temporaryRoot,
-        "grok/.grok",
-        ".grok/skills",
+        "deepcode/.deepcode",
+        ".deepcode/skills",
     );
 }
 
@@ -799,25 +848,25 @@ export function smokeClaudeEngineeringFixture(
     );
     execFileSync(
         claudeCommand,
-        ["plugin", "install", `${pluginName}@${pluginName}`],
+        ["plugin", "install", `${pluginName}@cratis`],
         { env: environment, stdio: "pipe" },
     );
     const installed = execFileSync(claudeCommand, ["plugin", "list"], {
         env: environment,
         encoding: "utf8",
     });
-    if (!installed.includes(`${pluginName}@${pluginName}`))
+    if (!installed.includes(`${pluginName}@cratis`))
         throw new Error(
             "Claude engineering fixture install was not observable",
         );
     execFileSync(
         claudeCommand,
-        ["plugin", "uninstall", `${pluginName}@${pluginName}`],
+        ["plugin", "uninstall", `${pluginName}@cratis`],
         { env: environment, stdio: "pipe" },
     );
     execFileSync(
         claudeCommand,
-        ["plugin", "marketplace", "remove", pluginName],
+        ["plugin", "marketplace", "remove", "cratis"],
         { env: environment, stdio: "pipe" },
     );
     return { validated: true, installed: true, removed: true };

--- a/tooling/passive-profile-adapters.mjs
+++ b/tooling/passive-profile-adapters.mjs
@@ -22,6 +22,7 @@ export const passiveHarnesses = [
     "codex",
     "copilot",
     "cursor",
+    "deepcode",
     "deepseek",
     "gemini",
     "grok",
@@ -41,6 +42,32 @@ function writeExclusive(path, content) {
 
 function writeJson(path, value) {
     writeExclusive(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function createClaudeMarketplace({ name, version, description }) {
+    return {
+        name: "cratis",
+        owner: { name: "Cratis" },
+        metadata: { description, version },
+        plugins: [
+            {
+                name,
+                description,
+                version,
+                source: `./plugins/${name}`,
+                strict: true,
+            },
+        ],
+    };
+}
+
+export function createClaudePluginManifest({ name, version, description }) {
+    return {
+        name,
+        version,
+        description,
+        author: { name: "Cratis" },
+    };
 }
 
 export function createAgentPluginManifest({ name, version, description }) {
@@ -205,28 +232,13 @@ export function generatePassiveProfileAdapters({
 
     const claudeRoot = harnessRoot("claude");
     copySkills(skills, join(claudeRoot, `plugins/${profileId}`));
-    writeJson(join(claudeRoot, ".claude-plugin/marketplace.json"), {
-        name: "cratis",
-        owner: { name: "Cratis" },
-        metadata: { description, version },
-        plugins: [
-            {
-                name: profileId,
-                description,
-                version,
-                source: `./plugins/${profileId}`,
-                strict: true,
-            },
-        ],
-    });
+    writeJson(
+        join(claudeRoot, ".claude-plugin/marketplace.json"),
+        createClaudeMarketplace({ name: profileId, version, description }),
+    );
     writeJson(
         join(claudeRoot, `plugins/${profileId}/.claude-plugin/plugin.json`),
-        {
-            name: profileId,
-            version,
-            description,
-            author: { name: "Cratis" },
-        },
+        createClaudePluginManifest({ name: profileId, version, description }),
     );
 
     const codexRoot = harnessRoot("codex");
@@ -298,9 +310,9 @@ export function generatePassiveProfileAdapters({
     );
 
     const directRoots = {
+        deepcode: ".deepcode",
         deepseek: ".dsh",
         gemini: ".",
-        grok: ".grok",
         kiro: ".",
     };
     for (const [harness, destination] of Object.entries(directRoots))
@@ -315,12 +327,25 @@ export function generatePassiveProfileAdapters({
         createAgentPluginManifest({ name: profileId, version, description }),
     );
 
-    const junieRoot = join(harnessRoot("junie"), `extensions/${profileId}`);
-    copySkills(skills, junieRoot);
-    writeJson(join(junieRoot, "extension.json"), {
-        name: profileId,
-        description,
-    });
+    for (const harness of ["grok", "junie"]) {
+        const compatibleRoot = harnessRoot(harness);
+        copySkills(skills, join(compatibleRoot, `plugins/${profileId}`));
+        writeJson(
+            join(compatibleRoot, ".claude-plugin/marketplace.json"),
+            createClaudeMarketplace({ name: profileId, version, description }),
+        );
+        writeJson(
+            join(
+                compatibleRoot,
+                `plugins/${profileId}/.claude-plugin/plugin.json`,
+            ),
+            createClaudePluginManifest({
+                name: profileId,
+                version,
+                description,
+            }),
+        );
+    }
 
     const piRoot = harnessRoot("pi");
     copySkills(skills, piRoot);

--- a/tooling/specs/approved-profile-release.spec.mjs
+++ b/tooling/specs/approved-profile-release.spec.mjs
@@ -364,9 +364,49 @@ test("passive adapter materializer emits one install root per harness", () => {
         const kiroPlugin = readJson(
             join(outputRoot, "harnesses/kiro/plugin.json"),
         );
+        const claudePlugin = readJson(
+            join(
+                outputRoot,
+                "harnesses/claude/plugins/public-example/.claude-plugin/plugin.json",
+            ),
+        );
+        const grokMarketplace = readJson(
+            join(
+                outputRoot,
+                "harnesses/grok/.claude-plugin/marketplace.json",
+            ),
+        );
+        const grokPlugin = readJson(
+            join(
+                outputRoot,
+                "harnesses/grok/plugins/public-example/.claude-plugin/plugin.json",
+            ),
+        );
+        const junieMarketplace = readJson(
+            join(
+                outputRoot,
+                "harnesses/junie/.claude-plugin/marketplace.json",
+            ),
+        );
+        const juniePlugin = readJson(
+            join(
+                outputRoot,
+                "harnesses/junie/plugins/public-example/.claude-plugin/plugin.json",
+            ),
+        );
         assert.deepEqual(copilotPlugin, portablePlugin);
         assert.deepEqual(cursorPlugin, portablePlugin);
         assert.deepEqual(kiroPlugin, portablePlugin);
+        assert.equal(
+            grokMarketplace.plugins[0].source,
+            "./plugins/public-example",
+        );
+        assert.equal(
+            junieMarketplace.plugins[0].source,
+            "./plugins/public-example",
+        );
+        assert.deepEqual(grokPlugin, claudePlugin);
+        assert.deepEqual(juniePlugin, claudePlugin);
         assert.equal(
             portablePlugin.$schema,
             "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
@@ -406,7 +446,16 @@ test("passive adapter materializer emits one install root per harness", () => {
             readFileSync(
                 join(
                     outputRoot,
-                    "harnesses/grok/.grok/skills/cratis-example/SKILL.md",
+                    "harnesses/grok/plugins/public-example/skills/cratis-example/SKILL.md",
+                ),
+            ).equals(skillBytes),
+            true,
+        );
+        assert.equal(
+            readFileSync(
+                join(
+                    outputRoot,
+                    "harnesses/deepcode/.deepcode/skills/cratis-example/SKILL.md",
                 ),
             ).equals(skillBytes),
             true,

--- a/tooling/specs/catalog-v2-validation.spec.mjs
+++ b/tooling/specs/catalog-v2-validation.spec.mjs
@@ -753,7 +753,7 @@ test("stale and future-dated evidence fail and every fact remains evidence-bound
         ),
     );
     catalogs.evidence.evidence[0].expiresOn = "2026-08-19";
-    catalogs.evidence.evidence[1].verifiedOn = "2026-08-24";
+    catalogs.evidence.evidence[1].verifiedOn = "2026-08-25";
     const errors = validateEvidenceAndCoverage(catalogs);
     assert(errors.some((error) => error.includes("expired")));
     assert(errors.some((error) => error.includes("verified after")));

--- a/tooling/specs/catalog-validation.spec.mjs
+++ b/tooling/specs/catalog-validation.spec.mjs
@@ -147,5 +147,7 @@ test("ecosystem registry includes current MCP and compatible-client evidence", (
     assert.equal(byId.get("model-context-protocol").version, "2026-07-28");
     assert(byId.has("vscode-agent-plugins"));
     assert(byId.has("openclaw-bundles"));
+    assert.equal(byId.get("deepseek-deepcode-skills").status, "current");
+    assert.equal(byId.get("deepseek-harness-skills").status, "preview");
     assert(byId.has("npm-trusted-publishing"));
 });

--- a/tooling/specs/distribution-fixture.spec.mjs
+++ b/tooling/specs/distribution-fixture.spec.mjs
@@ -18,6 +18,7 @@ import { fileURLToPath } from "node:url";
 import {
     generateDistributionFixture,
     smokeClaudeDistributionFixture,
+    smokeDeepCodeDistributionFixture,
     smokeDeepSeekDistributionFixture,
     smokeCodexDistributionFixture,
     smokeCopilotDistributionFixture,
@@ -91,6 +92,7 @@ test("distribution requirements and artifact matrix stay authority bounded", () 
         "gemini-cli-extension",
         "pi-passive-package",
         "grok-build-skills",
+        "deepseek-deepcode-skills",
         "deepseek-harness-skills",
         "deepseek-model-provider",
         "npm-trusted-publication",
@@ -180,6 +182,7 @@ test("distribution fixture generation is deterministic across native adapters", 
             "codex",
             "copilot",
             "cursor",
+            "deepcode",
             "deepseek",
             "gemini",
             "grok",
@@ -238,9 +241,18 @@ test("generated marketplace manifests remain passive and idiomatic", () => {
         const providerCompatibility = readJson(
             join(stage, "provider-compatibility.json"),
         );
+        const grokMarketplace = readJson(
+            join(stage, "grok/.claude-plugin/marketplace.json"),
+        );
+        const grokPlugin = readJson(
+            join(stage, "grok/plugins/cratis/.claude-plugin/plugin.json"),
+        );
         const kiro = readJson(join(stage, "kiro/plugin.json"));
+        const junieMarketplace = readJson(
+            join(stage, "junie/.claude-plugin/marketplace.json"),
+        );
         const junie = readJson(
-            join(stage, "junie/extensions/cratis/extension.json"),
+            join(stage, "junie/plugins/cratis/.claude-plugin/plugin.json"),
         );
         const piPackage = readJson(join(stage, "pi/package/package.json"));
         assert.equal(claude.name, "cratis");
@@ -263,12 +275,30 @@ test("generated marketplace manifests remain passive and idiomatic", () => {
                 supportedHarnessOutputs: [
                     "claude",
                     "copilot",
+                    "deepcode",
                     "deepseek",
                     "pi",
                 ],
                 distinctArtifactRoot: null,
             },
         ]);
+        const canonicalSkill = readFileSync(
+            join(
+                stage,
+                "canonical/skills/cratis-fundamentals-concept/SKILL.md",
+            ),
+            "utf8",
+        );
+        assert.equal(
+            readFileSync(
+                join(
+                    stage,
+                    "deepcode/.deepcode/skills/cratis-fundamentals-concept/SKILL.md",
+                ),
+                "utf8",
+            ),
+            canonicalSkill,
+        );
         assert.equal(
             readFileSync(
                 join(
@@ -277,30 +307,22 @@ test("generated marketplace manifests remain passive and idiomatic", () => {
                 ),
                 "utf8",
             ),
-            readFileSync(
-                join(
-                    stage,
-                    "canonical/skills/cratis-fundamentals-concept/SKILL.md",
-                ),
-                "utf8",
-            ),
+            canonicalSkill,
         );
         assert.equal(
             readFileSync(
                 join(
                     stage,
-                    "grok/.grok/skills/cratis-fundamentals-concept/SKILL.md",
+                    "grok/plugins/cratis/skills/cratis-fundamentals-concept/SKILL.md",
                 ),
                 "utf8",
             ),
-            readFileSync(
-                join(
-                    stage,
-                    "canonical/skills/cratis-fundamentals-concept/SKILL.md",
-                ),
-                "utf8",
-            ),
+            canonicalSkill,
         );
+        assert.equal(grokMarketplace.plugins[0].source, "./plugins/cratis");
+        assert.deepEqual(grokPlugin, claude);
+        assert.equal(junieMarketplace.plugins[0].source, "./plugins/cratis");
+        assert.deepEqual(junie, claude);
         assert.equal(
             kiro.$schema,
             "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
@@ -355,12 +377,19 @@ test("distribution fixture detects payload and checksum tampering", () => {
     });
 });
 
-test("Grok and DeepSeek direct skill fixtures install and remove", () => {
+test("Grok compatibility and DeepSeek skill fixtures install and remove", () => {
     withTemporaryDirectory((root) => {
         const stage = join(root, "stage");
         generateDistributionFixture({ repositoryRoot, outputRoot: stage });
         assert.deepEqual(
             smokeGrokDistributionFixture(stage, join(root, "grok-home")),
+            { installed: true, removed: true },
+        );
+        assert.deepEqual(
+            smokeDeepCodeDistributionFixture(
+                stage,
+                join(root, "deepcode-home"),
+            ),
             { installed: true, removed: true },
         );
         assert.deepEqual(

--- a/tooling/specs/engineering-distribution-fixture.spec.mjs
+++ b/tooling/specs/engineering-distribution-fixture.spec.mjs
@@ -18,6 +18,7 @@ import { fileURLToPath } from "node:url";
 import {
     generateEngineeringDistributionFixture,
     smokeClaudeEngineeringFixture,
+    smokeDeepCodeEngineeringFixture,
     smokeDeepSeekEngineeringFixture,
     smokeCodexEngineeringFixture,
     smokeCopilotEngineeringFixture,
@@ -138,6 +139,7 @@ test("engineering fixture generation is deterministic and non-installable", () =
             "codex",
             "copilot",
             "cursor",
+            "deepcode",
             "deepseek",
             "gemini",
             "grok",
@@ -251,7 +253,7 @@ test("engineering fixture contains one passive skill and no project context", ()
             readFileSync(
                 join(
                     stage,
-                    "deepseek/.dsh/skills/cratis-engineering-docs-authoring/SKILL.md",
+                    "deepcode/.deepcode/skills/cratis-engineering-docs-authoring/SKILL.md",
                 ),
                 "utf8",
             ),
@@ -261,7 +263,37 @@ test("engineering fixture contains one passive skill and no project context", ()
             readFileSync(
                 join(
                     stage,
-                    "grok/.grok/skills/cratis-engineering-docs-authoring/SKILL.md",
+                    "deepseek/.dsh/skills/cratis-engineering-docs-authoring/SKILL.md",
+                ),
+                "utf8",
+            ),
+            canonicalSkill,
+        );
+        const claudePlugin = readJson(
+            join(
+                stage,
+                "claude/plugins/cratis-engineering-fixture/.claude-plugin/plugin.json",
+            ),
+        );
+        const grokPlugin = readJson(
+            join(
+                stage,
+                "grok/plugins/cratis-engineering-fixture/.claude-plugin/plugin.json",
+            ),
+        );
+        const juniePlugin = readJson(
+            join(
+                stage,
+                "junie/plugins/cratis-engineering-fixture/.claude-plugin/plugin.json",
+            ),
+        );
+        assert.deepEqual(grokPlugin, claudePlugin);
+        assert.deepEqual(juniePlugin, claudePlugin);
+        assert.equal(
+            readFileSync(
+                join(
+                    stage,
+                    "grok/plugins/cratis-engineering-fixture/skills/cratis-engineering-docs-authoring/SKILL.md",
                 ),
                 "utf8",
             ),
@@ -273,12 +305,9 @@ test("engineering fixture contains one passive skill and no project context", ()
         );
         assert.equal(
             readJson(
-                join(
-                    stage,
-                    "junie/extensions/cratis-engineering-fixture/extension.json",
-                ),
-            ).name,
-            "cratis-engineering-fixture",
+                join(stage, "junie/.claude-plugin/marketplace.json"),
+            ).plugins[0].source,
+            "./plugins/cratis-engineering-fixture",
         );
         const packageJson = readJson(join(stage, "pi/package/package.json"));
         assert.equal(packageJson.private, true);
@@ -308,7 +337,7 @@ test("engineering fixture detects canonical payload tampering", () => {
     });
 });
 
-test("engineering Grok and DeepSeek fixtures install and remove", () => {
+test("engineering Grok compatibility and DeepSeek fixtures install and remove", () => {
     withTemporaryDirectory((root) => {
         const stage = join(root, "stage");
         generateEngineeringDistributionFixture({
@@ -317,6 +346,10 @@ test("engineering Grok and DeepSeek fixtures install and remove", () => {
         });
         assert.deepEqual(
             smokeGrokEngineeringFixture(stage, join(root, "grok-home")),
+            { installed: true, removed: true },
+        );
+        assert.deepEqual(
+            smokeDeepCodeEngineeringFixture(stage, join(root, "deepcode-home")),
             { installed: true, removed: true },
         );
         assert.deepEqual(


### PR DESCRIPTION
# Summary

Reduces divergent host packaging while making DeepSeek support claims precise. Grok and Junie now consume the same Claude-compatible Cratis marketplace, and official Deep Code skills are separated from the preview DeepSeek Harness contract.

## Added

- Adds a current official Deep Code Agent Skills artifact under `.deepcode/skills` with direct install/remove evidence (#188)
- Adds separate catalog evidence for current Deep Code and preview DeepSeek Harness contracts (#188)

## Changed

- Makes Claude, Grok, and Junie share one marketplace/plugin structure and byte-identical skills (#188)
- Replaces the bespoke Junie `extension.json` package with Junie's documented Claude marketplace compatibility (#188)
- Uses Grok's documented Claude marketplace compatibility instead of a separately maintained direct-skill package (#188)
- Keeps `.dsh` output explicitly labeled as preview DeepSeek Harness support rather than presenting it as the current Deep Code contract (#188)
- Updates subscriptions, release assets, fixtures, and adoption guidance to distinguish Deep Code from DeepSeek Harness (#188)
