### PR TITLE
Add interactive mutation inverse escrow

### DIFF
--- a/.ai/rules/general.md
+++ b/.ai/rules/general.md
@@ -60,6 +60,43 @@ obtaining credentials, and other local conventions ("Product policy" above).
 
 Default to agentic behavior: inspect local rules, skills, code, tests, and generated patterns; make conservative assumptions supported by that context; implement and verify end to end when feasible. Don't interrupt with questions the repository can answer. Ask when the answer can't be found locally, when reasonable product/domain choices differ meaningfully, when a change is risky, or when the user asked for checkpoints.
 
+## Interactive Agent Mutation Protocol
+
+Ad-hoc interactive agents must not bulk-close issues, delete branches or labels,
+force-push, publish, or perform another destructive/bulk external mutation from
+memory or an age-only heuristic.
+
+Before any such effect:
+
+1. Produce a dry-run with the exact repository, target IDs, and forward action.
+2. Read and capture each target's exact pre-state. Issues labeled `idea` or
+   `investigate` are long-lived and exempt from staleness closure; age alone is
+   never positive closure evidence.
+3. Write a deterministic inverse escrow under the ignored local path
+   `.ai-work/reversals/<run-id>.json` before mutation. It records exact prior
+   state, labels, assignees, precondition fingerprint, forward state, and inverse
+   state for every target.
+4. In `Cratis/AI`, validate and digest it with
+   `node tooling/agent-mutation-protocol.mjs validate|digest <manifest>` and
+   render the machine-executable inverse with `render-inverse`. In another
+   repository, use its approved repository-owned equivalent; if none exists,
+   stop rather than falling back to agent memory. If an exact inverse or safe
+   compensation cannot be prepared, stop unless the owner separately authorizes
+   that explicit irreversible operation.
+5. Show the dry-run and inverse digest to the human and obtain explicit
+   authorization for that exact manifest. Approval for one manifest does not
+   authorize changed targets or actions.
+6. Re-read preconditions immediately before each mutation and stop on drift.
+   Record completed, failed, and not-attempted operations. A partial run remains
+   recoverable from the escrow; never reconstruct reversal from chat history.
+7. Reversal is a new separately authorized operation. Use a repository-owned
+   adapter to replay the rendered payload; the shared validator deliberately
+   performs no network or mutation itself.
+
+Issue comments, closure, labels, assignments, mentions, publication, and other
+notification-bearing effects remain separate authorizations. Git history
+rewrites stay prohibited even when an inverse payload exists.
+
 ## New Repository Strategy Intake
 
 When a repository is created in the Cratis organization, prepare one transient,

--- a/catalog/components.json
+++ b/catalog/components.json
@@ -5487,12 +5487,12 @@
       "canonicalSources": [
         {
           "path": ".ai/rules/general.md",
-          "digest": "dba032aee881958df8de0b912759519c53fc3cbbcc1da8af5f304bbabd5970c4",
+          "digest": "3c3248b6e3b65d898e17b1dbad65aac36e8d363164e692671e3e5966b73046da",
           "ownership": "owner",
           "ownerComponentId": "cratis-instruction-general"
         }
       ],
