### PR TITLE
Publish the first Fundamentals passive preview

### DIFF
--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "0769ff9beb36b37d262a3e1f77bcb6fbd98bdf0936973b2b5b70f3f1e25607d1",
+  "indexDigest": "cc764be2b2ceeeae414ea1af93ab1c23a23edd3909743c73bf86c80d467aadc8",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/distribution/preview-requests.json
+++ b/distribution/preview-requests.json
@@ -1,5 +1,18 @@
 {
   "schemaVersion": 1,
   "defaultPolicy": "deny",
-  "requests": []
+  "requests": [
+    {
+      "id": "public-fundamentals-0-1-0-preview-1",
+      "state": "preview-on-merge",
+      "profileId": "public-fundamentals",
+      "packageName": "@cratis/ai-fundamentals",
+      "version": "0.1.0-preview.1",
+      "sourceRevision": "b53caa555b9a3f05ba1462b86202fe3ccb8a9470",
+      "sourceContentDigest": "9e537c48a95c414709008c69ebfb616354d60992578ddd9da3d7dc7308c42caa",
+      "assuranceMode": "basic",
+      "supportClaim": false,
+      "releaseNotes": "First unsupported public preview of passive Cratis Fundamentals concept and Chronicle event-source identity guidance."
+    }
+  ]
 }

--- a/tooling/specs/fundamentals-preview-npm.spec.mjs
+++ b/tooling/specs/fundamentals-preview-npm.spec.mjs
@@ -50,6 +50,12 @@ const ready = Object.freeze({
     supportGranted: false,
 });
 
+const currentRequest = Object.freeze(
+    JSON.parse(
+        readFileSync("distribution/preview-requests.json", "utf8"),
+    ).requests.at(-1),
+);
+
 test("publishable Fundamentals preview npm asset is deterministic and scriptless", () => {
     withTemporaryDirectory((root) => {
         const firstRoot = join(root, "first");
@@ -177,16 +183,17 @@ test("publishable preview staging requires exact request source authority", () =
     });
 });
 
-test("an empty request registry blocks publishable preview staging", () => {
+test("current request stages the exact publishable preview", () => {
     withTemporaryDirectory((root) => {
-        assert.throws(
-            () =>
-                packageFundamentalsPreviewNpm({
-                    outputRoot: join(root, "blocked"),
-                    version: "0.1.0-preview.1",
-                }),
-            /No passive preview request exists/,
-        );
+        const manifest = packageFundamentalsPreviewNpm({
+            outputRoot: join(root, "current-request"),
+            version: currentRequest.version,
+        });
+        assert.equal(manifest.requestId, currentRequest.id);
+        assert.equal(manifest.version, currentRequest.version);
+        assert.equal(manifest.sourceRevision, currentRequest.sourceRevision);
+        assert.equal(manifest.previewPublicationEligible, true);
+        assert.equal(manifest.supportGranted, false);
     });
 });
 

--- a/tooling/specs/preview-request-validation.spec.mjs
+++ b/tooling/specs/preview-request-validation.spec.mjs
@@ -11,19 +11,19 @@ function readJson(path) {
     return JSON.parse(readFileSync(path, "utf8"));
 }
 
-test("preview request catalog is empty closed and valid before owner setup", () => {
+test("current preview request catalog is closed and valid", () => {
     assert.deepEqual(validatePreviewRequests(), []);
     assert.deepEqual(
         validatePreviewRequests(undefined, { baseRevision: "HEAD" }),
         [],
     );
-    assert(
-        validatePreviewRequests(undefined, { requireRequest: true }).some(
-            (error) => error.includes("At least one passive preview request"),
-        ),
+    assert.deepEqual(
+        validatePreviewRequests(undefined, { requireRequest: true }),
+        [],
     );
-    const requests = readJson("distribution/preview-requests.json");
-    assert.deepEqual(requests.requests, []);
+    const requests = readJson("distribution/preview-requests.json").requests;
+    assert(requests.length > 0);
+    assert(requests.every((request) => request.supportClaim === false));
 });
 
 test("preview request schema rejects support claims unknown fields and multiple releases", () => {


### PR DESCRIPTION
# Summary

Requests the first unsupported public Fundamentals preview from the exact previously reviewed source revision and content digest. Publication remains protected by the basic preview gate, npm OIDC, the `npm-stage` environment, and the explicit `preview` dist-tag.

## Added

- Request `@cratis/ai-fundamentals@0.1.0-preview.1` with no support claim. (#181)

## Changed

- Validate release specs against the current append-only preview request registry. (#181)
