### PR TITLE
Record merged Samples AI package canary

### DIFF
--- a/catalog/evidence-baseline.json
+++ b/catalog/evidence-baseline.json
@@ -528,6 +528,10 @@
       "digest": "345fdacc6d907aa701785d4e9306959282baa2d196e81ab925626acbe3e50219"
     },
     {
+      "repositoryPath": "distribution/evidence/registry-fundamentals-samples-canary-0.1.1-2026-08-28.json",
+      "digest": "720cb899eec49248a22aba195923b8098ecfce793b4054c26481c1296ebce60d"
+    },
+    {
       "repositoryPath": "distribution/evidence/s5b-passive-host-static-generation-2026-08-25.json",
       "digest": "d619e16b71976284c5812319a27abc612a92645d817e8a6d88aa27929c75ea9e"
     },

--- a/catalog/evidence.json
+++ b/catalog/evidence.json
@@ -8848,6 +8848,13 @@
       "reason": "Digest-bound by the named normalized observation for only its explicit assertions."
     },
     {
+      "repositoryPath": "distribution/evidence/registry-fundamentals-samples-canary-0.1.1-2026-08-28.json",
+      "digest": "720cb899eec49248a22aba195923b8098ecfce793b4054c26481c1296ebce60d",
+      "role": "inventory-only",
+      "observationIds": [],
+      "reason": "Preserves the exact merged-main public-registry Pi lifecycle, clean-cache Debug and Release specs, guidance alignment, and cleanup evidence. It remains inventory-only because it is later than the catalog asOf and explicitly grants no support."
+    },
+    {
       "repositoryPath": "distribution/evidence/s5b-passive-host-static-generation-2026-08-25.json",
       "digest": "d619e16b71976284c5812319a27abc612a92645d817e8a6d88aa27929c75ea9e",
       "role": "supporting",

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "804adbc0715e948e8dadb4a5c8d315cb12d1e8b91da1ad3d73c50b25f49fa3d6",
+  "indexDigest": "dd85ba8b4d9050086c28e1fbfa21a0e9b79893234b2fc365c64fd336b35f7956",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -736,6 +736,10 @@
     },
     {
       "path": "distribution/evidence/real-samples-fundamentals-preview-canary-2026-08-23.json",
+      "status": "added"
+    },
+    {
+      "path": "distribution/evidence/registry-fundamentals-samples-canary-0.1.1-2026-08-28.json",
       "status": "added"
     },
     {
@@ -3015,9 +3019,7 @@
       "status": "added"
     }
   ],
-  "admittedUntracked": [
-    "distribution/evidence/registry-fundamentals-samples-canary-0.1.1-2026-08-28.json"
-  ],
+  "admittedUntracked": [],
   "excludedRuntimePrefixes": [
     ".pi/delegate/",
     ".pi/fusion/",

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -3015,7 +3015,9 @@
       "status": "added"
     }
   ],