-      "contentDigest": "d488cbe5abfbf1a64abd42295f16eb8e6344f92648bf8f8f2277ff95b08075cf",
+      "contentDigest": "90b968642cf0c98aca3d438949aeea935defb48033dd388ddce04ef65390bf03",
       "owner": "reusable Cratis engineering behavior",
       "audience": "cratis-engineering",
       "classification": {

--- a/catalog/generated/human-catalog/catalog.json
+++ b/catalog/generated/human-catalog/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractVersion": 1,
   "disclaimer": "Catalog inclusion, evaluation evidence, component modeling, planned projection, bundle generation, or publication does not grant runtime permission, emitted bytes, support, or approval.",
-  "inputDigest": "b058e00644bbe23e51371983326ccc16089bb95ad8de3720f5f0ddcddc8c3ec9",
+  "inputDigest": "4242c98bef35633c8d6809ce1637f4c103742643cd1419d0c1b459250afc3be4",
   "componentSummary": {
     "disclaimer": "Modeled or planned components and projections are catalog metadata only; they are not emitted, supported, installable, published, promoted, or runtime eligible.",
     "total": 137,

--- a/catalog/generated/human-catalog/manifest.json
+++ b/catalog/generated/human-catalog/manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "contractVersion": 1,
-  "inputDigest": "b058e00644bbe23e51371983326ccc16089bb95ad8de3720f5f0ddcddc8c3ec9",
+  "inputDigest": "4242c98bef35633c8d6809ce1637f4c103742643cd1419d0c1b459250afc3be4",
   "files": [
     {
       "path": "CATALOG.md",
@@ -11,7 +11,7 @@
     {
       "path": "catalog.json",
       "size": 155727,
-      "sha256": "4d20b8d6ca8b87850777839ce7179836fcc0907b84e5ec1cd4f53cf78f5454f2"
+      "sha256": "d0b553392edc6d07b1f317c27fe1d24f3f732100bf814eab684d1b6fd96f466c"
     }
   ]
 }

--- a/catalog/v2/components.json
+++ b/catalog/v2/components.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "generatedBy": "tooling/generate-component-catalogs.mjs",
-  "sourceDigest": "1805d2372d9a3fd92e692226099e4eb0ce7c07c529bc0d4cd99e7d5f77f633e6",
+  "sourceDigest": "cf87c8104ce2bda81f577c5023ed13c00016bd2ae6fce8d2131ed807ca069983",
   "defaultPolicy": "deny",
   "canonicalSourceRoots": [
     ".ai/agents",
@@ -5489,12 +5489,12 @@
       "canonicalSources": [
         {
           "path": ".ai/rules/general.md",
-          "digest": "dba032aee881958df8de0b912759519c53fc3cbbcc1da8af5f304bbabd5970c4",
+          "digest": "3c3248b6e3b65d898e17b1dbad65aac36e8d363164e692671e3e5966b73046da",
           "ownership": "owner",
           "ownerComponentId": "cratis-instruction-general"
         }
       ],
-      "contentDigest": "d488cbe5abfbf1a64abd42295f16eb8e6344f92648bf8f8f2277ff95b08075cf",
+      "contentDigest": "90b968642cf0c98aca3d438949aeea935defb48033dd388ddce04ef65390bf03",
       "owner": "reusable Cratis engineering behavior",
       "audience": "cratis-engineering",
       "classification": {

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "a5b36de3d43a297e0c9be6a2985350a4b068bd6780d0645b42bb13643fc1104e",
+  "indexDigest": "c9b8311c7818cbd6771f82969fef0408f01574304b62acc7555ae9f3c327fc50",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -2291,6 +2291,14 @@
       "status": "added"
     },
     {
+      "path": "tooling/agent-mutation-manifest.schema.json",
+      "status": "added"
+    },
+    {
+      "path": "tooling/agent-mutation-protocol.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/benchmarks/release-generation.mjs",
       "status": "added"
     },
@@ -2704,6 +2712,10 @@
     },
     {
       "path": "tooling/specifications/agent-skills/current/specification.snapshot",
+      "status": "added"
+    },
+    {
+      "path": "tooling/specs/agent-mutation-protocol.spec.mjs",
       "status": "added"
     },
     {
@@ -4488,6 +4500,7 @@
       "id": "catalog-and-redesign-tooling",
       "sourcePathPatterns": [
         "tooling/*.mjs",
+        "tooling/*.schema.json",
         "tooling/benchmarks/**"
       ],
       "artifactType": "validation-tooling",
@@ -4504,8 +4517,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 72,
-      "expectedPathsDigest": "d3cf3e2603bc122b413ab16649895d16bd8e66f83101650a321655024f4d6c5a"
+      "expectedPathCount": 74,
+      "expectedPathsDigest": "4d48dc656917984ff6a6f6f45e5df72c62f57959122a582ee762b04dab710957"
     },
     {
       "excludePathPatterns": [],
@@ -4528,8 +4541,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 58,
-      "expectedPathsDigest": "c56d9549b21e095a0d7638ebf154520a6e21d3354dd76061986dda2971066dcc"
+      "expectedPathCount": 59,
+      "expectedPathsDigest": "38cd079fd227bb565a27b77be1c30f70f5c2470a20a81db65000beccfd94b567"
     },
     {
       "excludePathPatterns": [],

--- a/tooling/agent-mutation-manifest.schema.json
+++ b/tooling/agent-mutation-manifest.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Cratis/AI/tooling/agent-mutation-manifest.schema.json",
+  "title": "Cratis interactive agent mutation manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "runId", "state", "provider", "repository", "resource", "action", "policy", "authorization", "targets"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "runId": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" },
+    "state": { "const": "PREPARED" },
+    "provider": { "const": "github" },
+    "repository": { "type": "string", "minLength": 3 },
+    "resource": { "const": "issue" },
+    "action": { "const": "bulk-update" },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["dryRunRequired", "inverseRequired", "ageOnlyMutationAllowed", "longLivedLabels"],
+      "properties": {
+        "dryRunRequired": { "const": true },
+        "inverseRequired": { "const": true },
+        "ageOnlyMutationAllowed": { "const": false },
+        "longLivedLabels": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "uniqueItems": true,
+          "items": { "enum": ["idea", "investigate"] }
+        }
+      }
+    },
+    "authorization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "approvedBy", "approvedAt"],
+      "properties": {
+        "state": { "enum": ["pending", "approved"] },
+        "approvedBy": { "type": "string" },
+        "approvedAt": { "type": "string" }
+      }
+    },
+    "targets": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["issueNumber", "preState", "forward", "inverse"],
+        "properties": {
+          "issueNumber": { "type": "integer", "minimum": 1 },
+          "preState": { "$ref": "#/$defs/preState" },
+          "forward": { "$ref": "#/$defs/issueState" },
+          "inverse": { "$ref": "#/$defs/issueState" }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "stringSet": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "issueState": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "labels", "assignees"],
+      "properties": {
+        "state": { "enum": ["open", "closed"] },
+        "labels": { "$ref": "#/$defs/stringSet" },
+        "assignees": { "$ref": "#/$defs/stringSet" }
+      }
+    },
+    "preState": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "labels", "assignees", "updatedAt", "fingerprintSha256"],
+      "properties": {
+        "state": { "enum": ["open", "closed"] },
+        "labels": { "$ref": "#/$defs/stringSet" },
+        "assignees": { "$ref": "#/$defs/stringSet" },
+        "updatedAt": { "type": "string", "minLength": 1 },
+        "fingerprintSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+      }
+    }
+  }
+}

