### PR TITLE
Enable Fundamentals passive preview requests

### DIFF
--- a/.github/workflows/distribution-npm-stage.yml
+++ b/.github/workflows/distribution-npm-stage.yml
@@ -54,8 +54,7 @@ jobs:
           test "$(node -p "require('$package').dependencies === undefined")" = "true"
           node --test tooling/specs/distribution-fixture.spec.mjs
 
-      - name: Confirm npm publication remains absent
+      - name: Confirm staged publication remains absent
         run: |
           set -euo pipefail
           test "$(node -p "require('./distribution/npm-stage-contract.json').workflow.stagePublishEnabled")" = "false"
-          test "$(node -p "require('./distribution/npm-stage-contract.json').workflow.publicPublishEnabled")" = "false"

--- a/.github/workflows/release-passive-previews.yml
+++ b/.github/workflows/release-passive-previews.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "distribution/preview-requests.json"
       - "distribution/preview-requests.schema.json"
+      - "distribution/npm-stage-contract.json"
       - ".github/workflows/release-passive-previews.yml"
       - "tooling/package-fundamentals-preview-*.mjs"
       - "tooling/preview-*.mjs"
@@ -44,6 +45,25 @@ jobs:
         with:
           node-version: 24
           package-manager-cache: false
+
+      - name: Verify registry dist-tag safety
+        run: |
+          set -euo pipefail
+          package=@cratis/ai-fundamentals
+          latest=$(npm view "$package" dist-tags.latest)
+          if [[ -z "$latest" ]]; then
+            exit 0
+          fi
+          if [[ "$latest" == "0.0.0-bootstrap.0" ]]; then
+            deprecated=$(npm view "$package@$latest" deprecated)
+            test "$deprecated" = \
+              "Bootstrap only. Install an exact preview version or use the preview dist-tag."
+            exit 0
+          fi
+          if [[ "$latest" == *-* || ! "$latest" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "The npm latest tag must select a stable version or the deprecated bootstrap: $latest" >&2
+            exit 1
+          fi
 
       - name: deterministic-generation
         id: readiness

--- a/Documentation/releasing-cratis-ai.md
+++ b/Documentation/releasing-cratis-ai.md
@@ -1,8 +1,8 @@
 # Release Cratis AI
 
-> **Preview owner setup and governed S10 are blocked.** Candidate review is
-available now. Passive previews use the basic lane; stable support uses the
-sidelined governed lane and its complete S9/S10 assurance.
+> **Passive preview owner setup is recorded; bootstrap deprecation and governed S10 remain blocked.**
+Candidate review is available now. Passive previews use the basic lane; stable
+support uses the sidelined governed lane and its complete S9/S10 assurance.
 
 A merged release pull request is the recurring human release approval. Do not
 run a second manual publication, promotion, or rollout approval after merge.
@@ -14,18 +14,22 @@ tracked in [AI#181](https://github.com/Cratis/AI/issues/181).
 
 ## Passive preview lane
 
-`public-fundamentals` is the selected first preview. Generated
-[`preview-readiness.json`](../distribution/preview-readiness.json) is independent
-of S10 and currently lists four request-readiness blockers: prove ownership of
-`@cratis/ai-fundamentals`, configure its trusted publisher, enable OIDC, and
-enable public preview publishing.
+`public-fundamentals` is the selected first preview. The public
+`@cratis/ai-fundamentals` package exists, and its exact GitHub Actions trusted
+publisher, OIDC permission, and protected `npm-stage` environment are configured.
+Generated [`preview-readiness.json`](../distribution/preview-readiness.json) is
+independent of S10. npm assigns `latest` to a package's first publication even
+when another tag was requested and currently rejects removing it. Preview
+requests therefore stay blocked until the inert bootstrap version carries the
+required deprecation warning.
 
 The existing Fundamentals asset workflow remains packaging-only. The separate
-**Release Passive Previews** workflow now validates an append-only exact request,
+**Release Passive Previews** workflow validates an append-only exact request,
 runs every anchored basic check, stages a public scriptless/dependency-free npm
-archive, and binds publication to `npm-stage` with OIDC. Its publication job is
-unreachable while readiness is blocked. After owner setup, merging one reviewed
-request can publish that exact preview under the explicit npm `preview`
+archive, and binds publication to `npm-stage` with OIDC. It permits npm
+`latest` only when it selects a stable version or the exact deprecated inert
+bootstrap; every preview or other prerelease value is rejected. Merging one
+reviewed request can publish that exact preview under the explicit npm `preview`
 dist-tag; it cannot become `latest`, claim support, or promote itself to stable
 support.
 

--- a/Documentation/releasing-cratis-ai.md
+++ b/Documentation/releasing-cratis-ai.md
@@ -1,6 +1,6 @@
 # Release Cratis AI
 
-> **Passive preview owner setup is recorded; bootstrap deprecation and governed S10 remain blocked.**
+> **The passive preview lane is ready for one exact request; governed S10 remains blocked.**
 Candidate review is available now. Passive previews use the basic lane; stable
 support uses the sidelined governed lane and its complete S9/S10 assurance.
 
@@ -19,9 +19,9 @@ tracked in [AI#181](https://github.com/Cratis/AI/issues/181).
 publisher, OIDC permission, and protected `npm-stage` environment are configured.
 Generated [`preview-readiness.json`](../distribution/preview-readiness.json) is
 independent of S10. npm assigns `latest` to a package's first publication even
-when another tag was requested and currently rejects removing it. Preview
-requests therefore stay blocked until the inert bootstrap version carries the
-required deprecation warning.
+when another tag was requested and currently rejects removing it. The inert
+bootstrap version now carries the required deprecation warning, so one reviewed
+preview request is eligible without granting publication or support by itself.
 
 The existing Fundamentals asset workflow remains packaging-only. The separate
 **Release Passive Previews** workflow validates an append-only exact request,

--- a/README.md
+++ b/README.md
@@ -180,15 +180,18 @@ The main workflow runs for canonical skills, engineering content, catalogs,
 distribution contracts, evidence, evaluations, documentation, workflows, and
 tooling.
 
-## Current release blockers
+## Current release state
 
-The first narrow public preview still requires:
+The first narrow `public-fundamentals` preview has approved passive source,
+deterministic public package bytes, exact request binding, protected OIDC
+publication, and npm owner setup. npm forces `latest` onto a package's first
+publication and rejects removing it, so the inert bootstrap version must be
+deprecated before one reviewed append-only preview request becomes eligible. No
+preview version has been published, and the preview lane cannot claim support or
+move npm `latest` to a preview.
 
-- owner approval and exact product authority for the Fundamentals concept skill;
-- enabling and exercising the approval-driven production materializer after target approval;
-- scoped GitHub App credentials for generated pull requests;
-- one real consumer install/update/rollback/uninstall canary;
-- an immutable release channel and published installation instructions.
-
-Until those gates pass, this repository is a source and preview-generation
-system—not a supported installation endpoint.
+Stable support and broad rollout still require the governed S9/S10 lane,
+including scoped generated-repository automation, real consumer lifecycle
+canaries, release evidence, immutable installation guidance, and explicit
+support approval. Until those gates pass, any published preview remains an
+unsupported evaluation endpoint.

--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ tooling.
 The first narrow `public-fundamentals` preview has approved passive source,
 deterministic public package bytes, exact request binding, protected OIDC
 publication, and npm owner setup. npm forces `latest` onto a package's first
-publication and rejects removing it, so the inert bootstrap version must be
-deprecated before one reviewed append-only preview request becomes eligible. No
+publication and rejects removing it; the inert bootstrap version is therefore
+deprecated and one reviewed append-only preview request is now eligible. No
 preview version has been published, and the preview lane cannot claim support or
 move npm `latest` to a preview.
 

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "fc964761c5ddb82a8fb050ab3c8977ea511b1e29026c2de4683fe541b90b1fd2",
+  "indexDigest": "10adf1258139c68cf0c89336f016b675e144e4d3d1db9824375f712559f50fc2",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "10adf1258139c68cf0c89336f016b675e144e4d3d1db9824375f712559f50fc2",
+  "indexDigest": "0769ff9beb36b37d262a3e1f77bcb6fbd98bdf0936973b2b5b70f3f1e25607d1",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/distribution/npm-stage-contract.json
+++ b/distribution/npm-stage-contract.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "state": "OWNER_CONFIGURED_BOOTSTRAP_DEPRECATION_REQUIRED",
+  "state": "PASSIVE_PREVIEW_REQUEST_READY",
   "trackingIssue": "https://github.com/Cratis/Workflows/issues/70",
   "package": {
     "fixtureName": "@cratis/ai",
@@ -18,14 +18,19 @@
     },
     "bootstrapVersion": "0.0.0-bootstrap.0",
     "bootstrapDeprecationRequired": true,
-    "bootstrapDeprecationConfirmed": false,
+    "bootstrapDeprecationConfirmed": true,
+    "bootstrapDeprecationEvidence": {
+      "verifiedOn": "2026-08-27",
+      "registryReadbackVerified": true,
+      "cliExitReconciled": "E422_WRITE_PERSISTED"
+    },
     "latestTagPolicy": "stable-or-deprecated-bootstrap-never-preview",
-    "latestTagSafe": false
+    "latestTagSafe": true
   },
   "workflow": {
     "path": ".github/workflows/distribution-npm-stage.yml",
     "productionPath": ".github/workflows/release-approved-ai-profiles.yml",
-    "currentOperation": "DEPRECATE_BOOTSTRAP_LATEST_VERSION",
+    "currentOperation": "AWAIT_MERGED_PASSIVE_PREVIEW_REQUEST",
     "environment": "npm-stage",
     "passivePreviewPath": ".github/workflows/release-passive-previews.yml",
     "trustedPublisherConfigured": true,
@@ -54,7 +59,7 @@
     "pack install discovery uninstall and exact-version rollback smoke",
     "explicit npm preview dist-tag"
   ],
-  "previewRequestEligible": false,
+  "previewRequestEligible": true,
   "publicationEligible": false,
   "promotionEligible": false
 }

--- a/distribution/npm-stage-contract.json
+++ b/distribution/npm-stage-contract.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "state": "PACK_VERIFY_READY_OWNER_AND_TRUST_MISSING",
+  "state": "OWNER_CONFIGURED_BOOTSTRAP_DEPRECATION_REQUIRED",
   "trackingIssue": "https://github.com/Cratis/Workflows/issues/70",
   "package": {
     "fixtureName": "@cratis/ai",
@@ -8,31 +8,53 @@
     "fixturePrivate": true,
     "lifecycleScriptsAllowed": false,
     "dependenciesAllowed": false,
-    "publicOwnershipConfirmed": false
+    "publicOwnershipConfirmed": true,
+    "ownerSetupEvidence": {
+      "confirmedBy": "woksin.sindre",
+      "confirmedOn": "2026-08-27",
+      "publicRegistryStatusVerified": true,
+      "writeCollaboratorVerified": true,
+      "trustedPublisherConfiguration": "owner-attested"
+    },
+    "bootstrapVersion": "0.0.0-bootstrap.0",
+    "bootstrapDeprecationRequired": true,
+    "bootstrapDeprecationConfirmed": false,
+    "latestTagPolicy": "stable-or-deprecated-bootstrap-never-preview",
+    "latestTagSafe": false
   },
   "workflow": {
     "path": ".github/workflows/distribution-npm-stage.yml",
     "productionPath": ".github/workflows/release-approved-ai-profiles.yml",
-    "currentOperation": "VERIFY_PRIVATE_FIXTURE",
+    "currentOperation": "DEPRECATE_BOOTSTRAP_LATEST_VERSION",
     "environment": "npm-stage",
-    "trustedPublisherConfigured": false,
-    "oidcEnabled": false,
+    "passivePreviewPath": ".github/workflows/release-passive-previews.yml",
+    "trustedPublisherConfigured": true,
+    "trustedPublisher": {
+      "provider": "github-actions",
+      "organization": "Cratis",
+      "repository": "AI",
+      "workflowFilename": "release-passive-previews.yml",
+      "environment": "npm-stage",
+      "allowedOperation": "npm publish"
+    },
+    "oidcEnabled": true,
     "stagePublishEnabled": false,
-    "publicPublishEnabled": false,
+    "publicPublishEnabled": true,
     "publishAutomaticallyAfterMergedReleaseRequestAndCanary": true
   },
-  "futureStageRequirements": [
-    "approved public target and source contract",
-    "public package ownership",
-    "exact npm trusted-publisher workflow registration",
+  "previewPublicationControls": [
+    "approved public target and immutable source contract",
+    "append-only request bound to exact source revision and digest",
     "Node 22.14 or newer",
     "npm 11.5.1 or newer",
     "npm-stage environment approval",
-    "id-token write only in the stage job",
-    "unpacked allowlist and zero lifecycle scripts",
-    "provenance and checksum verification",
-    "reject and rollback evidence"
+    "id-token write only in the publish job",
+    "unpacked allowlist and zero lifecycle scripts or dependencies",
+    "provenance checksum and exact-artifact verification",
+    "pack install discovery uninstall and exact-version rollback smoke",
+    "explicit npm preview dist-tag"
   ],
+  "previewRequestEligible": false,
   "publicationEligible": false,
   "promotionEligible": false
 }

--- a/distribution/preview-readiness.json
+++ b/distribution/preview-readiness.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "generatedBy": "tooling/preview-readiness.mjs",
-  "state": "OWNER_SETUP_REQUIRED",
+  "state": "READY_FOR_PREVIEW_REQUEST",
   "lane": "passive-preview",
   "assuranceMode": "basic",
   "profileId": "public-fundamentals",
@@ -10,18 +10,13 @@
     "cratis-fundamentals-concept"
   ],
   "staticCandidateReady": true,
-  "blockers": [
-    {
-      "code": "npm-latest-tag-unsafe",
-      "reason": "The npm-forced bootstrap latest version is not confirmed deprecated."
-    }
-  ],
+  "blockers": [],
   "governedAssurance": {
     "requiredForPreview": false,
     "availableForGraduation": true,
     "readinessPath": "catalog/v2/release-readiness.json"
   },
-  "previewRequestEligible": false,
+  "previewRequestEligible": true,
   "publicationEligible": false,
   "supportGranted": false
 }