-  "admittedUntracked": [],
+  "admittedUntracked": [
+    "distribution/evidence/registry-fundamentals-samples-canary-0.1.1-2026-08-28.json"
+  ],
   "excludedRuntimePrefixes": [
     ".pi/delegate/",
     ".pi/fusion/",
@@ -4484,8 +4486,8 @@
       "evidenceIds": [
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 67,
-      "expectedPathsDigest": "95ba7956af3343791c1f224d6eca8f644766ada2a7c22c6b6b35bb9208628d1e"
+      "expectedPathCount": 68,
+      "expectedPathsDigest": "44d1de38d8b2e53269fc1499441728d8a0586740c0bc5c3a5181037ff3161942"
     },
     {
       "excludePathPatterns": [],

--- a/distribution/evidence/registry-fundamentals-samples-canary-0.1.1-2026-08-28.json
+++ b/distribution/evidence/registry-fundamentals-samples-canary-0.1.1-2026-08-28.json
@@ -1,0 +1,87 @@
+{
+  "schemaVersion": "1.0.0",
+  "observedOn": "2026-08-28",
+  "state": "REAL_REGISTRY_SAMPLES_CANARY_PASS_NON_SUPPORTING",
+  "repository": "https://github.com/Cratis/Samples",
+  "repositoryRevision": "c8d149adb8ffc2728f0c54886ad060a27048faa3",
+  "scope": "Chronicle/Backend",
+  "profileId": "public-fundamentals",
+  "targetId": "cratis-fundamentals-concept",
+  "sourceRevision": "b53caa555b9a3f05ba1462b86202fe3ccb8a9470",
+  "sourceContentDigest": "9e537c48a95c414709008c69ebfb616354d60992578ddd9da3d7dc7308c42caa",
+  "package": {
+    "name": "@cratis/ai-fundamentals",
+    "version": "0.1.1",
+    "archiveSha256": "08330c9ce7f8c1e754002007e12e08dd97cb499775a43fb54e1819c102202602",
+    "sourceCommit": "42236fb28dda494392200a255c0a914ada3a8961",
+    "provenance": "https://registry.npmjs.org/-/npm/v1/attestations/@cratis%2fai-fundamentals@0.1.1"
+  },
+  "isolation": {
+    "nugetCache": "temporary-empty-cache",
+    "piHome": "temporary-empty-home",
+    "samplesCheckout": "detached-clean-worktree"
+  },
+  "results": [
+    {
+      "gate": "isolated-nuget-restore",
+      "status": "PASS",
+      "logSha256": "ce40faa700754f7090b014a67a6793dfa1e8c86092955d39ac69c94b282c0533"
+    },
+    {
+      "gate": "debug-specifications",
+      "status": "PASS",
+      "passed": 4,
+      "failed": 0,
+      "logSha256": "e8075f67879aa87daf7557d7d2933038a518f32047e99ba1e82a1939667bc1b9"
+    },
+    {
+      "gate": "release-specifications",
+      "status": "PASS",
+      "passed": 4,
+      "failed": 0,
+      "logSha256": "d8ef259e827fcc62a193f80318513eae3dc63d5f97a03e22db0ebb758802aaf8"
+    },
+    {
+      "gate": "pi-install-and-discovery",
+      "status": "PASS",
+      "installLogSha256": "d4945323dc8c9fc07324df9012a8a9db0952477763a62e6eb53b7afa4e05b1ad",
+      "listLogSha256": "a809669b5d8f858f927ad1d049aa35a87256c69260c660317639e24f96bbde2a"
+    },
+    {
+      "gate": "concept-guidance-alignment",
+      "status": "PASS",
+      "evidence": "TimelineEntryText derives from ConceptAs<string>."
+    },
+    {
+      "gate": "event-source-identity-guidance-alignment",
+      "status": "PASS",
+      "evidence": "TimelineId derives from EventSourceId<Guid>."
+    },
+    {
+      "gate": "event-source-id-omission",
+      "status": "PASS",
+      "evidence": "TimelineEntryRecorded does not carry TimelineId, EventSourceId, or Guid."
+    },
+    {
+      "gate": "pi-remove-and-settings-cleanup",
+      "status": "PASS",
+      "removeLogSha256": "0cb67fb702ca70aea6f00c5eb9cff5667450eb087867fe69969b9f52f473b5ba",
+      "listLogSha256": "97b79322c8820b3eb74b04575cf8151359ba74ba5bec6bf48ce26480414de561"
+    },
+    {
+      "gate": "worktree-preservation",
+      "status": "PASS",
+      "evidence": "git status --porcelain remained empty after restore, specs, package install, and removal."
+    }
+  ],
+  "limitations": [
+    "No model response was invoked or graded.",
+    "Analyzer warnings remain in pre-existing sample source and specification style.",
+    "This canary validates Pi package lifecycle and exact guidance alignment only.",
+    "This evidence grants no support, stable promotion, marketplace, or broad rollout claim."
+  ],
+  "installationSupported": false,
+  "behaviorSupported": false,
+  "supportGranted": false,
+  "promotionEligible": false
+}

--- a/tooling/specs/fundamentals-preview-npm.spec.mjs
+++ b/tooling/specs/fundamentals-preview-npm.spec.mjs
@@ -234,6 +234,30 @@ test("normal release stages a support-free 0.x package for latest", () => {
     });
 });
 
+test("merged Samples registry canary remains exact and non-supporting", () => {
+    const evidence = JSON.parse(
+        readFileSync(
+            "distribution/evidence/registry-fundamentals-samples-canary-0.1.1-2026-08-28.json",
+            "utf8",
+        ),
+    );
+    assert.equal(
+        evidence.state,
+        "REAL_REGISTRY_SAMPLES_CANARY_PASS_NON_SUPPORTING",
+    );
+    assert.equal(
+        evidence.repositoryRevision,
+        "c8d149adb8ffc2728f0c54886ad060a27048faa3",
+    );
+    assert.equal(evidence.package.version, "0.1.1");
+    assert.equal(evidence.results.length, 9);
+    assert(evidence.results.every((result) => result.status === "PASS"));
+    assert.equal(evidence.installationSupported, false);
+    assert.equal(evidence.behaviorSupported, false);
+    assert.equal(evidence.supportGranted, false);
+    assert.equal(evidence.promotionEligible, false);
+});
+
 test("npm staging rejects 1.x and malformed versions", () => {
     withTemporaryDirectory((root) => {
         for (const version of [


### PR DESCRIPTION
# Summary

Records the successful merged-main `Cratis/Samples` canary for the exact public `@cratis/ai-fundamentals@0.1.1` package while preserving the no-support boundary.

## Added

- Preserve clean-cache Debug and Release specs, Pi install/discovery/remove, guidance alignment, and worktree-cleanliness evidence. (#181)

## Changed

- Register the canary as inventory-only evidence rather than a support-bearing observation. (#181)
