### PR TITLE
Use normal labeled releases for AI packages

### DIFF
--- a/.github/workflows/release-passive-previews.yml
+++ b/.github/workflows/release-passive-previews.yml
@@ -1,170 +1,53 @@
 # Copyright (c) Cratis. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-name: Release Passive Previews
+# The filename is retained because npm trusted publishing binds it exactly.
+name: Publish Fundamentals AI Package
 
 on:
-  pull_request:
-    paths:
-      - "distribution/preview-requests.json"
-      - "distribution/preview-requests.schema.json"
-      - "distribution/npm-stage-contract.json"
-      - ".github/workflows/release-passive-previews.yml"
-      - "tooling/package-fundamentals-preview-*.mjs"
-      - "tooling/preview-*.mjs"
   push:
     branches: ["main"]
     paths:
-      - "distribution/preview-requests.json"
+      - ".github/workflows/release-passive-previews.yml"
+      - "catalog/v2/sources.json"
+      - "catalog/v2/targets.json"
+      - "distribution/npm-stage-contract.json"
+      - "distribution/profile-catalog.json"
+      - "tooling/package-fundamentals-preview-assets.mjs"
+      - "tooling/package-fundamentals-preview-npm.mjs"
+      - "tooling/passive-profile-adapters.mjs"
+      - "tooling/smoke-fundamentals-preview-npm.mjs"
+
+concurrency:
+  group: fundamentals-ai-package-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
 
