### PR TITLE
Document evaluation artifacts and tune evidence scanning

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,16 @@
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Generated evidence catalog immutable Git revisions"
+paths = ['''^catalog/(?:v2/)?evidence\.json$''']
+regexTarget = "line"
+regexes = [
+  '''^\s*"applicableVersion": "(?:Cratis/Samples@)?[0-9a-f]{40}",?$''',
+  '''^\s*"immutableRevision": "[0-9a-f]{40}",?$''',
+  '''^\s*"(?:officialUrl|locator)": "https://github\.com/Cratis/AI/(?:tree|blob)/[0-9a-f]{40}(?:/[^"]*)?",?$''',
+  '''^\s*"version": "[0-9a-f]{40}",?$'''
+]

--- a/README.md
+++ b/README.md
@@ -192,3 +192,13 @@ A `1.0.0` release, stable support, and broad rollout still require the governed
 S9/S10 lane, including real consumer lifecycle canaries, release evidence, and
 explicit support approval. Until those gates pass, the package remains an
 unsupported evaluation endpoint.
+
+## Evaluation artifacts
+
+[Cratis/AI.Distribution v0.1.0](https://github.com/Cratis/AI.Distribution/releases/tag/v0.1.0)
+contains one checksum-bound download with all currently generated review output:
+41 packaged skill targets across 68 host-specific archives, plus four native
+non-skill rule/instruction archives kept in their own semantic form. The release
+manifests retain every blocked and repository-only exclusion. These downloads
+are public evaluation artifacts, not supported installers or marketplace
+claims.

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "c39a21971157bb8c3a10c7065d93dd5d4842090e8459ee07df5c467e37f46f25",
+  "indexDigest": "8793a6d950b3a748c8cae20b52b2f6e4360a77b00988b0f73a13038454dedf84",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -173,6 +173,10 @@
     {
       "path": ".gitignore",
       "status": "modified"
+    },
+    {
+      "path": ".gitleaks.toml",
+      "status": "added"
     },
     {
       "path": "Documentation/.markdownlint.json",
@@ -3024,6 +3028,7 @@
       "sourcePathPatterns": [
         ".gitattributes",
         ".gitignore",
+        ".gitleaks.toml",
         "LICENSE",
         "README.md"
       ],
@@ -3039,8 +3044,8 @@
       "evidenceIds": [
         "repo-main-b795d53"
       ],
-      "expectedPathCount": 4,
-      "expectedPathsDigest": "afe74be8573bd6b2bbaf6cb00ab97dd574334d3b9cf74980d60cdc96ec3e59fc"
+      "expectedPathCount": 5,
+      "expectedPathsDigest": "8caa01de1b913d15c864daef16c57d13fc2a99a19e9a23e63f0ceb8dddfd3c78"
     },
     {
       "excludePathPatterns": [],

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "a0e166f3b9bc4df15a6455dce7eb7ea95b2dd80b3cc38d6777483e6b9c49223d",
+  "indexDigest": "c39a21971157bb8c3a10c7065d93dd5d4842090e8459ee07df5c467e37f46f25",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/tooling/generate-repository-inventory.mjs
+++ b/tooling/generate-repository-inventory.mjs
@@ -162,6 +162,7 @@ const definitions = [
         sourcePathPatterns: [
             ".gitattributes",
             ".gitignore",
+            ".gitleaks.toml",
             "LICENSE",
             "README.md",
         ],

--- a/tooling/specs/fundamentals-preview-npm.spec.mjs
+++ b/tooling/specs/fundamentals-preview-npm.spec.mjs
@@ -112,8 +112,16 @@ test("publishable Fundamentals preview npm asset is deterministic and scriptless
             files.has("package/skills/cratis-fundamentals-concept/SKILL.md"),
         );
         const readme = files.get("package/README.md").toString("utf8");
-        assert(readme.includes("pi install npm:@cratis/ai-fundamentals@0.1.0-preview.1"));
-        assert(readme.includes("pi install -l npm:@cratis/ai-fundamentals@0.1.0-preview.1"));
+        assert(
+            readme.includes(
+                "pi install npm:@cratis/ai-fundamentals@0.1.0-preview.1",
+            ),
+        );
+        assert(
+            readme.includes(
+                "pi install -l npm:@cratis/ai-fundamentals@0.1.0-preview.1",
+            ),
+        );
         assert(readme.includes("unsupported evaluation release"));
         const checksums = readFileSync(join(firstRoot, "SHA256SUMS"), "utf8");
         assert(checksums.includes(first.filename));


### PR DESCRIPTION
# Summary

Links the public bulk evaluation release and keeps secret scanning focused on real credentials rather than immutable Git revisions in generated evidence catalogs.

## Added

- Document the downloadable Cratis AI evaluation artifact bundle.

## Fixed

- Narrowly allow Git revision fields in evidence-catalog gitleaks scans while retaining the default rules everywhere else.
