### PR TITLE
Rule: GitHub Actions capacity, cost, and release discipline

### DIFF
--- a/.ai/rules/github-actions.md
+++ b/.ai/rules/github-actions.md
@@ -1,0 +1,87 @@
+---
+applyTo: ".github/workflows/**"
+paths:
+  - ".github/workflows/**"
+---
+
+# GitHub Actions workflows: capacity, cost, and release discipline
+
+> **Why this rule exists.** On 2026-08-25 the organization's hosted runners starved for
+> most of a working day: every repository ran its scheduled jobs at the same minute,
+> hour-long jobs with no timeout occupied the shared concurrency pool, and a
+> comment-triggered assistant booted a runner for every comment in two repositories.
+> The remediation that followed is encoded here so it stays true.
+
+## The budget you are spending
+
+- The whole organization shares **one hosted-runner concurrency pool** (20 concurrent
+  jobs on the Free plan, 5 for macOS). Every queued job competes with every repository.
+- **Public repositories** run free on hosted runners; **private repositories bill every
+  minute** — Linux 1×, Windows 2×, macOS 10× — against a small monthly allowance.
+- The organization runs its own scale set (`cratis-arc`). Jobs there cost nothing and
+  do not touch the hosted pool.
+
+## Scheduling
+
+- **Never schedule on the top of the hour**, and never copy another repository's cron.
+  `0 6 * * *` in 36 repositories produced a 270-job stampede into 20 slots. Pick a
+  deterministic offset unique to the repository (minute 1–59, spread across 03:00–07:00 UTC).
+- A scheduled workflow that exists to keep coverage (nightly full matrix, health probe)
+  should run the *narrowest* thing that preserves the claim it exists to make.
+
+## Every job, always
+
+- **`timeout-minutes` on every job.** The default is 6 hours; one hung job holds a
+  pool slot for all of it. Tiers that work: quick checks 15, builds 30–45,
+  publish/release 60, integration/benchmarks 120.
+- **A `concurrency` group on every pull-request verification workflow** with
+  `cancel-in-progress: true`, keyed `${{ github.workflow }}-${{ github.ref }}`.
+  **Never** cancel-in-progress on publish, release, or deploy workflows — a cancelled
+  half-publish is worse than a queued one.
+
+## Matrices and operating systems
+
+- Run the full OS matrix on `schedule`/`workflow_dispatch`; run **Linux only on pull
+  request syncs**. Windows bills double and macOS ten-fold, and per-PR duplication has
+  to earn that cost with unique signal. (Measured before adopting this: 75 dual-OS runs
+  of one private repository, zero Windows-only failures.)
+- Skip the expensive job entirely for documentation-only changes: a cheap change-detection
+  job (`git diff --name-only HEAD^1 HEAD` on the merge commit) gating the build job.
+
+## Runners
+
+- Private-repository jobs belong on the organization scale set: `runs-on: cratis-arc`,
+  or a repository variable such as `${{ vars.<REPO>_RUNNER || 'ubuntu-latest' }}` so
+  routing changes without a code change.
+- On self-hosted runners, `actions/setup-dotnet` cannot write `/usr/share/dotnet`.
+  Set `DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet` on the setup step.
+- **Never** route `pull_request`-triggered jobs of a *public* repository to self-hosted
+  runners — that hands code execution on our infrastructure to any fork.
+
+## Automation that writes back
+
+- A bot that pushes to a branch must **retry with `git pull --rebase`** — the branch
+  moves while the job runs, and a plain push loses the whole run to a non-fast-forward.
+- A bot's pre-push verification build must match the strictest configuration any CI in
+  the organization applies to the same commit (build `Release` when consumers enforce
+  analyzers there). Do not add `[skip ci]` to bot commits as a load optimization: the
+  downstream CI run is the only check that sees the merged result.
+- Comment-triggered agent workflows must gate on the trigger phrase in the job's `if:`
+  (for example `contains(github.event.comment.body, '@claude')`) so a runner only
+  starts when the agent is actually addressed.
+
+## Releases
+
+- A pull request that changes nothing outward-facing — workflow edits, CI configuration,
+  documentation — carries the **`no-release`** label, never `patch`. See
+  [`pull-requests.md`](./pull-requests.md). Merging config-only work under `patch` cut
+  four unintended releases on 2026-08-25.
+- Every repository's release-intent gate must accept `no-release`; a gate that only
+  accepts `major`/`minor`/`patch` forces exactly that mistake.
+
+## In this repository specifically
+
+- Workflow and rule files are tracked by the generated catalogs. Any change under
+  `.github/workflows/**` or `.ai/**` must regenerate and commit
+  `catalog/v2/repository-inventory.json` (and friends) **after staging the change** —
+  the inventory generator reads staged state, not the working tree.