-concurrency:
-  group: passive-preview-${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
-  verify:
-    name: preview / verify
+  release:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: read
     outputs:
-      preview_allowed: ${{ steps.authorize.outputs.preview_allowed }}
-      version: ${{ steps.request.outputs.version }}
-      artifact_sha256: ${{ steps.stage.outputs.artifact_sha256 }}
+      publish: ${{ steps.release.outputs.should-publish }}
+      version: ${{ steps.release.outputs.version }}
     steps:
-      - name: Check out complete immutable history
+      - name: Check out the canonical repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
           persist-credentials: false
 
-      - name: Use Node.js 24
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-          package-manager-cache: false
-
-      - name: Verify registry dist-tag safety
-        run: |
-          set -euo pipefail
-          package=@cratis/ai-fundamentals
-          latest=$(npm view "$package" dist-tags.latest)
-          if [[ -z "$latest" ]]; then
-            exit 0
-          fi
-          if [[ "$latest" == "0.0.0-bootstrap.0" ]]; then
-            deprecated=$(npm view "$package@$latest" deprecated)
-            test "$deprecated" = \
-              "Bootstrap only. Install an exact preview version or use the preview dist-tag."
-            exit 0
-          fi
-          if [[ "$latest" == *-* || ! "$latest" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "The npm latest tag must select a stable version or the deprecated bootstrap: $latest" >&2
-            exit 1
-          fi
-
-      - name: deterministic-generation
-        id: readiness
-        run: |
-          set -euo pipefail
-          node tooling/preview-readiness.mjs
-          git diff --exit-code -- distribution/preview-readiness.json
-          state=$(node -p "require('./distribution/preview-readiness.json').state")
-          test "$(node -p "require('./distribution/preview-readiness.json').supportGranted")" = "false"
-          echo "state=$state" >> "$GITHUB_OUTPUT"
-
-      - name: schema-validation
-        id: request
-        env:
-          BASE_REVISION: ${{ github.event.pull_request.base.sha || github.event.before }}
-        run: |
-          set -euo pipefail
-          arguments=(--base "$BASE_REVISION")
-          request_present=false
-          request_count=$(node -p "require('./distribution/preview-requests.json').requests.length")
-          if ! git diff --quiet "$BASE_REVISION" -- distribution/preview-requests.json &&
-             [ "$request_count" -gt 0 ]; then
-            arguments+=(--require-request)
-            request_present=true
-          fi
-          node tooling/preview-request-validation.mjs "${arguments[@]}"
-          echo "request_present=$request_present" >> "$GITHUB_OUTPUT"
-          if [ "$request_present" = "true" ]; then
-            version=$(node - <<'NODE'
-          const requests = require('./distribution/preview-requests.json').requests;
-          if (requests.length === 0) process.exit(1);
-          process.stdout.write(requests.at(-1).version);
-          NODE
-            )
-            echo "version=$version" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Authorize exact reviewed request
-        id: authorize
-        env:
-          READINESS_STATE: ${{ steps.readiness.outputs.state }}
-          REQUEST_PRESENT: ${{ steps.request.outputs.request_present }}
-        run: |
-          set -euo pipefail
-          if [ "$READINESS_STATE" = "READY_FOR_PREVIEW_REQUEST" ] &&
-             [ "$REQUEST_PRESENT" = "true" ]; then
-            echo "preview_allowed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "preview_allowed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: static-contract-validation
-        run: node tooling/validate-catalogs.mjs --basic
-
-      - name: secret-and-path-scanning
-        run: |
-          node --test tooling/specs/public-artifact-materializer.spec.mjs
-          node --test tooling/specs/fundamentals-preview-assets.spec.mjs
-
-      - name: checksums
-        if: steps.request.outputs.request_present == 'true'
-        id: stage
-        env:
-          VERSION: ${{ steps.request.outputs.version }}
-        run: |
-          set -euo pipefail
-          node tooling/package-fundamentals-preview-npm.mjs \
-            "$RUNNER_TEMP/fundamentals-preview-npm" "$VERSION"
-          (cd "$RUNNER_TEMP/fundamentals-preview-npm" && sha256sum -c SHA256SUMS)
-          archive="$RUNNER_TEMP/fundamentals-preview-npm/cratis-ai-fundamentals-$VERSION.tgz"
-          echo "artifact_sha256=$(sha256sum "$archive" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-
-      - name: owner-review
-        run: |
-          echo "The protected pull request and environment provide the owner review boundary."
-
-      - name: basic-pack-install-discovery-uninstall-smoke
-        if: steps.request.outputs.request_present == 'true'
-        env:
-          VERSION: ${{ steps.request.outputs.version }}
-        run: |
-          node tooling/smoke-fundamentals-preview-npm.mjs \
-            "$RUNNER_TEMP/fundamentals-preview-npm/cratis-ai-fundamentals-$VERSION.tgz" \
-            "$VERSION"
-
-      - name: exact-version-rollback
-        if: steps.request.outputs.request_present == 'true'
-        run: node --test tooling/specs/fundamentals-preview-npm.spec.mjs
-
-      - name: Upload preview review assets
-        if: github.event_name == 'pull_request' && steps.request.outputs.request_present == 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v7.0.1
-        with:
-          name: fundamentals-${{ steps.request.outputs.version }}-preview-review
-          path: ${{ runner.temp }}/fundamentals-preview-npm
-          if-no-files-found: error
-          retention-days: 7
+      - name: Determine release from the merged pull request
+        id: release
+        uses: cratis/release-action@bdaded342eb31b52b48dca0611f0214794f8c655 # v1.2.0
 
   publish:
-    if: github.event_name == 'push' && needs.verify.outputs.preview_allowed == 'true'
-    needs: verify
+    if: needs.release.outputs.publish == 'true'
+    needs: release
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: npm-stage
@@ -172,7 +55,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Check out complete immutable history
+      - name: Check out the canonical repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
@@ -185,43 +68,26 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
-      - name: Verify trusted-publishing npm CLI
-        run: |
-          set -euo pipefail
-          npm_version=$(npm --version)
-          node -e '
-            const [major, minor, patch] = process.argv[1].split(".").map(Number);
-            if (major < 11 || (major === 11 && minor < 5) ||
-                (major === 11 && minor === 5 && patch < 1)) process.exit(1);
-          ' "$npm_version"
-
-      - name: Revalidate preview request and readiness
+      - name: Build and verify the exact package
         env:
-          BASE_REVISION: ${{ github.event.before }}
+          VERSION: ${{ needs.release.outputs.version }}
         run: |
           set -euo pipefail
-          node tooling/preview-readiness.mjs
-          test "$(node -p "require('./distribution/preview-readiness.json').state")" = \
-            "READY_FOR_PREVIEW_REQUEST"
-          node tooling/preview-request-validation.mjs \
-            --require-request --base "$BASE_REVISION"
-
-      - name: Stage publishable passive preview
-        env:
-          VERSION: ${{ needs.verify.outputs.version }}
-          EXPECTED_SHA256: ${{ needs.verify.outputs.artifact_sha256 }}
-        run: |
-          set -euo pipefail
+          [[ "$VERSION" =~ ^0\.[0-9]+\.[0-9]+$ ]]
           node tooling/package-fundamentals-preview-npm.mjs \
-            "$RUNNER_TEMP/fundamentals-preview-npm" "$VERSION"
-          (cd "$RUNNER_TEMP/fundamentals-preview-npm" && sha256sum -c SHA256SUMS)
-          archive="$RUNNER_TEMP/fundamentals-preview-npm/cratis-ai-fundamentals-$VERSION.tgz"
-          test "$(sha256sum "$archive" | cut -d' ' -f1)" = "$EXPECTED_SHA256"
+            "$RUNNER_TEMP/fundamentals-npm" "$VERSION" release
+          (cd "$RUNNER_TEMP/fundamentals-npm" && sha256sum -c SHA256SUMS)
+          manifest="$RUNNER_TEMP/fundamentals-npm/preview-npm-manifest.json"
+          test "$(node -p "require('$manifest').distTag")" = "latest"
+          test "$(node -p "require('$manifest').supportGranted")" = "false"
+          node tooling/smoke-fundamentals-preview-npm.mjs \
+            "$RUNNER_TEMP/fundamentals-npm/cratis-ai-fundamentals-$VERSION.tgz" \
+            "$VERSION"
 
-      - name: Publish exact passive preview through OIDC
+      - name: Publish through npm trusted OIDC
         env:
-          VERSION: ${{ needs.verify.outputs.version }}
+          VERSION: ${{ needs.release.outputs.version }}
         run: |
           set -euo pipefail
-          archive="$RUNNER_TEMP/fundamentals-preview-npm/cratis-ai-fundamentals-$VERSION.tgz"
-          npm publish --provenance --access public --tag preview "$archive"
+          archive="$RUNNER_TEMP/fundamentals-npm/cratis-ai-fundamentals-$VERSION.tgz"
+          npm publish --provenance --access public --tag latest "$archive"

--- a/.github/workflows/verify-semver-label.yml
+++ b/.github/workflows/verify-semver-label.yml
@@ -1,0 +1,20 @@
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+name: Verify Release Intent
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-intent-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-intent:
+    uses: Cratis/Workflows/.github/workflows/verify-release-intent.yml@1e5319ff574ce61a771ec5199527b917204a13b5

--- a/Documentation/releasing-cratis-ai.md
+++ b/Documentation/releasing-cratis-ai.md
@@ -1,37 +1,30 @@
 # Release Cratis AI
 
-> **The passive preview lane is ready for one exact request; governed S10 remains blocked.**
-Candidate review is available now. Passive previews use the basic lane; stable
-support uses the sidelined governed lane and its complete S9/S10 assurance.
+> **Normal support-free `0.x.y` package releases are enabled; governed S10 remains blocked.**
+Candidate review is available now. Passive `0.x.y` packages use the basic lane;
+a `1.0.0` release and stable support use the governed lane and its complete
+S9/S10 assurance.
 
-A merged release pull request is the recurring human release approval. Do not
-run a second manual publication, promotion, or rollout approval after merge.
-A passive preview can never claim `supported`; that claim requires graduation to
-governed assurance.
+A merged, labeled release pull request is the sole recurring human approval.
+There is no second environment approval. A `0.x.y` package can never claim
+`supported`; that claim requires graduation to governed assurance.
 
 One-time external App, registry, canary-scope, and marketplace account setup is
 tracked in [AI#181](https://github.com/Cratis/AI/issues/181).
 
-## Passive preview lane
+## Passive `0.x.y` release lane
 
-`public-fundamentals` is the selected first preview. The public
-`@cratis/ai-fundamentals` package exists, and its exact GitHub Actions trusted
-publisher, OIDC permission, and protected `npm-stage` environment are configured.
-Generated [`preview-readiness.json`](../distribution/preview-readiness.json) is
-independent of S10. npm assigns `latest` to a package's first publication even
-when another tag was requested and currently rejects removing it. The inert
-bootstrap version now carries the required deprecation warning, so one reviewed
-preview request is eligible without granting publication or support by itself.
+`public-fundamentals` is the first package. Pull requests must carry exactly one
+`major`, `minor`, `patch`, or `no-release` label. The shared Cratis release action
+derives the next version after merge; while this lane is active, publication
+accepts only `0.x.y`. The package is generated from the exact immutable source,
+passes checksum and install/discovery/uninstall verification, and publishes to
+npm `latest` through the main-only `npm-stage` OIDC environment.
 
-The existing Fundamentals asset workflow remains packaging-only. The separate
-**Release Passive Previews** workflow validates an append-only exact request,
-runs every anchored basic check, stages a public scriptless/dependency-free npm
-archive, and binds publication to `npm-stage` with OIDC. It permits npm
-`latest` only when it selects a stable version or the exact deprecated inert
-bootstrap; every preview or other prerelease value is rejected. Merging one
-reviewed request can publish that exact preview under the explicit npm `preview`
-dist-tag; it cannot become `latest`, claim support, or promote itself to stable
-support.
+The historical `0.1.0-preview.1` request remains an immutable record of the first
+OIDC canary. Future releases do not use a preview tag or require an append-only
+preview request. Package provenance and lifecycle checks continue to grant no
+support, runtime, stable-promotion, or marketplace claim.
 
 ## Static candidate review before release authority
 
@@ -70,7 +63,7 @@ Create `distribution/releases/v<version>.json`:
 {
   "schemaVersion": "1.0.0",
   "state": "release-on-merge",
-  "version": "0.1.0-preview.1",
+  "version": "1.0.0",
   "sourceRevision": "<reviewed-40-character-commit>",
   "preflightDigest": "<64-character-preflight-digest>",
   "artifactDigest": "<64-character-artifact-digest>",
@@ -103,10 +96,10 @@ exactly one profile. Requests are append-only and version-unique.
 
 The request may claim only automation recorded in
 [`release-automation-capabilities.json`](../distribution/release-automation-capabilities.json).
-The first preview cleans up unpublished draft state automatically, but it does
-not claim that an immutable npm version can be rolled back, and subscriber or
-marketplace automation remains disabled until its own implementation and canary
-exist.
+The governed release cleans up unpublished draft state automatically, but it
+does not claim that an immutable npm version can be rolled back, and subscriber
+or marketplace automation remains disabled until its own implementation and
+canary exist.
 
 ## 3. Open the release PR
 
@@ -182,8 +175,8 @@ release path.
 - Promotion failure after npm succeeds: npm is immutable and is **not** described
   as rolled back. The draft release and index PR remain for explicit recovery,
   and the failure is recorded on AI#181.
-- Subscriber and marketplace delivery are disabled for this preview and cannot
-  advance automatically.
+- Subscriber and marketplace delivery remain disabled until their own gates
+  explicitly allow them.
 
 Never rewrite or reuse a release request version. Correct a released defect with
 a new SemVer version.

--- a/README.md
+++ b/README.md
@@ -182,16 +182,13 @@ tooling.
 
 ## Current release state
 
-The first narrow `public-fundamentals` preview has approved passive source,
-deterministic public package bytes, exact request binding, protected OIDC
-publication, and npm owner setup. npm forces `latest` onto a package's first
-publication and rejects removing it; the inert bootstrap version is therefore
-deprecated and one reviewed append-only preview request is now eligible. No
-preview version has been published, and the preview lane cannot claim support or
-move npm `latest` to a preview.
+`@cratis/ai-fundamentals` uses the normal Cratis release flow: exactly one
+`major`, `minor`, `patch`, or `no-release` pull-request label, followed by an
+automatic release from protected `main`. Releases stay on `0.x.y` and publish to
+npm `latest` through trusted OIDC while the API is still evolving. Package
+provenance and lifecycle checks do not grant support.
 
-Stable support and broad rollout still require the governed S9/S10 lane,
-including scoped generated-repository automation, real consumer lifecycle
-canaries, release evidence, immutable installation guidance, and explicit
-support approval. Until those gates pass, any published preview remains an
+A `1.0.0` release, stable support, and broad rollout still require the governed
+S9/S10 lane, including real consumer lifecycle canaries, release evidence, and
+explicit support approval. Until those gates pass, the package remains an
 unsupported evaluation endpoint.

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "cc764be2b2ceeeae414ea1af93ab1c23a23edd3909743c73bf86c80d467aadc8",
+  "indexDigest": "c9367af6948a3658c78d4bda50691abeff94a9db52010233df6eecd112dda58f",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -164,6 +164,10 @@
     },
     {
       "path": ".github/workflows/verify-no-work-records.yml",
+      "status": "added"
+    },
+    {
+      "path": ".github/workflows/verify-semver-label.yml",
       "status": "added"
     },
     {
@@ -3613,7 +3617,8 @@
         ".github/workflows/release-approved-ai-profiles.yml",
         ".github/workflows/release-passive-previews.yml",
         ".github/workflows/verify-ai-corpus.yml",
-        ".github/workflows/verify-no-work-records.yml"
+        ".github/workflows/verify-no-work-records.yml",
+        ".github/workflows/verify-semver-label.yml"
       ],
       "artifactType": "workflow",
       "currentOwner": "repository-only authoring/release tooling",
@@ -3631,8 +3636,8 @@
         "repo-main-b795d53",
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 13,
-      "expectedPathsDigest": "9baffda4e0ab2f7c8600acd9c15b3a65c4d8b9f1536bb86b2aef2dd498fc96ea"
+      "expectedPathCount": 14,
+      "expectedPathsDigest": "3d3bea4b355438e51bb0c0088c1423a30d910ecee0d91b5669078c5b2f492d6b"
     },
     {
       "excludePathPatterns": [],

--- a/distribution/assurance-lanes.json
+++ b/distribution/assurance-lanes.json
@@ -60,7 +60,7 @@
   "selectedPreview": {
     "profileId": "public-fundamentals",
     "packageName": "@cratis/ai-fundamentals",
-    "requiredStatusContext": "preview / verify",
+    "requiredStatusContext": "release-intent / verify",
     "protectedEnvironment": "npm-stage"
   },
   "advancedAssurance": {

--- a/distribution/assurance-lanes.schema.json
+++ b/distribution/assurance-lanes.schema.json
@@ -37,7 +37,7 @@
       "properties": {
         "profileId": { "const": "public-fundamentals" },
         "packageName": { "const": "@cratis/ai-fundamentals" },
-        "requiredStatusContext": { "const": "preview / verify" },
+        "requiredStatusContext": { "const": "release-intent / verify" },
         "protectedEnvironment": { "const": "npm-stage" }
       }
     },

--- a/distribution/npm-stage-contract.json
+++ b/distribution/npm-stage-contract.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "state": "PASSIVE_PREVIEW_REQUEST_READY",
+  "state": "NORMAL_0X_RELEASES_ENABLED",
   "trackingIssue": "https://github.com/Cratis/Workflows/issues/70",
   "package": {
     "fixtureName": "@cratis/ai",
@@ -30,9 +30,10 @@
   "workflow": {
     "path": ".github/workflows/distribution-npm-stage.yml",
     "productionPath": ".github/workflows/release-approved-ai-profiles.yml",
-    "currentOperation": "AWAIT_MERGED_PASSIVE_PREVIEW_REQUEST",
+    "currentOperation": "PUBLISH_MERGED_LABELED_PULL_REQUEST",
     "environment": "npm-stage",
-    "passivePreviewPath": ".github/workflows/release-passive-previews.yml",
+    "environmentApprovalRequired": false,
+    "packageReleasePath": ".github/workflows/release-passive-previews.yml",
     "trustedPublisherConfigured": true,
     "trustedPublisher": {
       "provider": "github-actions",
@@ -45,21 +46,22 @@
     "oidcEnabled": true,
     "stagePublishEnabled": false,
     "publicPublishEnabled": true,
-    "publishAutomaticallyAfterMergedReleaseRequestAndCanary": true
+    "publishAutomaticallyAfterMergedLabeledPullRequest": true
   },
-  "previewPublicationControls": [
+  "releaseControls": [
+    "exactly one major minor patch or no-release pull-request label",
+    "release version derived by cratis release-action",
+    "0.x versions only until governed support approval",
     "approved public target and immutable source contract",
-    "append-only request bound to exact source revision and digest",
     "Node 22.14 or newer",
     "npm 11.5.1 or newer",
-    "npm-stage environment approval",
+    "main-only npm-stage OIDC environment",
     "id-token write only in the publish job",
     "unpacked allowlist and zero lifecycle scripts or dependencies",
-    "provenance checksum and exact-artifact verification",
-    "pack install discovery uninstall and exact-version rollback smoke",
-    "explicit npm preview dist-tag"
+    "provenance checksum and package lifecycle verification",
+    "explicit npm latest dist-tag"
   ],
-  "previewRequestEligible": true,
+  "releaseEligible": true,
   "publicationEligible": false,
   "promotionEligible": false
 }

--- a/tooling/generate-repository-inventory.mjs
+++ b/tooling/generate-repository-inventory.mjs
@@ -105,8 +105,7 @@ const unexpectedUntracked = admittedUntracked.filter(
             path === ".github/workflows/engineering-distribution-fixture.yml" ||
             path === ".github/workflows/distribution-generated-update.yml" ||
             path === ".github/workflows/distribution-npm-stage.yml" ||
-            path ===
-                ".github/workflows/package-passive-candidate-assets.yml" ||
+            path === ".github/workflows/package-passive-candidate-assets.yml" ||
             path === ".github/workflows/release-approved-ai-profiles.yml" ||
             /^AI-REPOSITORY-REDESIGN-[A-Z0-9-]+\.md$/.test(path) ||
             path === "Documentation/.markdownlint.json" ||
@@ -538,6 +537,7 @@ const definitions = [
             ".github/workflows/release-passive-previews.yml",
             ".github/workflows/verify-ai-corpus.yml",
             ".github/workflows/verify-no-work-records.yml",
+            ".github/workflows/verify-semver-label.yml",
         ],
         artifactType: "workflow",
         currentOwner: repositoryOwner,

--- a/tooling/package-fundamentals-preview-npm.mjs
+++ b/tooling/package-fundamentals-preview-npm.mjs
@@ -43,7 +43,9 @@ function walkFiles(root, current = root) {
             throw new Error(`Preview npm stage contains a symlink: ${path}`);
         if (stat.isDirectory()) return walkFiles(root, path);
         if (!stat.isFile())
-            throw new Error(`Preview npm stage contains a special file: ${path}`);
+            throw new Error(
+                `Preview npm stage contains a special file: ${path}`,
+            );
         return [relative(root, path).replaceAll("\\", "/")];
     });
 }
@@ -60,7 +62,9 @@ export function materializeFundamentalsPreviewNpmAsset({
     request,
 } = {}) {
     if (!outputRoot || !version || !readiness || !request)
-        throw new Error("outputRoot, version, readiness, and request are required");
+        throw new Error(
+            "outputRoot, version, readiness, and request are required",
+        );
     if (
         readiness.state !== "READY_FOR_PREVIEW_REQUEST" ||
         readiness.assuranceMode !== "basic" ||
@@ -69,18 +73,28 @@ export function materializeFundamentalsPreviewNpmAsset({
         readiness.previewRequestEligible !== true ||
         readiness.supportGranted !== false
     )
-        throw new Error("Basic preview readiness does not authorize npm staging");
-    if (!/^0\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)-preview\.(?:0|[1-9][0-9]*)$/.test(version))
-        throw new Error("Preview npm version must match 0.MINOR.PATCH-preview.N");
+        throw new Error(
+            "Basic preview readiness does not authorize npm staging",
+        );
+    const isPreview = version.includes("-preview.");
     if (
-        request.state !== "preview-on-merge" ||
+        !/^0\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-preview\.(?:0|[1-9][0-9]*))?$/.test(
+            version,
+        )
+    )
+        throw new Error(
+            "npm version must match 0.MINOR.PATCH or 0.MINOR.PATCH-preview.N",
+        );
+    if (
+        request.state !==
+            (isPreview ? "preview-on-merge" : "release-on-merge") ||
         request.profileId !== profileId ||
         request.packageName !== packageName ||
         request.version !== version ||
         request.assuranceMode !== "basic" ||
         request.supportClaim !== false
     )
-        throw new Error("Preview request does not authorize this npm artifact");
+        throw new Error("Release input does not authorize this npm artifact");
     const root = resolve(outputRoot);
     if (existsSync(root))
         throw new Error(`Preview npm output must not exist: ${root}`);
@@ -92,7 +106,9 @@ export function materializeFundamentalsPreviewNpmAsset({
         request.sourceRevision !== authority.source.sourceRevision ||
         request.sourceContentDigest !== authority.source.contentDigest
     )
-        throw new Error("Preview request source does not match immutable authority");
+        throw new Error(
+            "Preview request source does not match immutable authority",
+        );
     const temporaryRoot = mkdtempSync(join(tmpdir(), "cratis-preview-npm-"));
     const stageRoot = join(temporaryRoot, "stage");
     mkdirSync(root, { recursive: false });
@@ -102,7 +118,7 @@ export function materializeFundamentalsPreviewNpmAsset({
             version,
             profileId,
             packageName,
-            description: "Preview of Cratis Fundamentals concept guidance",
+            description: "Cratis Fundamentals concept guidance",
             skills: [authority.skill],
             codexInstallationPolicy: "NOT_AVAILABLE",
             piPrivate: false,
@@ -115,7 +131,7 @@ export function materializeFundamentalsPreviewNpmAsset({
         const expectedPackageJson = {
             name: packageName,
             version,
-            description: "Preview of Cratis Fundamentals concept guidance",
+            description: "Cratis Fundamentals concept guidance",
             private: false,
             license: "MIT",
             repository: {
@@ -129,10 +145,8 @@ export function materializeFundamentalsPreviewNpmAsset({
                 skills: ["./skills"],
             },
         };
-        if (
-            !isDeepStrictEqual(packageJson, expectedPackageJson)
-        )
-            throw new Error("Generated preview npm package metadata is unsafe");
+        if (!isDeepStrictEqual(packageJson, expectedPackageJson))
+            throw new Error("Generated npm package metadata is unsafe");
         const filename = `cratis-ai-fundamentals-${version}.tgz`;
         const content = createTarGzip(piRoot, paths, "package");
         const archive = readTarGzip(content);
@@ -140,14 +154,16 @@ export function materializeFundamentalsPreviewNpmAsset({
             const archivePath = `package/${path}`;
             if (
                 !archive.has(archivePath) ||
-                !archive.get(archivePath).equals(readFileSync(join(piRoot, path)))
+                !archive
+                    .get(archivePath)
+                    .equals(readFileSync(join(piRoot, path)))
             )
-                throw new Error(`Preview npm archive byte drift: ${path}`);
+                throw new Error(`npm archive byte drift: ${path}`);
         }
         writeFileSync(join(root, filename), content, { flag: "wx" });
         const manifest = {
             schemaVersion: 1,
-            state: "PASSIVE_PREVIEW_NPM_STAGED",
+            state: "PASSIVE_NPM_STAGED",
             profileId,
             packageName,
             version,
@@ -160,7 +176,9 @@ export function materializeFundamentalsPreviewNpmAsset({
             repositoryUrl: packageJson.repository.url,
             lifecycleScripts: false,
             dependencies: false,
-            previewPublicationEligible: true,
+            distTag: isPreview ? "preview" : "latest",
+            publicationEligible: true,
+            previewPublicationEligible: isPreview,
             supportGranted: false,
             stablePromotionEligible: false,
         };
@@ -179,6 +197,31 @@ export function materializeFundamentalsPreviewNpmAsset({
     } finally {
         rmSync(temporaryRoot, { recursive: true, force: true });
     }
+}
+
+export function packageFundamentalsNpmRelease({
+    repositoryRoot = defaultRepositoryRoot,
+    outputRoot,
+    version,
+} = {}) {
+    const authority = loadPreviewAuthority(repositoryRoot);
+    return materializeFundamentalsPreviewNpmAsset({
+        repositoryRoot,
+        outputRoot,
+        version,
+        readiness: buildPreviewReadiness(repositoryRoot),
+        request: {
+            id: `public-fundamentals-${version.replaceAll(".", "-")}`,
+            state: "release-on-merge",
+            profileId,
+            packageName,
+            version,
+            sourceRevision: authority.source.sourceRevision,
+            sourceContentDigest: authority.source.contentDigest,
+            assuranceMode: "basic",
+            supportClaim: false,
+        },
+    });
 }
 
 export function packageFundamentalsPreviewNpm({
@@ -211,18 +254,18 @@ export function packageFundamentalsPreviewNpm({
 }
 
 function main() {
-    const [outputRoot, version] = process.argv.slice(2);
+    const [outputRoot, version, mode = "preview"] = process.argv.slice(2);
     try {
-        const manifest = packageFundamentalsPreviewNpm({
-            outputRoot,
-            version,
-        });
+        const manifest =
+            mode === "release"
+                ? packageFundamentalsNpmRelease({ outputRoot, version })
+                : packageFundamentalsPreviewNpm({ outputRoot, version });
         process.stdout.write(
-            `Staged ${manifest.packageName}@${manifest.version} for protected preview publication.\n`,
+            `Staged ${manifest.packageName}@${manifest.version} for npm publication.\n`,
         );
     } catch (error) {
         process.stderr.write(
-            `${error instanceof Error ? error.message : "Preview npm staging failed"}\n`,
+            `${error instanceof Error ? error.message : "npm staging failed"}\n`,
         );
         process.exitCode = 1;
     }

--- a/tooling/preview-readiness.mjs
+++ b/tooling/preview-readiness.mjs
@@ -140,30 +140,35 @@ export function buildPreviewReadiness(repositoryRoot = defaultRepositoryRoot) {
             "npm-latest-tag-unsafe",
             "The npm-forced bootstrap latest version is not confirmed deprecated.",
         );
-    const previewWorkflowPath = join(
+    const packageWorkflowPath = join(
         root,
         ".github/workflows/release-passive-previews.yml",
     );
-    if (!existsSync(previewWorkflowPath)) {
+    if (!existsSync(packageWorkflowPath)) {
         addBlocker(
             blockers,
             "preview-release-workflow-not-implemented",
-            "The passive preview request and publication workflow is not implemented.",
+            "The passive package publication workflow is not implemented.",
         );
     } else {
-        const previewWorkflow = readFileSync(previewWorkflowPath, "utf8");
-        for (const requiredCheck of expectedPreviewChecks)
-            if (!previewWorkflow.includes(requiredCheck))
+        const packageWorkflow = readFileSync(packageWorkflowPath, "utf8");
+        const requiredControls =
+            npmStage.state === "NORMAL_0X_RELEASES_ENABLED"
+                ? [
+                      "cratis/release-action@",
+                      `environment: ${lanes.selectedPreview.protectedEnvironment}`,
+                      "npm publish --provenance --access public --tag latest",
+                      "supportGranted",
+                  ]
+                : [
+                      ...expectedPreviewChecks,
+                      `name: ${lanes.selectedPreview.requiredStatusContext}`,
+                      `environment: ${lanes.selectedPreview.protectedEnvironment}`,
+                  ];
+        for (const requiredControl of requiredControls)
+            if (!packageWorkflow.includes(requiredControl))
                 throw new Error(
-                    `Preview release workflow omits required check ${requiredCheck}`,
-                );
-        for (const requiredControl of [
-            `name: ${lanes.selectedPreview.requiredStatusContext}`,
-            `environment: ${lanes.selectedPreview.protectedEnvironment}`,
-        ])
-            if (!previewWorkflow.includes(requiredControl))
-                throw new Error(
-                    `Preview release workflow omits ${requiredControl}`,
+                    `Package release workflow omits ${requiredControl}`,
                 );
     }
     const readiness = {

--- a/tooling/specs/assurance-lanes.spec.mjs
+++ b/tooling/specs/assurance-lanes.spec.mjs
@@ -94,7 +94,7 @@ test("current passive preview is ready for one exact request without granting su
     assert.equal(first.supportGranted, false);
 });
 
-test("basic owner setup can admit a preview request without granting support", () => {
+test("basic owner setup can enable normal 0.x releases without granting support", () => {
     withTemporaryInputs((root) => {
         const lanes = readJson(root, "distribution/assurance-lanes.json");
         writeJson(root, "distribution/assurance-lanes.json", lanes);
@@ -111,14 +111,12 @@ test("basic owner setup can admit a preview request without granting support", (
             ".github/workflows/release-passive-previews.yml",
         );
         mkdirSync(dirname(workflowPath), { recursive: true });
-        const previewLane = lanes.lanes.find(
-            (lane) => lane.id === "passive-preview",
-        );
         writeFileSync(
             workflowPath,
-            `name: ${lanes.selectedPreview.requiredStatusContext}\n` +
+            "cratis/release-action@pinned\n" +
                 `environment: ${lanes.selectedPreview.protectedEnvironment}\n` +
-                `${previewLane.requiredChecks.join("\n")}\n`,
+                "npm publish --provenance --access public --tag latest\n" +
+                "supportGranted\n",
         );
         const readiness = buildPreviewReadiness(root);
         assert.equal(readiness.state, "READY_FOR_PREVIEW_REQUEST");

--- a/tooling/specs/distribution-npm-stage.spec.mjs
+++ b/tooling/specs/distribution-npm-stage.spec.mjs
@@ -22,8 +22,8 @@ const workflow = readFileSync(
     "utf8",
 );
 
-test("npm stage contract admits an exact passive preview request", () => {
-    assert.equal(contract.state, "PASSIVE_PREVIEW_REQUEST_READY");
+test("npm stage contract enables normal support-free 0.x releases", () => {
+    assert.equal(contract.state, "NORMAL_0X_RELEASES_ENABLED");
     assert.equal(contract.package.fixtureName, "@cratis/ai");
     assert.equal(contract.package.productionName, "@cratis/ai-fundamentals");
     assert.equal(contract.package.fixturePrivate, true);
@@ -62,22 +62,22 @@ test("npm stage contract admits an exact passive preview request", () => {
     assert.equal(contract.workflow.publicPublishEnabled, true);
     assert.equal(
         contract.workflow.currentOperation,
-        "AWAIT_MERGED_PASSIVE_PREVIEW_REQUEST",
+        "PUBLISH_MERGED_LABELED_PULL_REQUEST",
     );
     assert.equal(
-        contract.workflow.passivePreviewPath,
+        contract.workflow.packageReleasePath,
         ".github/workflows/release-passive-previews.yml",
     );
     assert.equal(
-        contract.workflow
-            .publishAutomaticallyAfterMergedReleaseRequestAndCanary,
+        contract.workflow.publishAutomaticallyAfterMergedLabeledPullRequest,
         true,
     );
     assert.equal(
         contract.workflow.productionPath,
         ".github/workflows/release-approved-ai-profiles.yml",
     );
-    assert.equal(contract.previewRequestEligible, true);
+    assert.equal(contract.workflow.environmentApprovalRequired, false);
+    assert.equal(contract.releaseEligible, true);
     assert.equal(contract.publicationEligible, false);
     assert.equal(contract.promotionEligible, false);
 });

--- a/tooling/specs/fundamentals-preview-npm.spec.mjs
+++ b/tooling/specs/fundamentals-preview-npm.spec.mjs
@@ -9,6 +9,7 @@ import { test } from "node:test";
 import { readTarGzip } from "../package-fundamentals-preview-assets.mjs";
 import {
     materializeFundamentalsPreviewNpmAsset,
+    packageFundamentalsNpmRelease,
     packageFundamentalsPreviewNpm,
 } from "../package-fundamentals-preview-npm.mjs";
 import {
@@ -73,8 +74,10 @@ test("publishable Fundamentals preview npm asset is deterministic and scriptless
             request,
         });
         assert.deepEqual(second, first);
-        assert.equal(first.state, "PASSIVE_PREVIEW_NPM_STAGED");
+        assert.equal(first.state, "PASSIVE_NPM_STAGED");
         assert.equal(first.packageName, "@cratis/ai-fundamentals");
+        assert.equal(first.distTag, "preview");
+        assert.equal(first.publicationEligible, true);
         assert.equal(first.previewPublicationEligible, true);
         assert.equal(first.supportGranted, false);
         assert.equal(first.stablePromotionEligible, false);
@@ -91,7 +94,7 @@ test("publishable Fundamentals preview npm asset is deterministic and scriptless
         assert.deepEqual(packageJson, {
             name: "@cratis/ai-fundamentals",
             version: "0.1.0-preview.1",
-            description: "Preview of Cratis Fundamentals concept guidance",
+            description: "Cratis Fundamentals concept guidance",
             private: false,
             license: "MIT",
             repository: {
@@ -197,9 +200,30 @@ test("current request stages the exact publishable preview", () => {
     });
 });
 
-test("publishable preview staging rejects stable and malformed versions", () => {
+test("normal release stages a support-free 0.x package for latest", () => {
     withTemporaryDirectory((root) => {
-        for (const version of ["1.0.0", "latest", "0.1.0-preview"]) {
+        const manifest = packageFundamentalsNpmRelease({
+            outputRoot: join(root, "release"),
+            version: "0.1.0",
+        });
+        assert.equal(manifest.state, "PASSIVE_NPM_STAGED");
+        assert.equal(manifest.version, "0.1.0");
+        assert.equal(manifest.distTag, "latest");
+        assert.equal(manifest.publicationEligible, true);
+        assert.equal(manifest.previewPublicationEligible, false);
+        assert.equal(manifest.supportGranted, false);
+        assert.equal(manifest.stablePromotionEligible, false);
+    });
+});
+
+test("npm staging rejects 1.x and malformed versions", () => {
+    withTemporaryDirectory((root) => {
+        for (const version of [
+            "1.0.0",
+            "latest",
+            "0.1.0-preview",
+            "0.1.0-beta.1",
+        ]) {
             assert.throws(
                 () =>
                     materializeFundamentalsPreviewNpmAsset({
@@ -211,7 +235,7 @@ test("publishable preview staging rejects stable and malformed versions", () => 
                         readiness: ready,
                         request: { ...request, version },
                     }),
-                /must match 0\.MINOR\.PATCH-preview\.N/,
+                /must match 0\.MINOR\.PATCH or 0\.MINOR\.PATCH-preview\.N/,
             );
         }
     });

--- a/tooling/specs/preview-request-validation.spec.mjs
+++ b/tooling/specs/preview-request-validation.spec.mjs
@@ -50,9 +50,7 @@ test("preview request schema rejects support claims unknown fields and multiple 
         schema,
         schema,
     );
-    assert(
-        errors.some((error) => error.includes("duplicate items")),
-    );
+    assert(errors.some((error) => error.includes("duplicate items")));
     assert(
         errors.some((error) =>
             error.includes("supportClaim: expected constant false"),

--- a/tooling/specs/workflow-safety.spec.mjs
+++ b/tooling/specs/workflow-safety.spec.mjs
@@ -149,65 +149,50 @@ test("release candidates remain readable while every side-effect job is S10-bloc
         assert.equal(workflow.includes(forbidden), false, forbidden);
 });
 
-test("passive preview publication is request readiness and environment gated", () => {
+test("Fundamentals package uses the normal labeled Cratis release flow", () => {
     const workflow = readFileSync(
         ".github/workflows/release-passive-previews.yml",
         "utf8",
     );
     for (const required of [
-        "name: preview / verify",
-        "distribution/preview-requests.json",
-        "distribution/npm-stage-contract.json",
-        "Verify registry dist-tag safety",
-        'latest=$(npm view "$package" dist-tags.latest)',
-        "0.0.0-bootstrap.0",
-        'deprecated=$(npm view "$package@$latest" deprecated)',
-        "Bootstrap only. Install an exact preview version or use the preview dist-tag.",
-        "*-*",
-        "preview_allowed",
-        "git diff --quiet",
-        "request_count",
-        "--require-request",
-        "--base",
-        "request_present",
-        "requests.at(-1).version",
-        "artifact_sha256",
-        "EXPECTED_SHA256",
-        "smoke-fundamentals-preview-npm.mjs",
-        "github.event_name == 'push'",
-        "needs.verify.outputs.preview_allowed == 'true'",
+        "name: Publish Fundamentals AI Package",
+        'branches: ["main"]',
+        "cratis/release-action@bdaded342eb31b52b48dca0611f0214794f8c655",
+        "needs.release.outputs.publish == 'true'",
         "environment: npm-stage",
         "id-token: write",
-        "npm_version=$(npm --version)",
-        "major < 11",
-        "npm publish --provenance --access public --tag preview",
+        '[[ "$VERSION" =~ ^0\\.[0-9]+\\.[0-9]+$ ]]',
         "package-fundamentals-preview-npm.mjs",
+        "smoke-fundamentals-preview-npm.mjs",
+        "npm publish --provenance --access public --tag latest",
         "supportGranted",
     ])
         assert(workflow.includes(required), required);
-    for (const check of [
-        "deterministic-generation",
-        "static-contract-validation",
-        "secret-and-path-scanning",
-        "schema-validation",
-        "checksums",
-        "owner-review",
-        "basic-pack-install-discovery-uninstall-smoke",
-        "exact-version-rollback",
-    ])
-        assert(workflow.includes(check), check);
     for (const forbidden of [
         "NPM_TOKEN",
         "NODE_AUTH_TOKEN",
         "secrets:",
-        "contents: write",
-        "pull-requests: write",
-        "supportGranted: true",
         "workflow_dispatch:",
-        "dist-tags.latest 2>/dev/null || true",
-        "0.1.0-preview.1');",
+        "--tag preview",
+        "distribution/preview-requests.json",
     ])
         assert.equal(workflow.includes(forbidden), false, forbidden);
+});
+
+test("AI delegates release-intent labels to the shared pinned workflow", () => {
+    const workflow = readFileSync(
+        ".github/workflows/verify-semver-label.yml",
+        "utf8",
+    );
+    for (const required of [
+        "pull_request:",
+        "opened, reopened, synchronize, labeled, unlabeled",
+        'branches: ["main"]',
+        "release-intent:",
+        "Cratis/Workflows/.github/workflows/verify-release-intent.yml@1e5319ff574ce61a771ec5199527b917204a13b5",
+    ])
+        assert(workflow.includes(required), required);
+    assert.equal(workflow.includes("secrets: inherit"), false);
 });
 
 test("Fundamentals preview workflow is read-only short-lived and non-publishing", () => {


### PR DESCRIPTION
# Summary

Moves `@cratis/ai-fundamentals` onto the standard Cratis labeled release flow. A merged semantic-release pull request now produces a support-free `0.x.y` package automatically through the existing trusted OIDC publisher, with no second environment approval.

## Added

- Validate release intent through the shared pinned Cratis workflow. (#181)

## Changed

- Publish normal `0.x.y` Fundamentals packages to npm `latest` from labeled merges. (#181)
- Keep exact source, checksum, lifecycle, provenance, and no-support controls without a recurring manual deployment gate. (#181)