--- a/tooling/agent-mutation-protocol.mjs
+++ b/tooling/agent-mutation-protocol.mjs
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+    validateAgainstSchema,
+    validateSchemaVocabulary,
+} from "./catalog-validation.mjs";
+
+const toolingRoot = resolve(fileURLToPath(new URL(".", import.meta.url)));
+const schemaPath = resolve(toolingRoot, "agent-mutation-manifest.schema.json");
+
+function canonicalize(value) {
+    if (Array.isArray(value))
+        return `[${value.map((item) => canonicalize(item)).join(",")}]`;
+    if (value && typeof value === "object")
+        return `{${Object.keys(value)
+            .sort()
+            .map(
+                (key) =>
+                    `${JSON.stringify(key)}:${canonicalize(value[key])}`,
+            )
+            .join(",")}}`;
+    return JSON.stringify(value);
+}
+
+function sha256(value) {
+    return createHash("sha256").update(value).digest("hex");
+}
+
+function normalizedStrings(values) {
+    return [...values].sort((left, right) => {
+        if (left < right) return -1;
+        if (left > right) return 1;
+        return 0;
+    });
+}
+
+function issueState(value = {}) {
+    return {
+        state: value.state,
+        labels: normalizedStrings(value.labels ?? []),
+        assignees: normalizedStrings(value.assignees ?? []),
+    };
+}
+
+export function issuePreStateFingerprint(preState) {
+    return sha256(
+        canonicalize({
+            ...issueState(preState),
+            updatedAt: preState?.updatedAt,
+        }),
+    );
+}
+
+export function mutationManifestDigest(manifest) {
+    return sha256(canonicalize(manifest));
+}
+
+function repositoryIsValid(repository) {
+    return /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository);
+}
+
+export function validateMutationManifest(manifest) {
+    let schema;
+    try {
+        schema = JSON.parse(readFileSync(schemaPath, "utf8"));
+    } catch (error) {
+        throw new Error("Unable to load mutation manifest schema", {
+            cause: error,
+        });
+    }
+    const errors = [
+        ...validateSchemaVocabulary(schema),
+        ...validateAgainstSchema(manifest, schema, schema),
+    ];
+    if (!repositoryIsValid(manifest.repository))
+        errors.push("$.repository: expected exact owner/repository identity");
+    if (
+        JSON.stringify(manifest.policy?.longLivedLabels) !==
+        JSON.stringify(["idea", "investigate"])
+    )
+        errors.push("$.policy.longLivedLabels: expected idea and investigate");
+    if (manifest.authorization?.state === "pending") {
+        if (
+            manifest.authorization.approvedBy !== "" ||
+            manifest.authorization.approvedAt !== ""
+        )
+            errors.push("$.authorization: pending approval must be empty");
+    } else if (manifest.authorization?.state === "approved") {
+        if (
+            !manifest.authorization.approvedBy ||
+            !manifest.authorization.approvedAt
+        )
+            errors.push("$.authorization: approved mutation requires identity and time");
+    }
+    const issueNumbers = new Set();
+    for (const [index, target] of (manifest.targets ?? []).entries()) {
+        const path = `$.targets[${index}]`;
+        if (issueNumbers.has(target.issueNumber))
+            errors.push(`${path}.issueNumber: duplicate target`);
+        issueNumbers.add(target.issueNumber);
+        for (const field of ["labels", "assignees"])
+            for (const stateName of ["preState", "forward", "inverse"]) {
+                const values = target[stateName]?.[field] ?? [];
+                if (
+                    JSON.stringify(values) !==
+                    JSON.stringify(normalizedStrings(values))
+                )
+                    errors.push(
+                        `${path}.${stateName}.${field}: values must be sorted`,
+                    );
+            }
+        if (
+            target.preState?.fingerprintSha256 !==
+            issuePreStateFingerprint(target.preState)
+        )
+            errors.push(`${path}.preState: fingerprint mismatch`);
+        if (
+            JSON.stringify(issueState(target.inverse)) !==
+            JSON.stringify(issueState(target.preState))
+        )
+            errors.push(`${path}.inverse: must exactly restore pre-state`);
+        if (
+            target.forward?.state === "closed" &&
+            target.preState?.labels?.some((label) =>
+                manifest.policy?.longLivedLabels?.includes(label),
+            )
+        )
+            errors.push(`${path}: long-lived issue cannot be closed`);
+        if (
+            JSON.stringify(issueState(target.forward)) ===
+            JSON.stringify(issueState(target.preState))
+        )
+            errors.push(`${path}.forward: mutation has no effect`);
+    }
+    return [...new Set(errors)];
+}
+
+export function renderInversePayload(manifest) {
+    const errors = validateMutationManifest(manifest);
+    if (errors.length > 0)
+        throw new Error(`Mutation manifest is invalid: ${errors.join("; ")}`);
+    return {
+        schemaVersion: 1,
+        state: "REVERSAL_PAYLOAD_PREPARED",
+        runId: manifest.runId,
+        repository: manifest.repository,
+        manifestSha256: mutationManifestDigest(manifest),
+        authorizationState: manifest.authorization.state,
+        operations: manifest.targets
+            .map((target) => ({
+                issueNumber: target.issueNumber,
+                method: "PATCH",
+                endpoint: `repos/${manifest.repository}/issues/${target.issueNumber}`,
+                expectedPreStateFingerprint:
+                    target.preState.fingerprintSha256,
+                body: issueState(target.inverse),
+            }))
+            .sort(
+                (left, right) => left.issueNumber - right.issueNumber,
+            ),
+        executionPerformed: false,
+    };
+}
+
+function readManifest(path) {
+    try {
+        return JSON.parse(readFileSync(path, "utf8"));
+    } catch (error) {
+        throw new Error(`Unable to read mutation manifest: ${path}`, {
+            cause: error,
+        });
+    }
+}
+
+function main() {
+    const [operation, manifestPath] = process.argv.slice(2);
+    if (!new Set(["validate", "digest", "render-inverse"]).has(operation) || !manifestPath) {
+        process.stderr.write(
+            "Usage: node tooling/agent-mutation-protocol.mjs validate|digest|render-inverse <manifest.json>\n",
+        );
+        process.exitCode = 1;
+        return;
+    }
+    try {
+        const manifest = readManifest(manifestPath);
+        const errors = validateMutationManifest(manifest);
+        if (errors.length > 0)
+            throw new Error(errors.join("\n"));
+        if (operation === "validate") {
+            process.stdout.write("Mutation manifest is valid.\n");
+            return;
+        }
+        if (operation === "digest") {
+            process.stdout.write(`${mutationManifestDigest(manifest)}\n`);
+            return;
+        }
+        process.stdout.write(
+            `${JSON.stringify(renderInversePayload(manifest), null, 2)}\n`,
+        );
+    } catch (error) {
+        process.stderr.write(
+            `${error instanceof Error ? error.message : "Mutation protocol failed"}\n`,
+        );
+        process.exitCode = 1;
+    }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/tooling/component-catalog-validation.mjs
+++ b/tooling/component-catalog-validation.mjs
@@ -32,7 +32,7 @@ export const componentCatalogPaths = Object.freeze({
 });
 
 const expectedComponentAnchor =
-    "293461cd41ae39e761cebc9afb75442401aef69efec4059c02f07f10f277a951";
+    "927088b7313f6a7a75a44bbd8dcb23ec1bc6c7180626dab66023631c7dc98fb1";
 const expectedProjectionAnchor =
     "70f3e05988839ba21247eff528709caf4738f2aa7f637e05e28658ff05902027";
 const expectedProjectionHostAnchor =

--- a/tooling/fixtures/s8-native-non-skill-expected-tree.json
+++ b/tooling/fixtures/s8-native-non-skill-expected-tree.json
@@ -10,8 +10,8 @@
         {
           "path": "AGENTS.md",
           "sourcePath": ".ai/rules/general.md",
-          "size": 27939,
-          "sha256": "8c8a7b1c48205a69b9cde5b21b504112a235fae39a701b2c6b19282a4c901f8a"
+          "size": 30041,
+          "sha256": "2d52218946f10c2718a4d1673a94a0f383c7e134944ee1e9239404302900635f"
         }
       ]
     },
