### PR TITLE
Add Fundamentals package usage guidance

### DIFF
--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "c9367af6948a3658c78d4bda50691abeff94a9db52010233df6eecd112dda58f",
+  "indexDigest": "a0e166f3b9bc4df15a6455dce7eb7ea95b2dd80b3cc38d6777483e6b9c49223d",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/tooling/package-fundamentals-preview-npm.mjs
+++ b/tooling/package-fundamentals-preview-npm.mjs
@@ -54,6 +54,48 @@ function writeJson(path, value) {
     writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, { flag: "wx" });
 }
 
+function packageReadme(version) {
+    return `<!--
+Copyright (c) Cratis. All rights reserved.
+Licensed under the MIT license. See LICENSE in this package for full license information.
+-->
+
+# @cratis/ai-fundamentals
+
+Passive AI guidance for Cratis Fundamentals concepts and Chronicle event-source identities.
+
+## Install
+
+Install this exact version globally:
+
+\`\`\`bash
+pi install npm:@cratis/ai-fundamentals@${version}
+\`\`\`
+
+Install it for one trusted project:
+
+\`\`\`bash
+pi install -l npm:@cratis/ai-fundamentals@${version}
+\`\`\`
+
+Try it for one Pi run without changing settings:
+
+\`\`\`bash
+pi -e npm:@cratis/ai-fundamentals@${version}
+\`\`\`
+
+## Update or remove
+
+Move to another exact version with \`pi install npm:@cratis/ai-fundamentals@<version>\`.
+Remove the package with \`pi remove npm:@cratis/ai-fundamentals\`.
+
+## Status
+
+This \`0.x\` package is an unsupported evaluation release. Packaging, provenance,
+and lifecycle checks do not grant a support claim. Review skill instructions before use.
+`;
+}
+
 export function materializeFundamentalsPreviewNpmAsset({
     repositoryRoot = defaultRepositoryRoot,
     outputRoot,
@@ -124,6 +166,9 @@ export function materializeFundamentalsPreviewNpmAsset({
             piPrivate: false,
         });
         const piRoot = join(stageRoot, adapters.roots.pi);
+        writeFileSync(join(piRoot, "README.md"), packageReadme(version), {
+            flag: "wx",
+        });
         const paths = walkFiles(piRoot).sort();
         const packageJson = JSON.parse(
             readFileSync(join(piRoot, "package.json"), "utf8"),

--- a/tooling/specs/fundamentals-preview-npm.spec.mjs
+++ b/tooling/specs/fundamentals-preview-npm.spec.mjs
@@ -111,6 +111,10 @@ test("publishable Fundamentals preview npm asset is deterministic and scriptless
         assert(
             files.has("package/skills/cratis-fundamentals-concept/SKILL.md"),
         );
+        const readme = files.get("package/README.md").toString("utf8");
+        assert(readme.includes("pi install npm:@cratis/ai-fundamentals@0.1.0-preview.1"));
+        assert(readme.includes("pi install -l npm:@cratis/ai-fundamentals@0.1.0-preview.1"));
+        assert(readme.includes("unsupported evaluation release"));
         const checksums = readFileSync(join(firstRoot, "SHA256SUMS"), "utf8");
         assert(checksums.includes(first.filename));
         assert(checksums.includes("preview-npm-manifest.json"));
@@ -213,6 +217,12 @@ test("normal release stages a support-free 0.x package for latest", () => {
         assert.equal(manifest.previewPublicationEligible, false);
         assert.equal(manifest.supportGranted, false);
         assert.equal(manifest.stablePromotionEligible, false);
+        const files = readTarGzip(
+            readFileSync(join(root, "release", manifest.filename)),
+        );
+        const readme = files.get("package/README.md").toString("utf8");
+        assert(readme.includes("pi install npm:@cratis/ai-fundamentals@0.1.0"));
+        assert(readme.includes("pi -e npm:@cratis/ai-fundamentals@0.1.0"));
     });
 });
 


### PR DESCRIPTION
# Summary

Adds concise install, project-local install, one-run trial, update, removal, and support-status guidance directly to the published Fundamentals npm package.

## Added

- Include version-pinned Pi usage instructions in `@cratis/ai-fundamentals`. (#181)