--- a/distribution/preview-readiness.json
+++ b/distribution/preview-readiness.json
@@ -12,20 +12,8 @@
   "staticCandidateReady": true,
   "blockers": [
     {
-      "code": "package-ownership-unconfirmed",
-      "reason": "Exact npm package ownership is not confirmed."
-    },
-    {
-      "code": "trusted-publisher-not-configured",
-      "reason": "The exact npm trusted publisher is not configured."
-    },
-    {
-      "code": "oidc-not-enabled",
-      "reason": "OIDC publication is not enabled."
-    },
-    {
-      "code": "public-preview-publish-disabled",
-      "reason": "Public preview publication remains disabled."
+      "code": "npm-latest-tag-unsafe",
+      "reason": "The npm-forced bootstrap latest version is not confirmed deprecated."
     }
   ],
   "governedAssurance": {

--- a/distribution/preview-readiness.schema.json
+++ b/distribution/preview-readiness.schema.json
@@ -23,7 +23,7 @@
         "additionalProperties": false,
         "required": ["code", "reason"],
         "properties": {
-          "code": { "enum": ["package-ownership-unconfirmed", "trusted-publisher-not-configured", "oidc-not-enabled", "public-preview-publish-disabled", "preview-release-workflow-not-implemented"] },
+          "code": { "enum": ["package-ownership-unconfirmed", "trusted-publisher-not-configured", "oidc-not-enabled", "public-preview-publish-disabled", "npm-latest-tag-unsafe", "preview-release-workflow-not-implemented"] },
           "reason": { "type": "string", "minLength": 1 }
         }
       }