@@ -442,8 +442,8 @@
         {
           "path": ".github/copilot-instructions.md",
           "sourcePath": ".ai/rules/general.md",
-          "size": 27939,
-          "sha256": "8c8a7b1c48205a69b9cde5b21b504112a235fae39a701b2c6b19282a4c901f8a"
+          "size": 30041,
+          "sha256": "2d52218946f10c2718a4d1673a94a0f383c7e134944ee1e9239404302900635f"
         }
       ]
     }
@@ -455,14 +455,14 @@
       "canonicalOwnerId": "cratis-instruction-general",
       "semanticKind": "instruction",
       "sourcePath": ".ai/rules/general.md",
-      "sourceDigest": "dba032aee881958df8de0b912759519c53fc3cbbcc1da8af5f304bbabd5970c4",
+      "sourceDigest": "3c3248b6e3b65d898e17b1dbad65aac36e8d363164e692671e3e5966b73046da",
       "outputPath": "devin-hosted-instructions/AGENTS.md",
       "hostId": "devin-hosted",
       "hostAdapterId": "devin-hosted-host-adapter",
       "evidenceIds": [
         "devin-hosted-source-2"
       ],
-      "outputDigest": "8c8a7b1c48205a69b9cde5b21b504112a235fae39a701b2c6b19282a4c901f8a"
+      "outputDigest": "2d52218946f10c2718a4d1673a94a0f383c7e134944ee1e9239404302900635f"
     },
     {
       "projectionId": "cratis-instruction-general-to-visual-studio-copilot-instruction",
@@ -470,14 +470,14 @@
       "canonicalOwnerId": "cratis-instruction-general",
       "semanticKind": "instruction",
       "sourcePath": ".ai/rules/general.md",
-      "sourceDigest": "dba032aee881958df8de0b912759519c53fc3cbbcc1da8af5f304bbabd5970c4",
+      "sourceDigest": "3c3248b6e3b65d898e17b1dbad65aac36e8d363164e692671e3e5966b73046da",
       "outputPath": "visual-studio-copilot-instructions/.github/copilot-instructions.md",
       "hostId": "visual-studio-copilot",
       "hostAdapterId": "visual-studio-copilot-host-adapter",
       "evidenceIds": [
         "visual-studio-copilot-source-2"
       ],
-      "outputDigest": "8c8a7b1c48205a69b9cde5b21b504112a235fae39a701b2c6b19282a4c901f8a"
+      "outputDigest": "2d52218946f10c2718a4d1673a94a0f383c7e134944ee1e9239404302900635f"
     },
     {
       "projectionId": "cratis-rule-code-quality-csharp-to-jetbrains-ai-assistant-rule",

--- a/tooling/generate-repository-inventory.mjs
+++ b/tooling/generate-repository-inventory.mjs
@@ -1209,7 +1209,11 @@ const definitions = [
     },
     {
         id: "catalog-and-redesign-tooling",
-        sourcePathPatterns: ["tooling/*.mjs", "tooling/benchmarks/**"],
+        sourcePathPatterns: [
+            "tooling/*.mjs",
+            "tooling/*.schema.json",
+            "tooling/benchmarks/**",
+        ],
         artifactType: "validation-tooling",
         currentOwner: repositoryOwner,
         targetOwner: repositoryOwner,

--- a/tooling/native-non-skill-projections.mjs
+++ b/tooling/native-non-skill-projections.mjs
@@ -29,7 +29,7 @@ export const s8NativeProjectionPaths = Object.freeze({
 });
 
 const expectedStaticComponentAnchor =
-    "e3d38dcd229c97a132908f94f90d3ecd8d11a889b7a1ec153770fce22946be91";
+    "0d070cad94d15b21d5e690f15fd16db55bf22da9e7dc578c2c2c1912a461522b";
 const expectedStaticProjectionAnchor =
     "5994bb761eeaf6f44fd5da70af8434f93b5197ccc7325bb9aa536eb1a9bf0056";
 const expectedStaticProjectionHostAnchor =

--- a/tooling/specs/agent-mutation-protocol.spec.mjs
+++ b/tooling/specs/agent-mutation-protocol.spec.mjs
@@ -1,0 +1,168 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import {
+    issuePreStateFingerprint,
+    mutationManifestDigest,
+    renderInversePayload,
+    validateMutationManifest,
+} from "../agent-mutation-protocol.mjs";
+
+function manifestFor({
+    labels = ["bug"],
+    inverseState = "open",
+    forwardState = "closed",
+} = {}) {
+    const preState = {
+        state: "open",
+        labels,
+        assignees: ["woksin"],
+        updatedAt: "2026-08-27T10:00:00Z",
+        fingerprintSha256: "",
+    };
+    preState.fingerprintSha256 = issuePreStateFingerprint(preState);
+    return {
+        schemaVersion: 1,
+        runId: "chronicle-stale-review-2026-08-27",
+        state: "PREPARED",
+        provider: "github",
+        repository: "Cratis/Chronicle",
+        resource: "issue",
+        action: "bulk-update",
+        policy: {
+            dryRunRequired: true,
+            inverseRequired: true,
+            ageOnlyMutationAllowed: false,
+            longLivedLabels: ["idea", "investigate"],
+        },
+        authorization: {
+            state: "pending",
+            approvedBy: "",
+            approvedAt: "",
+        },
+        targets: [
+            {
+                issueNumber: 3812,
+                preState,
+                forward: {
+                    state: forwardState,
+                    labels: ["stale-review"],
+                    assignees: [],
+                },
+                inverse: {
+                    state: inverseState,
+                    labels,
+                    assignees: ["woksin"],
+                },
+            },
+        ],
+    };
+}
+
+test("mutation manifest produces a deterministic non-executing inverse payload", () => {
+    const manifest = manifestFor();
+    assert.deepEqual(validateMutationManifest(manifest), []);
+    assert.match(mutationManifestDigest(manifest), /^[0-9a-f]{64}$/);
+    assert.equal(
+        mutationManifestDigest(structuredClone(manifest)),
+        mutationManifestDigest(manifest),
+    );
+    const payload = renderInversePayload(manifest);
+    assert.equal(payload.state, "REVERSAL_PAYLOAD_PREPARED");
+    assert.equal(payload.authorizationState, "pending");
+    assert.equal(payload.executionPerformed, false);
+    assert.equal(payload.operations.length, 1);
+    assert.deepEqual(payload.operations[0], {
+        issueNumber: 3812,
+        method: "PATCH",
+        endpoint: "repos/Cratis/Chronicle/issues/3812",
+        expectedPreStateFingerprint:
+            manifest.targets[0].preState.fingerprintSha256,
+        body: {
+            state: "open",
+            labels: ["bug"],
+            assignees: ["woksin"],
+        },
+    });
+});
+
+test("mutation manifest rejects age-only policy long-lived closure and weak inverses", () => {
+    const ageOnly = manifestFor();
+    ageOnly.policy.ageOnlyMutationAllowed = true;
+    assert(
+        validateMutationManifest(ageOnly).some((error) =>
+            error.includes("ageOnlyMutationAllowed"),
+        ),
+    );
+    const longLived = manifestFor({ labels: ["idea"] });
+    assert(
+        validateMutationManifest(longLived).some((error) =>
+            error.includes("long-lived issue cannot be closed"),
+        ),
+    );
+    const wrongInverse = manifestFor({ inverseState: "closed" });
+    assert(
+        validateMutationManifest(wrongInverse).some((error) =>
+            error.includes("must exactly restore pre-state"),
+        ),
+    );
+    const wrongFingerprint = manifestFor();
+    wrongFingerprint.targets[0].preState.fingerprintSha256 = "0".repeat(64);
+    assert(
+        validateMutationManifest(wrongFingerprint).some((error) =>
+            error.includes("fingerprint mismatch"),
+        ),
+    );
+});
+
+test("mutation manifest rejects duplicate targets unsorted state and invented approval", () => {
+    const duplicate = manifestFor();
+    duplicate.targets.push(structuredClone(duplicate.targets[0]));
+    assert(
+        validateMutationManifest(duplicate).some((error) =>
+            error.includes("duplicate target"),
+        ),
+    );
+    const unsorted = manifestFor({ labels: ["z-label", "a-label"] });
+    assert(
+        validateMutationManifest(unsorted).some((error) =>
+            error.includes("values must be sorted"),
+        ),
+    );
+    const inventedApproval = manifestFor();
+    inventedApproval.authorization.state = "approved";
+    assert(
+        validateMutationManifest(inventedApproval).some((error) =>
+            error.includes("requires identity and time"),
+        ),
+    );
+});
+
+test("shared mutation tooling validates and renders but cannot execute effects", () => {
+    const source = readFileSync(
+        "tooling/agent-mutation-protocol.mjs",
+        "utf8",
+    );
+    for (const forbidden of [
+        "node:child_process",
+        "gh api",
+        "fetch(",
+        "https.request",
+        "executionPerformed: true",
+    ])
+        assert.equal(source.includes(forbidden), false, forbidden);
+    const general = readFileSync(".ai/rules/general.md", "utf8");
+    for (const required of [
+        "## Interactive Agent Mutation Protocol",
+        ".ai-work/reversals/<run-id>.json",
+        "idea",
+        "investigate",
+        "age alone",
+        "render-inverse",
+        "separately authorized operation",
+    ])
+        assert(general.includes(required), required);
+});


### PR DESCRIPTION
# Summary

Adds a lean, always-loaded protocol for interactive bulk/destructive GitHub issue mutations. Agents must escrow and validate an exact machine-readable inverse before requesting authorization; shared tooling never performs network effects itself.

## Added

- Add dry-run, long-lived-label exemption, precondition fingerprint, exact inverse, authorization, and partial-run recovery requirements. (#199)
- Add a closed mutation manifest schema plus deterministic validation, digest, and inverse-payload rendering tooling. (#199)

## Security

- Reject age-only closure, `idea`/`investigate` closure, duplicate targets, precondition drift, weak inverses, invented approval, and unsorted state. (#199)
- Keep reversal replay as a separately authorized repository-owned operation with no network or mutation capability in the shared renderer. (#199)
