### PR TITLE
Use the Fundamentals preview package name

### DIFF
--- a/Documentation/phase-0-verification.md
+++ b/Documentation/phase-0-verification.md
@@ -59,8 +59,11 @@ This environment is not authenticated to npm. `npm whoami` returned
 new packages were not verified. No name was claimed and no package was
 published.
 
-Maintainers approved the three names. Trusted-publisher and organization access
-must still be configured and verified before release.
+Maintainers approved the three initial names. The later profile architecture
+selected `@cratis/ai-fundamentals` as the exact first production preview package;
+the generic `@cratis/ai` name remains fixture-only. Ownership of the selected
+profile package plus trusted-publisher and organization access must still be
+configured and verified before release.
 
 ## Ecosystem verification result
 

--- a/Documentation/releasing-cratis-ai.md
+++ b/Documentation/releasing-cratis-ai.md
@@ -16,9 +16,10 @@ tracked in [AI#181](https://github.com/Cratis/AI/issues/181).
 
 `public-fundamentals` is the selected first preview. Generated
 [`preview-readiness.json`](../distribution/preview-readiness.json) is independent
-of S10 and currently lists six request-readiness blockers: reconcile the exact
-npm package name, prove ownership, configure trusted OIDC, enable public preview
-publishing, and implement the separately reviewed preview release workflow.
+of S10 and currently lists five request-readiness blockers: prove ownership of
+`@cratis/ai-fundamentals`, configure its trusted publisher, enable OIDC, enable
+public preview publishing, and implement the separately reviewed preview release
+workflow.
 
 The current Fundamentals workflow is packaging-only: it emits private,
 approval-pending review assets and asserts that preview requests remain blocked.

--- a/Documentation/skill-classification-audit.md
+++ b/Documentation/skill-classification-audit.md
@@ -30,7 +30,8 @@ The eight engineering classifications are:
 - `cratis-csharp-standards`.
 
 The engineering source remains public under `engineering/`, but none of these
-skills enters the public `@cratis/ai` or Agent Plugin artifact.
+skills enters a public product-profile package such as
+`@cratis/ai-fundamentals` or its Agent Plugin artifact.
 
 ## Audit of all current skills
 

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "a5b36de3d43a297e0c9be6a2985350a4b068bd6780d0645b42bb13643fc1104e",
+  "indexDigest": "95f1f8f9a4aa9cfc38c797f51f90158093336c8446a71464723e4f715255e9d5",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/distribution/npm-stage-contract.json
+++ b/distribution/npm-stage-contract.json
@@ -3,7 +3,8 @@
   "state": "PACK_VERIFY_READY_OWNER_AND_TRUST_MISSING",
   "trackingIssue": "https://github.com/Cratis/Workflows/issues/70",
   "package": {
-    "name": "@cratis/ai",
+    "fixtureName": "@cratis/ai",
+    "productionName": "@cratis/ai-fundamentals",
     "fixturePrivate": true,
     "lifecycleScriptsAllowed": false,
     "dependenciesAllowed": false,

--- a/distribution/preview-readiness.json
+++ b/distribution/preview-readiness.json
@@ -12,10 +12,6 @@
   "staticCandidateReady": true,
   "blockers": [
     {
-      "code": "package-name-not-reconciled",
-      "reason": "npm stage names @cratis/ai; preview profile names @cratis/ai-fundamentals."
-    },
-    {
       "code": "package-ownership-unconfirmed",
       "reason": "Exact npm package ownership is not confirmed."
     },

--- a/distribution/preview-readiness.schema.json
+++ b/distribution/preview-readiness.schema.json
@@ -23,7 +23,7 @@
         "additionalProperties": false,
         "required": ["code", "reason"],
         "properties": {
-          "code": { "enum": ["package-name-not-reconciled", "package-ownership-unconfirmed", "trusted-publisher-not-configured", "oidc-not-enabled", "public-preview-publish-disabled", "preview-release-workflow-not-implemented"] },
+          "code": { "enum": ["package-ownership-unconfirmed", "trusted-publisher-not-configured", "oidc-not-enabled", "public-preview-publish-disabled", "preview-release-workflow-not-implemented"] },
           "reason": { "type": "string", "minLength": 1 }
         }
       }

--- a/tooling/preview-readiness.mjs
+++ b/tooling/preview-readiness.mjs
@@ -114,12 +114,11 @@ export function buildPreviewReadiness(
     )
         throw new Error("Fundamentals preview artifact changed");
     const blockers = [];
-    if (npmStage.package.name !== lanes.selectedPreview.packageName)
-        addBlocker(
-            blockers,
-            "package-name-not-reconciled",
-            `npm stage names ${npmStage.package.name}; preview profile names ${lanes.selectedPreview.packageName}.`,
-        );
+    if (
+        npmStage.package.productionName !==
+        lanes.selectedPreview.packageName
+    )
+        throw new Error("Preview production package name is not reconciled");
     if (npmStage.package.publicOwnershipConfirmed !== true)
         addBlocker(
             blockers,

--- a/tooling/specs/assurance-lanes.spec.mjs
+++ b/tooling/specs/assurance-lanes.spec.mjs
@@ -95,7 +95,6 @@ test("current passive preview is statically ready and blocked only on basic owne
     assert.deepEqual(
         first.blockers.map((blocker) => blocker.code),
         [
-            "package-name-not-reconciled",
             "package-ownership-unconfirmed",
             "trusted-publisher-not-configured",
             "oidc-not-enabled",
@@ -113,7 +112,7 @@ test("basic owner setup can admit a preview request without granting support", (
         const lanes = readJson(root, "distribution/assurance-lanes.json");
         writeJson(root, "distribution/assurance-lanes.json", lanes);
         const npm = readJson(root, "distribution/npm-stage-contract.json");
-        npm.package.name = "@cratis/ai-fundamentals";
+        npm.package.productionName = "@cratis/ai-fundamentals";
         npm.package.publicOwnershipConfirmed = true;
         npm.workflow.trustedPublisherConfigured = true;
         npm.workflow.oidcEnabled = true;

--- a/tooling/specs/distribution-npm-stage.spec.mjs
+++ b/tooling/specs/distribution-npm-stage.spec.mjs
@@ -24,7 +24,11 @@ const workflow = readFileSync(
 
 test("npm stage contract keeps ownership OIDC and publication blocked", () => {
     assert.equal(contract.state, "PACK_VERIFY_READY_OWNER_AND_TRUST_MISSING");
-    assert.equal(contract.package.name, "@cratis/ai");
+    assert.equal(contract.package.fixtureName, "@cratis/ai");
+    assert.equal(
+        contract.package.productionName,
+        "@cratis/ai-fundamentals",
+    );
     assert.equal(contract.package.fixturePrivate, true);
     assert.equal(contract.package.publicOwnershipConfirmed, false);
     assert.equal(contract.workflow.trustedPublisherConfigured, false);
@@ -48,6 +52,7 @@ test("npm fixture workflow verifies a private scriptless package", () => {
     assert.match(workflow, /workflow_dispatch:/);
     assert.match(workflow, /package-manager-cache: false/);
     assert.match(workflow, /require\('\$package'\)\.private/);
+    assert(workflow.includes('= "@cratis/ai"'));
     assert.match(workflow, /scripts === undefined/);
     assert.match(workflow, /dependencies === undefined/);
     assert.match(workflow, /distribution-fixture\.spec\.mjs/);


### PR DESCRIPTION
# Summary

Reconciles the selected first preview profile and npm-stage contract on the exact `@cratis/ai-fundamentals` production package name while retaining `@cratis/ai` only for private fixture validation.

## Changed

- Separate fixture and production npm identities in the stage contract. (#181)
- Reduce basic preview readiness to the five remaining owner/setup blockers. (#187)

## Fixed

- Remove the package-name mismatch between `public-fundamentals`, preview generation, and npm readiness. (#187)