--- a/.claude/rules/github-actions.md
+++ b/.claude/rules/github-actions.md
@@ -1,0 +1,1 @@
+../../.ai/rules/github-actions.md

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "caa8eabf30d481c9cd271cf2845d20a8bcd82ab07eae71168dec4b7a5b58b94f",
+  "indexDigest": "a99a8d239669f79d7e98ff03c731d103dec379eafe8a4ff7e1c75d3bfc211864",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -39,6 +39,10 @@
       "status": "modified"
     },
     {
+      "path": ".ai/rules/github-actions.md",
+      "status": "added"
+    },
+    {
       "path": ".ai/rules/managing-ai-rules.md",
       "status": "modified"
     },
@@ -65,6 +69,10 @@
     {
       "path": ".ai/workflows/claude.yml",
       "status": "modified"
+    },
+    {
+      "path": ".claude/rules/github-actions.md",
+      "status": "added"
     },
     {
       "path": ".github/ISSUE_TEMPLATE/shared-ai-improvement.yml",
@@ -2430,8 +2438,8 @@
         "repo-main-b795d53",
         "ai-126"
       ],
-      "expectedPathCount": 35,
-      "expectedPathsDigest": "b61335ee479ba0b46f861baf40ac257abe6b0687909e655ea3f4de59cd3fbd49"
+      "expectedPathCount": 36,
+      "expectedPathsDigest": "8d7706204bf0c1ae7289dded92089adcb2fdacd54e7a9668412eb8f501be9b9d"
     },
     {
       "excludePathPatterns": [],
@@ -2721,8 +2729,8 @@
         "reevaluation-authority"
       ],
       "generator": "legacy-manual-adapter-model",
-      "expectedPathCount": 57,
-      "expectedPathsDigest": "8df9cc32a0bf05818a3bdb16823d6231d4c1ca5d7b4658fc0a6841e524d0b8f0"
+      "expectedPathCount": 58,
+      "expectedPathsDigest": "ccf44ef5d952014b918a42ddcb3f4f6ae743a43916b55a07bb29828d2e98b543"
     },
     {
       "excludePathPatterns": [],


### PR DESCRIPTION
Transfers the 2026-08-25 incident learnings into the corpus as `.ai/rules/github-actions.md` (scoped `applyTo: .github/workflows/**`, universal profile):

- shared 20-slot hosted pool + private-repo billing model as the mental budget
- staggered schedules (never top-of-hour), timeouts, concurrency-group rules (and where cancel-in-progress is forbidden)
- Linux-only PR matrices / full matrix on schedule, docs-only build skipping
- `cratis-arc` routing for private repos incl. the `DOTNET_INSTALL_DIR` pattern, and the fork-safety rule for public repos
- bot-push discipline (rebase retry, Release-config verification, no `[skip ci]`), @-mention gates for agent workflows
- `no-release` intent for config-only PRs (cross-links `pull-requests.md`)
- the this-repo caveat that workflow/rule edits must regenerate the inventory **after staging**

Claude per-file symlink added per `managing-ai-rules.md`; Copilot/Codex need no per-rule step. Catalogs + repository inventory regenerated in-commit.