--- a/tooling/preview-readiness.mjs
+++ b/tooling/preview-readiness.mjs
@@ -49,16 +49,10 @@ function addBlocker(blockers, code, reason) {
     blockers.push({ code, reason });
 }
 
-export function buildPreviewReadiness(
-    repositoryRoot = defaultRepositoryRoot,
-) {
+export function buildPreviewReadiness(repositoryRoot = defaultRepositoryRoot) {
     const root = resolve(repositoryRoot);
     const lanes = readJson(root, "distribution/assurance-lanes.json");
-    validateWithSchema(
-        root,
-        lanes,
-        "distribution/assurance-lanes.schema.json",
-    );
+    validateWithSchema(root, lanes, "distribution/assurance-lanes.schema.json");
     const profileCatalog = readJson(root, "distribution/profile-catalog.json");
     const targets = readJson(root, "catalog/v2/targets.json").targets;
     const artifacts = readJson(root, "catalog/v2/artifacts.json").artifacts;
@@ -114,10 +108,7 @@ export function buildPreviewReadiness(
     )
         throw new Error("Fundamentals preview artifact changed");
     const blockers = [];
-    if (
-        npmStage.package.productionName !==
-        lanes.selectedPreview.packageName
-    )
+    if (npmStage.package.productionName !== lanes.selectedPreview.packageName)
         throw new Error("Preview production package name is not reconciled");
     if (npmStage.package.publicOwnershipConfirmed !== true)
         addBlocker(
@@ -142,6 +133,12 @@ export function buildPreviewReadiness(
             blockers,
             "public-preview-publish-disabled",
             "Public preview publication remains disabled.",
+        );
+    if (npmStage.package.latestTagSafe !== true)
+        addBlocker(
+            blockers,
+            "npm-latest-tag-unsafe",
+            "The npm-forced bootstrap latest version is not confirmed deprecated.",
         );
     const previewWorkflowPath = join(
         root,

--- a/tooling/specs/assurance-lanes.spec.mjs
+++ b/tooling/specs/assurance-lanes.spec.mjs
@@ -56,11 +56,7 @@ test("assurance lanes keep preview lightweight and support governed", () => {
     );
     assert.equal(policy.defaultLane, "candidate-review");
     assert.deepEqual(
-        policy.lanes.map((lane) => [
-            lane.id,
-            lane.assuranceMode,
-            lane.channel,
-        ]),
+        policy.lanes.map((lane) => [lane.id, lane.assuranceMode, lane.channel]),
         [
             ["candidate-review", "basic", "candidate"],
             ["passive-preview", "basic", "preview"],
@@ -83,7 +79,7 @@ test("assurance lanes keep preview lightweight and support governed", () => {
     assert.equal(policy.advancedAssurance.status, "SIDELINED_AVAILABLE");
 });
 
-test("current passive preview is statically ready and blocked only on basic owner setup", () => {
+test("current passive preview records owner setup but blocks an undeprecated bootstrap", () => {
     const first = generatePreviewReadiness();
     const second = generatePreviewReadiness();
     assert.deepEqual(second, first);
@@ -94,12 +90,7 @@ test("current passive preview is statically ready and blocked only on basic owne
     assert.equal(first.governedAssurance.availableForGraduation, true);
     assert.deepEqual(
         first.blockers.map((blocker) => blocker.code),
-        [
-            "package-ownership-unconfirmed",
-            "trusted-publisher-not-configured",
-            "oidc-not-enabled",
-            "public-preview-publish-disabled",
-        ],
+        ["npm-latest-tag-unsafe"],
     );
     assert.equal(first.previewRequestEligible, false);
     assert.equal(first.publicationEligible, false);
@@ -113,6 +104,7 @@ test("basic owner setup can admit a preview request without granting support", (
         const npm = readJson(root, "distribution/npm-stage-contract.json");
         npm.package.productionName = "@cratis/ai-fundamentals";
         npm.package.publicOwnershipConfirmed = true;
+        npm.package.latestTagSafe = true;
         npm.workflow.trustedPublisherConfigured = true;
         npm.workflow.oidcEnabled = true;
         npm.workflow.publicPublishEnabled = true;

--- a/tooling/specs/assurance-lanes.spec.mjs
+++ b/tooling/specs/assurance-lanes.spec.mjs
@@ -79,20 +79,17 @@ test("assurance lanes keep preview lightweight and support governed", () => {
     assert.equal(policy.advancedAssurance.status, "SIDELINED_AVAILABLE");
 });
 
-test("current passive preview records owner setup but blocks an undeprecated bootstrap", () => {
+test("current passive preview is ready for one exact request without granting support", () => {
     const first = generatePreviewReadiness();
     const second = generatePreviewReadiness();
     assert.deepEqual(second, first);
-    assert.equal(first.state, "OWNER_SETUP_REQUIRED");
+    assert.equal(first.state, "READY_FOR_PREVIEW_REQUEST");
     assert.equal(first.staticCandidateReady, true);
     assert.equal(first.assuranceMode, "basic");
     assert.equal(first.governedAssurance.requiredForPreview, false);
     assert.equal(first.governedAssurance.availableForGraduation, true);
-    assert.deepEqual(
-        first.blockers.map((blocker) => blocker.code),
-        ["npm-latest-tag-unsafe"],
-    );
-    assert.equal(first.previewRequestEligible, false);
+    assert.deepEqual(first.blockers, []);
+    assert.equal(first.previewRequestEligible, true);
     assert.equal(first.publicationEligible, false);
     assert.equal(first.supportGranted, false);
 });

--- a/tooling/specs/distribution-npm-stage.spec.mjs
+++ b/tooling/specs/distribution-npm-stage.spec.mjs
@@ -22,19 +22,50 @@ const workflow = readFileSync(
     "utf8",
 );
 
-test("npm stage contract keeps ownership OIDC and publication blocked", () => {
-    assert.equal(contract.state, "PACK_VERIFY_READY_OWNER_AND_TRUST_MISSING");
-    assert.equal(contract.package.fixtureName, "@cratis/ai");
+test("npm stage contract records owner setup while bootstrap deprecation remains", () => {
     assert.equal(
-        contract.package.productionName,
-        "@cratis/ai-fundamentals",
+        contract.state,
+        "OWNER_CONFIGURED_BOOTSTRAP_DEPRECATION_REQUIRED",
     );
+    assert.equal(contract.package.fixtureName, "@cratis/ai");
+    assert.equal(contract.package.productionName, "@cratis/ai-fundamentals");
     assert.equal(contract.package.fixturePrivate, true);
-    assert.equal(contract.package.publicOwnershipConfirmed, false);
-    assert.equal(contract.workflow.trustedPublisherConfigured, false);
-    assert.equal(contract.workflow.oidcEnabled, false);
+    assert.equal(contract.package.publicOwnershipConfirmed, true);
+    assert.equal(contract.package.bootstrapVersion, "0.0.0-bootstrap.0");
+    assert.equal(contract.package.bootstrapDeprecationRequired, true);
+    assert.equal(contract.package.bootstrapDeprecationConfirmed, false);
+    assert.equal(
+        contract.package.latestTagPolicy,
+        "stable-or-deprecated-bootstrap-never-preview",
+    );
+    assert.equal(contract.package.latestTagSafe, false);
+    assert.deepEqual(contract.package.ownerSetupEvidence, {
+        confirmedBy: "woksin.sindre",
+        confirmedOn: "2026-08-27",
+        publicRegistryStatusVerified: true,
+        writeCollaboratorVerified: true,
+        trustedPublisherConfiguration: "owner-attested",
+    });
+    assert.equal(contract.workflow.trustedPublisherConfigured, true);
+    assert.deepEqual(contract.workflow.trustedPublisher, {
+        provider: "github-actions",
+        organization: "Cratis",
+        repository: "AI",
+        workflowFilename: "release-passive-previews.yml",
+        environment: "npm-stage",
+        allowedOperation: "npm publish",
+    });
+    assert.equal(contract.workflow.oidcEnabled, true);
     assert.equal(contract.workflow.stagePublishEnabled, false);
-    assert.equal(contract.workflow.publicPublishEnabled, false);
+    assert.equal(contract.workflow.publicPublishEnabled, true);
+    assert.equal(
+        contract.workflow.currentOperation,
+        "DEPRECATE_BOOTSTRAP_LATEST_VERSION",
+    );
+    assert.equal(
+        contract.workflow.passivePreviewPath,
+        ".github/workflows/release-passive-previews.yml",
+    );
     assert.equal(
         contract.workflow
             .publishAutomaticallyAfterMergedReleaseRequestAndCanary,
@@ -44,6 +75,7 @@ test("npm stage contract keeps ownership OIDC and publication blocked", () => {
         contract.workflow.productionPath,
         ".github/workflows/release-approved-ai-profiles.yml",
     );
+    assert.equal(contract.previewRequestEligible, false);
     assert.equal(contract.publicationEligible, false);
     assert.equal(contract.promotionEligible, false);
 });

--- a/tooling/specs/distribution-npm-stage.spec.mjs
+++ b/tooling/specs/distribution-npm-stage.spec.mjs
@@ -22,23 +22,25 @@ const workflow = readFileSync(
     "utf8",
 );
 
-test("npm stage contract records owner setup while bootstrap deprecation remains", () => {
-    assert.equal(
-        contract.state,
-        "OWNER_CONFIGURED_BOOTSTRAP_DEPRECATION_REQUIRED",
-    );
+test("npm stage contract admits an exact passive preview request", () => {
+    assert.equal(contract.state, "PASSIVE_PREVIEW_REQUEST_READY");
     assert.equal(contract.package.fixtureName, "@cratis/ai");
     assert.equal(contract.package.productionName, "@cratis/ai-fundamentals");
     assert.equal(contract.package.fixturePrivate, true);
     assert.equal(contract.package.publicOwnershipConfirmed, true);
     assert.equal(contract.package.bootstrapVersion, "0.0.0-bootstrap.0");
     assert.equal(contract.package.bootstrapDeprecationRequired, true);
-    assert.equal(contract.package.bootstrapDeprecationConfirmed, false);
+    assert.equal(contract.package.bootstrapDeprecationConfirmed, true);
+    assert.deepEqual(contract.package.bootstrapDeprecationEvidence, {
+        verifiedOn: "2026-08-27",
+        registryReadbackVerified: true,
+        cliExitReconciled: "E422_WRITE_PERSISTED",
+    });
     assert.equal(
         contract.package.latestTagPolicy,
         "stable-or-deprecated-bootstrap-never-preview",
     );
-    assert.equal(contract.package.latestTagSafe, false);
+    assert.equal(contract.package.latestTagSafe, true);
     assert.deepEqual(contract.package.ownerSetupEvidence, {
         confirmedBy: "woksin.sindre",
         confirmedOn: "2026-08-27",
@@ -60,7 +62,7 @@ test("npm stage contract records owner setup while bootstrap deprecation remains
     assert.equal(contract.workflow.publicPublishEnabled, true);
     assert.equal(
         contract.workflow.currentOperation,
-        "DEPRECATE_BOOTSTRAP_LATEST_VERSION",
+        "AWAIT_MERGED_PASSIVE_PREVIEW_REQUEST",
     );
     assert.equal(
         contract.workflow.passivePreviewPath,
@@ -75,7 +77,7 @@ test("npm stage contract records owner setup while bootstrap deprecation remains
         contract.workflow.productionPath,
         ".github/workflows/release-approved-ai-profiles.yml",
     );
-    assert.equal(contract.previewRequestEligible, false);
+    assert.equal(contract.previewRequestEligible, true);
     assert.equal(contract.publicationEligible, false);
     assert.equal(contract.promotionEligible, false);
 });

--- a/tooling/specs/fundamentals-preview-npm.spec.mjs
+++ b/tooling/specs/fundamentals-preview-npm.spec.mjs
@@ -17,7 +17,9 @@ import {
 } from "../smoke-fundamentals-preview-npm.mjs";
 
 function withTemporaryDirectory(callback) {
-    const root = mkdtempSync(join(tmpdir(), "cratis-fundamentals-preview-npm-"));
+    const root = mkdtempSync(
+        join(tmpdir(), "cratis-fundamentals-preview-npm-"),
+    );
     try {
         return callback(root);
     } finally {
@@ -97,7 +99,9 @@ test("publishable Fundamentals preview npm asset is deterministic and scriptless
                 skills: ["./skills"],
             },
         });
-        assert(files.has("package/skills/cratis-fundamentals-concept/SKILL.md"));
+        assert(
+            files.has("package/skills/cratis-fundamentals-concept/SKILL.md"),
+        );
         const checksums = readFileSync(join(firstRoot, "SHA256SUMS"), "utf8");
         assert(checksums.includes(first.filename));
         assert(checksums.includes("preview-npm-manifest.json"));
@@ -173,7 +177,7 @@ test("publishable preview staging requires exact request source authority", () =
     });
 });
 
-test("current owner setup blocks publishable preview staging", () => {
+test("an empty request registry blocks publishable preview staging", () => {
     withTemporaryDirectory((root) => {
         assert.throws(
             () =>

--- a/tooling/specs/workflow-safety.spec.mjs
+++ b/tooling/specs/workflow-safety.spec.mjs
@@ -157,6 +157,13 @@ test("passive preview publication is request readiness and environment gated", (
     for (const required of [
         "name: preview / verify",
         "distribution/preview-requests.json",
+        "distribution/npm-stage-contract.json",
+        "Verify registry dist-tag safety",
+        'latest=$(npm view "$package" dist-tags.latest)',
+        "0.0.0-bootstrap.0",
+        'deprecated=$(npm view "$package@$latest" deprecated)',
+        "Bootstrap only. Install an exact preview version or use the preview dist-tag.",
+        "*-*",
         "preview_allowed",
         "git diff --quiet",
         "request_count",
@@ -197,6 +204,7 @@ test("passive preview publication is request readiness and environment gated", (
         "pull-requests: write",
         "supportGranted: true",
         "workflow_dispatch:",
+        "dist-tags.latest 2>/dev/null || true",
         "0.1.0-preview.1');",
     ])
         assert.equal(workflow.includes(forbidden), false, forbidden);
@@ -267,10 +275,7 @@ test("generated Distribution updates preserve the reviewed control plane", () =>
         "utf8",
     );
     const contract = JSON.parse(
-        readFileSync(
-            "distribution/generated-repository-contract.json",
-            "utf8",
-        ),
+        readFileSync("distribution/generated-repository-contract.json", "utf8"),
     );
     assert(
         workflow.includes(
@@ -303,12 +308,11 @@ test("legacy propagation entry points are removed", () => {
     ])
         assert.equal(existsSync(path), false, path);
     for (const filename of readdirSync(".github/workflows")) {
-        const workflow = readFileSync(
-            `.github/workflows/${filename}`,
-            "utf8",
-        );
+        const workflow = readFileSync(`.github/workflows/${filename}`, "utf8");
         assert.equal(
-            workflow.includes(".github/scripts/propagate-copilot-instructions.sh"),
+            workflow.includes(
+                ".github/scripts/propagate-copilot-instructions.sh",
+            ),
             false,
             filename,
         );
@@ -323,13 +327,9 @@ test("merge-reachable reusable workflows are pinned and do not inherit secrets",
     assert.equal(cleanup.includes("secrets: inherit"), false);
     assert(cleanup.includes("PAT_WORKFLOWS: ${{ secrets.PAT_WORKFLOWS }}"));
     for (const filename of readdirSync(".github/workflows")) {
-        const workflow = readFileSync(
-            `.github/workflows/${filename}`,
-            "utf8",
-        );
-        const references = workflow.match(
-            /uses: Cratis\/Workflows\/[^\s]+@([^\s]+)/g,
-        ) ?? [];
+        const workflow = readFileSync(`.github/workflows/${filename}`, "utf8");
+        const references =
+            workflow.match(/uses: Cratis\/Workflows\/[^\s]+@([^\s]+)/g) ?? [];
         for (const reference of references)
             assert.match(reference, /@[0-9a-f]{40}$/, filename);
     }


### PR DESCRIPTION
# Summary

Records the completed npm owner and trusted-publisher setup for the first passive Fundamentals preview. npm's forced bootstrap `latest` remains inert and deprecated; live verification prevents any preview or other prerelease from becoming `latest`.

## Added

- Enforce live npm dist-tag safety before preview review or publication. (#181)

## Changed

- Admit one exact append-only Fundamentals preview request through protected OIDC publication without granting support. (#181)
