### PR TITLE
Prove Gemini extension skill discovery

### DIFF
--- a/catalog/generated/human-catalog/catalog.json
+++ b/catalog/generated/human-catalog/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractVersion": 1,
   "disclaimer": "Catalog inclusion, evaluation evidence, bundle generation, or publication does not grant runtime permission or approval.",
-  "inputDigest": "8d29dcca0cce41fc42d1ee73a34ff7e2687416f4887cae49cb9122245bad514a",
+  "inputDigest": "297b144769692e05b6ed74123d8a1db011bf93cb7c4a491a20ab644a0eb08547",
   "profiles": [
     {
       "id": "public-application",

--- a/catalog/generated/human-catalog/manifest.json
+++ b/catalog/generated/human-catalog/manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "contractVersion": 1,
-  "inputDigest": "8d29dcca0cce41fc42d1ee73a34ff7e2687416f4887cae49cb9122245bad514a",
+  "inputDigest": "297b144769692e05b6ed74123d8a1db011bf93cb7c4a491a20ab644a0eb08547",
   "files": [
     {
       "path": "CATALOG.md",
@@ -11,7 +11,7 @@
     {
       "path": "catalog.json",
       "size": 129922,
-      "sha256": "6deef2ed34cd09ecfcc294aa5ffd52bed65ec832e8b546270970ff5d1420bced"
+      "sha256": "197a99194f8a300a3a9216d3ee37fbc68a065afd1f78dd2825124d5a24ac74f2"
     }
   ]
 }

--- a/catalog/v2/evidence.json
+++ b/catalog/v2/evidence.json
@@ -93,6 +93,17 @@
       "digest": "345fdacc6d907aa701785d4e9306959282baa2d196e81ab925626acbe3e50219"
     },
     {
+      "id": "gemini-skill-discovery-2026-08-24",
+      "officialUrl": "https://github.com/Cratis/AI",
+      "sourceKind": "local-evidence-report",
+      "verifiedOn": "2026-08-24",
+      "expiresOn": "2026-11-22",
+      "applicableVersion": "Gemini CLI 0.33.1",
+      "confidence": "high",
+      "repositoryPath": "distribution/evidence/local-gemini-skill-discovery-2026-08-24.json",
+      "digest": "e9c1eaf711c93ceb1a261b299b8dc94272e351fc3afe2c32e5cc64ddb74a9587"
+    },
+    {
       "id": "engineering-docs-add-page-source-684d037",
       "officialUrl": "https://github.com/Cratis/AI/tree/684d03755bacd40af95463b81b4a0c8b9f088ec1/engineering/skills/cratis-engineering-docs-add-page",
       "sourceKind": "repository-snapshot",

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "f44dfcbc6fd2c24ecfebaafa66128e959cc482b5847a61904b1c215b6e294b99",
+  "indexDigest": "4a9562b7160bdfcbcf039974ba939fd3856d8950bb5ba79c48b63ca3e1c8c05e",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -500,6 +500,10 @@
     },
     {
       "path": "distribution/evidence/local-fundamentals-preview-assets-b53caa5-2026-08-23.json",
+      "status": "added"
+    },
+    {
+      "path": "distribution/evidence/local-gemini-skill-discovery-2026-08-24.json",
       "status": "added"
     },
     {
@@ -3587,8 +3591,8 @@
       "evidenceIds": [
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 28,
-      "expectedPathsDigest": "37938651506109f6e867144bb871a36874b2afd7f7566df3bf3a2b15f95505aa"
+      "expectedPathCount": 29,
+      "expectedPathsDigest": "fd834db5c4993ac7e32fd33ee85171742e0c2aa183dcd208cf554a44c5d3ec0d"
     },
     {
       "excludePathPatterns": [],

--- a/distribution/artifact-matrix.json
+++ b/distribution/artifact-matrix.json
@@ -86,7 +86,7 @@
       "smokeGates": [
         "manifest-parse",
         "canonical-byte-parity",
-        "isolated-link-uninstall-when-available"
+        "isolated-link-skill-list-uninstall-gemini-0.33.1"
       ]
     },
     {

--- a/distribution/evidence/local-gemini-skill-discovery-2026-08-24.json
+++ b/distribution/evidence/local-gemini-skill-discovery-2026-08-24.json
@@ -1,0 +1,50 @@
+{
+  "schemaVersion": "1.0.0",
+  "observedOn": "2026-08-24",
+  "state": "LOCAL_GEMINI_SKILL_DISCOVERY_PASS",
+  "host": "darwin-arm64",
+  "geminiCliVersion": "0.33.1",
+  "publicFixture": {
+    "extension": "cratis",
+    "skill": "cratis-fundamentals-concept",
+    "skillSha256": "423ab2d27b08e13d3c7c3fbaf9bbc06ea1fb9a13610bdcfdf37398b12d593ec9"
+  },
+  "engineeringFixture": {
+    "extension": "cratis-engineering-fixture",
+    "skill": "cratis-engineering-docs-authoring",
+    "sourceRevision": "f58bcf7f5cc9fc0e11305ada3b5ecb6fa20953e9",
+    "skillSha256": "014f2e7b55d4f1a7dd982e4e352cffc8cfa078a262056bb55b76eb2b81da0791"
+  },
+  "results": [
+    {
+      "gate": "isolated-extension-link",
+      "status": "PASS"
+    },
+    {
+      "gate": "extension-list-reports-agent-skill",
+      "status": "PASS"
+    },
+    {
+      "gate": "gemini-skills-list-discovers-extension-path",
+      "status": "PASS"
+    },
+    {
+      "gate": "extension-uninstall-removes-discovery-path",
+      "status": "PASS"
+    },
+    {
+      "gate": "public-and-engineering-canonical-byte-parity",
+      "status": "PASS"
+    }
+  ],
+  "limitations": [
+    "This is local exact-version host evidence, not a public marketplace listing or production support commitment.",
+    "No model request, network tool, script, MCP server, hook, or repository mutation was part of skill discovery.",
+    "Update and rollback against a published remote Gemini extension remain untested.",
+    "The extension was linked from a generated local fixture and removed from an isolated HOME."
+  ],
+  "hostTested": true,
+  "installationEligible": false,
+  "publicationEligible": false,
+  "promotionEligible": false
+}

--- a/distribution/marketplace-requirements.json
+++ b/distribution/marketplace-requirements.json
@@ -136,8 +136,9 @@
     },
     {
       "id": "gemini-cli-extension",
-      "status": "VERIFIED",
+      "status": "VERIFIED_HOST_SKILL_DISCOVERY_0_33_1",
       "sourceUrls": [
+        "https://google-gemini.github.io/gemini-cli/docs/extensions/",
         "https://geminicli.com/docs/extensions/reference/",
         "https://geminicli.com/docs/extensions/releasing/"
       ],
@@ -157,7 +158,8 @@
       "constraints": [
         "Extension name is lowercase letters, digits, and dashes and matches its directory.",
         "gemini-extension.json is at the repository or release-archive root.",
-        "Manifest version matches the GitHub release tag."
+        "Manifest version matches the GitHub release tag.",
+        "Gemini CLI 0.33.1 linked the public and engineering fixtures, reported their Agent Skills in the extension list, discovered them through gemini skills list, and removed their discovery paths on uninstall."
       ]
     },
     {

--- a/tooling/generate-catalog-v2.mjs
+++ b/tooling/generate-catalog-v2.mjs
@@ -1662,6 +1662,20 @@ const evidence = [
         ),
     },
     {
+        id: "gemini-skill-discovery-2026-08-24",
+        officialUrl: "https://github.com/Cratis/AI",
+        sourceKind: "local-evidence-report",
+        verifiedOn: "2026-08-24",
+        expiresOn: "2026-11-22",
+        applicableVersion: "Gemini CLI 0.33.1",
+        confidence: "high",
+        repositoryPath:
+            "distribution/evidence/local-gemini-skill-discovery-2026-08-24.json",
+        digest: digestFile(
+            "distribution/evidence/local-gemini-skill-discovery-2026-08-24.json",
+        ),
+    },
+    {
         id: "engineering-docs-add-page-source-684d037",
         officialUrl:
             "https://github.com/Cratis/AI/tree/684d03755bacd40af95463b81b4a0c8b9f088ec1/engineering/skills/cratis-engineering-docs-add-page",

--- a/tooling/generate-distribution-fixture.mjs
+++ b/tooling/generate-distribution-fixture.mjs
@@ -2,7 +2,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
     cpSync,
@@ -49,6 +49,18 @@ const generatedTargets = [
 
 function sha256(content) {
     return createHash("sha256").update(content).digest("hex");
+}
+
+function captureCommand(command, args, environment) {
+    const result = spawnSync(command, args, {
+        env: environment,
+        encoding: "utf8",
+    });
+    if (result.status !== 0)
+        throw new Error(
+            `Command failed: ${command} ${args.join(" ")}\n${result.stderr}`,
+        );
+    return `${result.stdout}${result.stderr}`;
 }
 
 function readJson(path) {
@@ -894,13 +906,30 @@ export function smokeGeminiDistributionFixture(
     const installedRoot = join(temporaryHome, ".gemini/extensions/cratis");
     if (!existsSync(installedRoot))
         throw new Error("Gemini fixture extension was not observable");
+    const skillList = captureCommand(
+        geminiCommand,
+        ["skills", "list"],
+        environment,
+    );
+    if (
+        !skillList.includes("cratis-fundamentals-concept") ||
+        !skillList.includes(realpathSync(extensionRoot))
+    )
+        throw new Error("Gemini fixture skill discovery was not observable");
     execFileSync(geminiCommand, ["extensions", "uninstall", "cratis"], {
         env: environment,
         stdio: "pipe",
     });
     if (existsSync(installedRoot))
         throw new Error("Gemini fixture uninstall left extension content");
-    return { linked: true, removed: true };
+    const removedSkills = captureCommand(
+        geminiCommand,
+        ["skills", "list"],
+        environment,
+    );
+    if (removedSkills.includes(realpathSync(extensionRoot)))
+        throw new Error("Gemini fixture uninstall left skill discovery state");
+    return { linked: true, skillDiscovered: true, removed: true };
 }
 
 function main() {

--- a/tooling/generate-engineering-distribution-fixture.mjs
+++ b/tooling/generate-engineering-distribution-fixture.mjs
@@ -2,7 +2,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
     cpSync,
@@ -53,6 +53,18 @@ const generatedTargets = [
 
 function sha256(content) {
     return createHash("sha256").update(content).digest("hex");
+}
+
+function captureCommand(command, args, environment) {
+    const result = spawnSync(command, args, {
+        env: environment,
+        encoding: "utf8",
+    });
+    if (result.status !== 0)
+        throw new Error(
+            `Command failed: ${command} ${args.join(" ")}\n${result.stderr}`,
+        );
+    return `${result.stdout}${result.stderr}`;
 }
 
 function readJson(path) {
@@ -963,6 +975,18 @@ export function smokeGeminiEngineeringFixture(
         throw new Error(
             "Gemini engineering fixture extension was not observable",
         );
+    const skillList = captureCommand(
+        geminiCommand,
+        ["skills", "list"],
+        environment,
+    );
+    if (
+        !skillList.includes(skillName) ||
+        !skillList.includes(realpathSync(extensionRoot))
+    )
+        throw new Error(
+            "Gemini engineering skill discovery was not observable",
+        );
     execFileSync(geminiCommand, ["extensions", "uninstall", pluginName], {
         env: environment,
         stdio: "pipe",
@@ -971,7 +995,16 @@ export function smokeGeminiEngineeringFixture(
         throw new Error(
             "Gemini engineering fixture uninstall left extension content",
         );
-    return { linked: true, removed: true };
+    const removedSkills = captureCommand(
+        geminiCommand,
+        ["skills", "list"],
+        environment,
+    );
+    if (removedSkills.includes(realpathSync(extensionRoot)))
+        throw new Error(
+            "Gemini engineering uninstall left skill discovery state",
+        );
+    return { linked: true, skillDiscovered: true, removed: true };
 }
 
 function main() {

--- a/tooling/specs/distribution-fixture.spec.mjs
+++ b/tooling/specs/distribution-fixture.spec.mjs
@@ -220,6 +220,27 @@ test("fixture provenance binds the authorized immutable public source", () => {
     });
 });
 
+test("Gemini evidence binds public and engineering skill discovery", () => {
+    const evidence = readJson(
+        join(
+            repositoryRoot,
+            "distribution/evidence/local-gemini-skill-discovery-2026-08-24.json",
+        ),
+    );
+    assert.equal(evidence.state, "LOCAL_GEMINI_SKILL_DISCOVERY_PASS");
+    assert.equal(evidence.geminiCliVersion, "0.33.1");
+    assert.equal(evidence.publicFixture.skill, "cratis-fundamentals-concept");
+    assert.equal(
+        evidence.engineeringFixture.skill,
+        "cratis-engineering-docs-authoring",
+    );
+    assert(evidence.results.every((result) => result.status === "PASS"));
+    assert.equal(evidence.hostTested, true);
+    assert.equal(evidence.installationEligible, false);
+    assert.equal(evidence.publicationEligible, false);
+    assert.equal(evidence.promotionEligible, false);
+});
+
 test("generated marketplace manifests remain passive and idiomatic", () => {
     withTemporaryDirectory((root) => {
         const stage = join(root, "stage");
@@ -488,6 +509,7 @@ test("Gemini fixture links and removes in an isolated home", {
         mkdirSync(isolatedHome);
         assert.deepEqual(smokeGeminiDistributionFixture(stage, isolatedHome), {
             linked: true,
+            skillDiscovered: true,
             removed: true,
         });
     });

--- a/tooling/specs/engineering-distribution-fixture.spec.mjs
+++ b/tooling/specs/engineering-distribution-fixture.spec.mjs
@@ -492,6 +492,7 @@ test("engineering Gemini fixture links and removes", {
         mkdirSync(home);
         assert.deepEqual(smokeGeminiEngineeringFixture(stage, home), {
             linked: true,
+            skillDiscovered: true,
             removed: true,
         });
     });


### PR DESCRIPTION
# Summary

Upgrades Gemini from extension-link evidence to real skill-discovery evidence. Both public and maintainer fixtures now prove that Gemini reports the packaged Agent Skill, discovers it through `gemini skills list`, and removes the extension discovery path on uninstall.

## Added

- Adds checksum-bound Gemini CLI 0.33.1 evidence for public and engineering skill discovery (#188)
- Adds repeatable extension link, skill-list discovery, and uninstall-state fixture gates (#188)

## Changed

- Marks Gemini packaging as host-tested for exact local skill discovery rather than merely statically generated (#188)
- Records remaining limitations: remote marketplace update/rollback and public support are still separate gates (#188)
