### PR TITLE
Add job timeouts and PR concurrency to workflows

### DIFF
--- a/.github/workflows/cleanup-pr-artifacts.yml
+++ b/.github/workflows/cleanup-pr-artifacts.yml
@@ -1,5 +1,9 @@
 name: Cleanup PR Artifacts
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     types: [closed]

--- a/.github/workflows/release-approved-ai-profiles.yml
+++ b/.github/workflows/release-approved-ai-profiles.yml
@@ -363,6 +363,7 @@ jobs:
     if: ${{ always() && github.event_name == 'push' && needs.distribute.result == 'success' && needs['publish-npm'].result == 'failure' }}
     needs: [discover, distribute, publish-npm]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     environment: distribution-canary
     steps:
       - name: Create repository-scoped distribution token
@@ -438,6 +439,7 @@ jobs:
     if: ${{ always() && github.event_name == 'push' && needs['publish-npm'].result == 'success' && needs['promote-and-follow-up'].result == 'failure' }}
     needs: [discover, publish-npm, promote-and-follow-up]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Part of the org-wide Actions throttling remediation. Mechanical, rule-based sweep:

- **timeout-minutes** on every job that had none (previously 6 h default): quick checks 15, builds 30, publish/release 60, integration/benchmarks 120.
- **concurrency + cancel-in-progress** only on pull-request-triggered verification workflows — never on publish/release/deploy, `pull_request_target`, `workflow_run` or reusable (`workflow_call`) workflows.

Every edited file re-parsed as YAML before commit. Files changed:
- .github/workflows/cleanup-pr-artifacts.yml
- .github/workflows/release-approved-ai-profiles.yml