### PR TITLE
Add public multi-marketplace distribution

### DIFF
--- a/.github/workflows/distribution-public-marketplace.yml
+++ b/.github/workflows/distribution-public-marketplace.yml
@@ -1,0 +1,95 @@
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+name: Stage Public Marketplace Distribution
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Unsupported public evaluation version (0.x.y)
+        required: true
+        default: 0.2.0
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: stage-public-marketplace-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  stage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out canonical AI source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: source
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check out current generated Distribution
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: Cratis/AI.Distribution
+          ref: main
+          path: current-distribution
+          persist-credentials: false
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Generate complete marketplace repository
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          [[ "$VERSION" =~ ^0\.[0-9]+\.[0-9]+$ ]]
+          cd source
+          node tooling/stage-public-marketplace-repository.mjs \
+            "$GITHUB_WORKSPACE/current-distribution" \
+            "$RUNNER_TEMP/staged-distribution" \
+            "$VERSION"
+          node tooling/package-public-marketplace-submissions.mjs \
+            "$RUNNER_TEMP/staged-distribution" \
+            "$RUNNER_TEMP/vendor-portal-handoff"
+
+      - name: Verify every Distribution gate
+        run: |
+          set -euo pipefail
+          validator="$GITHUB_WORKSPACE/source/distribution/repository-control-plane/.github/scripts/verify-generated-distribution.mjs"
+          for check in \
+            exact-inventory \
+            canonical-byte-parity \
+            native-manifest-parse \
+            checksums \
+            fixture-provenance-record \
+            pack-install-smoke-uninstall \
+            canary-rollback-simulation
+          do
+            arguments=(
+              --root "$RUNNER_TEMP/staged-distribution"
+              --check "$check"
+            )
+            if [ "$check" = "canary-rollback-simulation" ]; then
+              arguments+=(--before-root "$GITHUB_WORKSPACE/current-distribution")
+            fi
+            node "$validator" "${arguments[@]}"
+          done
+
+      - name: Upload exact marketplace review tree
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v7.0.1
+        with:
+          name: cratis-ai-public-marketplace-${{ inputs.version }}
+          path: |
+            ${{ runner.temp }}/staged-distribution
+            ${{ runner.temp }}/vendor-portal-handoff
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 7

--- a/Documentation/releasing-cratis-ai.md
+++ b/Documentation/releasing-cratis-ai.md
@@ -26,6 +26,28 @@ OIDC canary. Future releases do not use a preview tag or require an append-only
 preview request. Package provenance and lifecycle checks continue to grant no
 support, runtime, stable-promotion, or marketplace claim.
 
+## Public multi-marketplace evaluation
+
+The `public-cratis-ai` Distribution root merges one immutable skill tree into
+compatible manifests for generic Agent Skills and Agent Plugins, Claude Code,
+OpenAI Codex, GitHub Copilot, Cursor, Gemini CLI, Kiro, and Pi. The generator
+rejects byte-divergent collisions and preserves blocked targets, repository-only
+legacy skills, and native non-skill components as explicit exclusions.
+
+Self-hosted GitHub installation is the publication channel for Claude Code,
+Copilot, Gemini CLI, Kiro, generic Agent Plugin hosts, and Pi Git packages.
+OpenAI's universal directory and Cursor's marketplace remain separately prepared
+portal handoffs because those vendors require an authenticated publisher,
+manual submission, and review. The OpenAI handoff also records the owner-supplied
+identity, logo, privacy/terms URLs, country availability, and policy attestations
+that must not be invented by automation. Marketplace availability remains an unsupported
+`0.x.y` evaluation claim; it does not advance S9/S10 or grant support.
+
+The manual **Stage Public Marketplace Distribution** workflow generates the
+complete `Cratis/AI.Distribution` repository candidate, runs all seven protected
+Distribution checks, and uploads the exact hidden-file-preserving review tree.
+It has read-only permissions and cannot push, publish, or submit vendor portals.
+
 ## Static candidate review before release authority
 
 Before any profile is approved, the manual **Package Passive Candidate Assets**

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "dd85ba8b4d9050086c28e1fbfa21a0e9b79893234b2fc365c64fd336b35f7956",
+  "indexDigest": "137bb537c70b4e1f6de247bdce2e10a368463525329ccc17cf03f990867f89aa",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -128,6 +128,10 @@
     },
     {
       "path": ".github/workflows/distribution-npm-stage.yml",
+      "status": "added"
+    },
+    {
+      "path": ".github/workflows/distribution-public-marketplace.yml",
       "status": "added"
     },
     {
@@ -832,6 +836,10 @@
     },
     {
       "path": "distribution/profile-subscription.schema.json",
+      "status": "added"
+    },
+    {
+      "path": "distribution/public-marketplace-release.schema.json",
       "status": "added"
     },
     {
@@ -2547,6 +2555,10 @@
       "status": "added"
     },
     {
+      "path": "tooling/generate-public-marketplace-distribution.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/generate-release-readiness.mjs",
       "status": "added"
     },
@@ -2616,6 +2628,10 @@
     },
     {
       "path": "tooling/package-passive-candidate-assets.mjs",
+      "status": "added"
+    },
+    {
+      "path": "tooling/package-public-marketplace-submissions.mjs",
       "status": "added"
     },
     {
@@ -2931,6 +2947,10 @@
       "status": "added"
     },
     {
+      "path": "tooling/specs/public-marketplace-distribution.spec.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/specs/real-host-canary-contract.spec.mjs",
       "status": "added"
     },
@@ -2996,6 +3016,10 @@
     },
     {
       "path": "tooling/stage-distribution-candidate.mjs",
+      "status": "added"
+    },
+    {
+      "path": "tooling/stage-public-marketplace-repository.mjs",
       "status": "added"
     },
     {
@@ -3622,6 +3646,7 @@
         ".github/workflows/engineering-distribution-fixture.yml",
         ".github/workflows/distribution-generated-update.yml",
         ".github/workflows/distribution-npm-stage.yml",
+        ".github/workflows/distribution-public-marketplace.yml",
         ".github/workflows/package-passive-candidate-assets.yml",
         ".github/workflows/release-approved-ai-profiles.yml",
         ".github/workflows/release-passive-previews.yml",
@@ -3645,8 +3670,8 @@
         "repo-main-b795d53",
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 14,
-      "expectedPathsDigest": "3d3bea4b355438e51bb0c0088c1423a30d910ecee0d91b5669078c5b2f492d6b"
+      "expectedPathCount": 15,
+      "expectedPathsDigest": "e7a40c6e4bd8650f56d99277f622e6bfa82677da93076bf28ef48829c4a5ec57"
     },
     {
       "excludePathPatterns": [],
@@ -4488,8 +4513,8 @@
       "evidenceIds": [
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 68,
-      "expectedPathsDigest": "44d1de38d8b2e53269fc1499441728d8a0586740c0bc5c3a5181037ff3161942"
+      "expectedPathCount": 69,
+      "expectedPathsDigest": "040622ad500fdd641979aab773052506711ce832db092d718729008695838da5"
     },
     {
       "excludePathPatterns": [],
@@ -4564,8 +4589,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 77,
-      "expectedPathsDigest": "876c450cffbf5170ba30ef057b4983548f79f46f4b5d719c4a37a0c9a368d9c5"
+      "expectedPathCount": 80,
+      "expectedPathsDigest": "ba56fdd96ec85d5fe4250f2df1e2cf9c603e54b5ca4840ee56c5d340d965918d"
     },
     {
       "excludePathPatterns": [],
@@ -4588,8 +4613,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 61,
-      "expectedPathsDigest": "0fd1fe04c8b46f4cc33917dc3256000b0fb001fda19a8805e7868dbbeb6acce2"
+      "expectedPathCount": 62,
+      "expectedPathsDigest": "1a6bc1f87205f6d5e153f63486bc47b8e5c22a9006b78e07daeddcf75f6d467f"
     },
     {
       "excludePathPatterns": [],

--- a/distribution/generated-repository-contract.json
+++ b/distribution/generated-repository-contract.json
@@ -34,6 +34,33 @@
     "preserveDuringPayloadReplacement": true,
     "releaseEligible": false
   },
+  "publicEvaluationMarketplace": {
+    "enabled": true,
+    "profileId": "public-cratis-ai",
+    "packageName": "@cratis/ai",
+    "versionPattern": "^0\\.(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)$",
+    "generator": "tooling/generate-public-marketplace-distribution.mjs",
+    "stager": "tooling/stage-public-marketplace-repository.mjs",
+    "sourceArtifactId": "candidate-passive-public-package",
+    "targetCount": 34,
+    "selfHostedChannels": [
+      "agent-skills",
+      "agent-plugin",
+      "claude-code",
+      "github-copilot",
+      "gemini-cli",
+      "kiro",
+      "pi-git-package"
+    ],
+    "vendorPortalHandoffs": [
+      "openai-skills-only-plugin",
+      "cursor-agent-plugin"
+    ],
+    "publicationEligible": true,
+    "installationSupported": false,
+    "supportGranted": false,
+    "promotionEligible": false
+  },
   "localSimulation": {
     "enabled": true,
     "identity": {

--- a/distribution/public-marketplace-release.schema.json
+++ b/distribution/public-marketplace-release.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Cratis/AI/distribution/public-marketplace-release.schema.json",
+  "title": "Cratis AI public marketplace evaluation release",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "schemaPath",
+    "schemaSha256",
+    "state",
+    "version",
+    "profileId",
+    "packageName",
+    "description",
+    "sourceCommit",
+    "targetCount",
+    "skillCount",
+    "selectedHarnesses",
+    "marketplaceChannels",
+    "installationAvailable",
+    "installationSupported",
+    "supportGranted",
+    "promotionEligible"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "schemaPath": { "const": "distribution/public-marketplace-release.schema.json" },
+    "schemaSha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "state": { "const": "PUBLIC_EVALUATION_MARKETPLACE" },
+    "version": { "type": "string", "pattern": "^0\\.(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)$" },
+    "profileId": { "const": "public-cratis-ai" },
+    "packageName": { "const": "@cratis/ai" },
+    "description": { "type": "string", "minLength": 1 },
+    "sourceCommit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "targetCount": { "const": 34 },
+    "skillCount": { "const": 34 },
+    "selectedHarnesses": {
+      "type": "array",
+      "minItems": 9,
+      "maxItems": 9,
+      "uniqueItems": true,
+      "items": {
+        "enum": ["agent-skills", "agent-plugin", "claude", "codex", "copilot", "cursor", "gemini", "kiro", "pi"]
+      }
+    },
+    "marketplaceChannels": {
+      "type": "array",
+      "minItems": 9,
+      "maxItems": 9,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "agent-skills",
+          "agent-plugin",
+          "claude-code",
+          "codex-openai-submission",
+          "github-copilot",
+          "cursor-submission",
+          "gemini-cli",
+          "kiro",
+          "pi-git-package"
+        ]
+      }
+    },
+    "installationAvailable": { "const": true },
+    "installationSupported": { "const": false },
+    "supportGranted": { "const": false },
+    "promotionEligible": { "const": false }
+  }
+}

--- a/distribution/repository-control-plane/.github/scripts/verify-generated-distribution.mjs
+++ b/distribution/repository-control-plane/.github/scripts/verify-generated-distribution.mjs
@@ -414,7 +414,16 @@ function verifyCandidateReviewRoot(root, candidateRoot) {
 function verifyExactInventory(root) {
     const manifest = loadManifest(root);
     const actualPaths = walkFiles(root).sort();
-    const actualControlPlanePaths = actualPaths.filter((path) => path.startsWith(".github/"));
+    const marketplaceGitHubPayloadPaths = new Set(
+        manifest.state === "PUBLIC_EVALUATION_MARKETPLACE"
+            ? [".github/plugin/marketplace.json"]
+            : [],
+    );
+    const actualControlPlanePaths = actualPaths.filter(
+        (path) =>
+            path.startsWith(".github/") &&
+            !marketplaceGitHubPayloadPaths.has(path),
+    );
     if (
         actualControlPlanePaths.length > 0 &&
         JSON.stringify(actualControlPlanePaths) !==
@@ -439,7 +448,7 @@ function verifyExactInventory(root) {
         verifyCandidateReviewRoot(root, candidateRoot);
     const payloadPaths = actualPaths.filter(
         (path) =>
-            !path.startsWith(".github/") &&
+            !controlPlanePaths.includes(path) &&
             !path.startsWith("candidates/"),
     );
     const expectedPayloadPaths = [
@@ -458,6 +467,29 @@ function verifyCanonicalByteParity(root) {
     if (!Array.isArray(provenance.canonicalFiles) || provenance.canonicalFiles.length === 0)
         throw new Error("Distribution provenance canonical inventory is missing");
     const manifestedPaths = manifest.files.map((file) => file.path);
+    if (manifest.state === "PUBLIC_EVALUATION_MARKETPLACE") {
+        for (const file of provenance.canonicalFiles) {
+            assertSafeRelativePath(file.path);
+            if (!Array.isArray(file.copies) || file.copies.length !== 2)
+                throw new Error(`Marketplace canonical copy inventory changed: ${file.path}`);
+            const expectedCopies = [
+                file.path,
+                `plugins/${manifest.profileId}/${file.path}`,
+            ];
+            if (JSON.stringify(file.copies) !== JSON.stringify(expectedCopies))
+                throw new Error(`Marketplace canonical copy paths changed: ${file.path}`);
+            const canonical = readFileSync(join(root, file.path));
+            if (canonical.length !== file.size || sha256(canonical) !== file.sha256)
+                throw new Error(`Marketplace canonical provenance mismatch: ${file.path}`);
+            for (const path of file.copies) {
+                if (!manifestedPaths.includes(path))
+                    throw new Error(`Marketplace canonical copy is unmanifested: ${path}`);
+                if (!readFileSync(join(root, path)).equals(canonical))
+                    throw new Error(`Marketplace canonical byte parity failed: ${path}`);
+            }
+        }
+        return;
+    }
     const expectedTargets = [...manifest.generatedTargets].sort();
     for (const file of provenance.canonicalFiles) {
         assertSafeRelativePath(file.path);
@@ -518,6 +550,28 @@ function verifyChecksums(root) {
 function verifyFixtureProvenance(root) {
     const manifest = verifyExactInventory(root);
     const provenance = readJson(join(root, "provenance.json"));
+    if (manifest.state === "PUBLIC_EVALUATION_MARKETPLACE") {
+        if (
+            manifest.publicationEligible !== true ||
+            manifest.installationSupported !== false ||
+            manifest.supportGranted !== false ||
+            manifest.promotionEligible !== false ||
+            provenance.state !== "PUBLIC_EVALUATION_MARKETPLACE_NOT_SUPPORT" ||
+            provenance.canonicalRepository !== "Cratis/AI" ||
+            provenance.distributionRepository !== "Cratis/AI.Distribution" ||
+            provenance.generator !==
+                "tooling/generate-public-marketplace-distribution.mjs" ||
+            provenance.version !== manifest.version ||
+            provenance.installationAvailable !== true ||
+            provenance.installationSupported !== false ||
+            provenance.behaviorSupported !== false ||
+            provenance.supportGranted !== false ||
+            provenance.promotionEligible !== false
+        ) {
+            throw new Error("Marketplace provenance or eligibility state changed");
+        }
+        return;
+    }
     if (
         manifest.state !== "FIXTURE_ONLY_LOCAL_STAGING" ||
         manifest.publicationEligible !== false ||

--- a/distribution/rollout-policy.json
+++ b/distribution/rollout-policy.json
@@ -27,6 +27,28 @@
       "pack-install-smoke-uninstall"
     ]
   },
+  "publicEvaluationMarketplace": {
+    "enabled": true,
+    "profileId": "public-cratis-ai",
+    "versionChannel": "0.x.y",
+    "selfHostedChannels": [
+      "agent-skills",
+      "agent-plugin",
+      "claude-code",
+      "github-copilot",
+      "gemini-cli",
+      "kiro",
+      "pi-git-package"
+    ],
+    "vendorPortalHandoffs": [
+      "openai-skills-only-plugin",
+      "cursor-agent-plugin"
+    ],
+    "publicationEligible": true,
+    "installationSupported": false,
+    "supportGranted": false,
+    "promotionEligible": false
+  },
   "canary": {
     "enabledTargets": [
       "local-fixture-simulator"

--- a/tooling/catalog-validation.mjs
+++ b/tooling/catalog-validation.mjs
@@ -163,6 +163,10 @@ function matchesKnownPattern(value, pattern) {
         case "^[a-f0-9]{64}$":
         case "^[0-9a-f]{64}$":
             return /^[a-f0-9]{64}$/.test(value);
+        case "^0\\.(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)$":
+            return /^0\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$/.test(
+                value,
+            );
         case "^0\\.0\\.(?:0|[1-9][0-9]*)-candidate\\.(?:0|[1-9][0-9]*)$":
             return /^0\.0\.(?:0|[1-9][0-9]*)-candidate\.(?:0|[1-9][0-9]*)$/.test(
                 value,

--- a/tooling/generate-public-marketplace-distribution.mjs
+++ b/tooling/generate-public-marketplace-distribution.mjs
@@ -1,0 +1,372 @@
+#!/usr/bin/env node
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+    existsSync,
+    lstatSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    readdirSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { compareOrdinal } from "./catalog-ordering.mjs";
+import { loadPassiveCandidateAuthority } from "./package-passive-candidate-assets.mjs";
+import { generatePassiveProfileAdapters } from "./passive-profile-adapters.mjs";
+
+const defaultRepositoryRoot = resolve(
+    fileURLToPath(new URL("..", import.meta.url)),
+);
+const profileId = "public-cratis-ai";
+const packageName = "@cratis/ai";
+const description =
+    "Cratis AI skills for event-sourced and CQRS application development";
+const repositoryUrl = "https://github.com/Cratis/AI.Distribution";
+const homepage = "https://cratis.io/ai";
+const selectedHarnesses = Object.freeze([
+    "agent-skills",
+    "agent-plugin",
+    "claude",
+    "codex",
+    "copilot",
+    "cursor",
+    "gemini",
+    "kiro",
+    "pi",
+]);
+
+function sha256(content) {
+    return createHash("sha256").update(content).digest("hex");
+}
+
+function writeJson(path, value) {
+    writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, { flag: "wx" });
+}
+
+function walkFiles(root, current = root) {
+    return readdirSync(current, { withFileTypes: true }).flatMap((entry) => {
+        const path = join(current, entry.name);
+        const relativePath = relative(root, path).replaceAll("\\", "/");
+        const stat = lstatSync(path);
+        if (stat.isSymbolicLink())
+            throw new Error(`Marketplace source contains a symlink: ${relativePath}`);
+        if (stat.isDirectory()) return walkFiles(root, path);
+        if (!stat.isFile())
+            throw new Error(`Marketplace source contains a special file: ${relativePath}`);
+        return [relativePath];
+    });
+}
+
+function mergeRoot(sourceRoot, outputRoot, origins, harness) {
+    for (const path of walkFiles(sourceRoot).sort(compareOrdinal)) {
+        const source = readFileSync(join(sourceRoot, path));
+        const destination = join(outputRoot, path);
+        if (existsSync(destination)) {
+            if (!readFileSync(destination).equals(source))
+                throw new Error(
+                    `Marketplace projection collision differs: ${path} (${origins.get(path)} and ${harness})`,
+                );
+            origins.set(path, `${origins.get(path)},${harness}`);
+            continue;
+        }
+        mkdirSync(dirname(destination), { recursive: true });
+        writeFileSync(destination, source, { flag: "wx" });
+        origins.set(path, harness);
+    }
+}
+
+function marketplaceReadme(version) {
+    return `# Cratis AI\n\n` +
+        `Passive skills for building event-sourced and CQRS applications with Cratis.\n\n` +
+        `## Install\n\n` +
+        `### Claude Code\n\n` +
+        `\`\`\`text\n/plugin marketplace add Cratis/AI.Distribution\n/plugin install ${profileId}@cratis\n\`\`\`\n\n` +
+        `### OpenAI Codex CLI\n\n` +
+        `\`\`\`bash\ncodex plugin marketplace add Cratis/AI.Distribution --ref v${version}\ncodex plugin add ${profileId}@cratis\n\`\`\`\n\n` +
+        `### GitHub Copilot CLI\n\n` +
+        `\`\`\`bash\ncopilot plugin marketplace add Cratis/AI.Distribution\ncopilot plugin install ${profileId}@cratis\n\`\`\`\n\n` +
+        `### Gemini CLI\n\n` +
+        `\`\`\`bash\ngemini extensions install https://github.com/Cratis/AI.Distribution --ref v${version}\n\`\`\`\n\n` +
+        `### Kiro\n\n` +
+        `Choose **Add Custom Power**, then import \`${repositoryUrl}\`.\n\n` +
+        `### Pi\n\n` +
+        `\`\`\`bash\npi install git:github.com/Cratis/AI.Distribution@v${version}\n\`\`\`\n\n` +
+        `### Generic Agent Skills and Agent Plugins\n\n` +
+        `Use the root \`skills/\` directory or root \`plugin.json\` from the tagged repository.\n\n` +
+        `## Status\n\n` +
+        `This is an unsupported \`0.x\` evaluation distribution. Publication, static validation, ` +
+        `and package lifecycle checks do not grant a support claim. The source repository's ` +
+        `blocked and repository-only exclusions remain excluded.\n`;
+}
+
+function openAiSubmission(version) {
+    return {
+        schemaVersion: "1.0.0",
+        submissionType: "skills-only",
+        pluginRoot: `plugins/${profileId}`,
+        name: "Cratis AI",
+        shortDescription:
+            "Cratis skills for event-sourced and CQRS application development.",
+        longDescription:
+            "Passive guidance for Cratis Fundamentals, Arc, Chronicle, Components, React, specifications, documentation, and application workflows. The plugin contains instructions and references only; it has no MCP server, scripts, dependencies, credentials, or network behavior.",
+        category: "Developer Tools",
+        website: homepage,
+        supportUrl: "https://github.com/Cratis/AI/issues",
+        sourceRepository: repositoryUrl,
+        version,
+        releaseNotes: "Initial unsupported 0.x public evaluation release.",
+        portalReadiness: "OWNER_IDENTITY_AND_LISTING_ASSETS_REQUIRED",
+        requiredOwnerInputs: [
+            "verified OpenAI developer identity",
+            "logo",
+            "privacy policy URL",
+            "terms URL",
+            "country availability",
+            "policy attestations",
+        ],
+        supportGranted: false,
+        positiveTests: [
+            {
+                prompt: "Create a strongly typed author name concept and a Guid-backed Chronicle event-source identity.",
+                expected: "Uses ConceptAs<string> and EventSourceId<Guid> with Cratis conventions.",
+            },
+            {
+                prompt: "Add a model-bound Arc command that appends a past-tense Chronicle event.",
+                expected: "Uses a model-bound command, validator boundaries, and an immutable event.",
+            },
+            {
+                prompt: "Create a Chronicle read model and projection for a list of registered authors.",
+                expected: "Uses a focused read model, AutoMap-first projection guidance, and a model-bound query.",
+            },
+            {
+                prompt: "Build a React page that consumes an Arc-generated observable query.",
+                expected: "Uses generated proxies, MVVM conventions, and Cratis Components.",
+            },
+            {
+                prompt: "Write behavior specs for a Cratis command and its appended event.",
+                expected: "Uses the appropriate in-process scenario and BDD naming conventions.",
+            },
+        ],
+        negativeTests: [
+            {
+                prompt: "Write a generic sorting algorithm in Rust.",
+                expected: "Does not apply Cratis-specific application guidance.",
+                rationale: "The request is unrelated to Cratis.",
+            },
+            {
+                prompt: "Call an undocumented Studio MCP operation to delete production data.",
+                expected: "Refuses to invent or invoke an unadmitted operation.",
+                rationale: "No executable Studio MCP operation is included.",
+            },
+            {
+                prompt: "Implement a Chronicle Java client from assumptions about the Kotlin client.",
+                expected: "Does not synthesize unsupported Java client authority.",
+                rationale: "The public profile records an authority gap for Java.",
+            },
+        ],
+    };
+}
+
+function cursorSubmission(version) {
+    return {
+        schemaVersion: "1.0.0",
+        name: profileId,
+        displayName: "Cratis AI",
+        repository: repositoryUrl,
+        pluginManifest: "plugin.json",
+        marketplaceManifest: ".cursor-plugin/marketplace.json",
+        category: "Developer Tools",
+        version,
+        description,
+        supportUrl: "https://github.com/Cratis/AI/issues",
+        localValidationRequired: true,
+        supportGranted: false,
+    };
+}
+
+function canonicalFileRecords(authority, outputRoot) {
+    return authority.skills.flatMap((skill) =>
+        skill.files.map((file) => {
+            const canonicalPath = `skills/${skill.name}/${file.path}`;
+            const pluginPath = `plugins/${profileId}/${canonicalPath}`;
+            const content = readFileSync(join(outputRoot, canonicalPath));
+            if (!readFileSync(join(outputRoot, pluginPath)).equals(content))
+                throw new Error(`Marketplace plugin byte parity failed: ${canonicalPath}`);
+            return {
+                path: canonicalPath,
+                size: content.length,
+                sha256: sha256(content),
+                copies: [canonicalPath, pluginPath],
+            };
+        }),
+    ).sort((left, right) => compareOrdinal(left.path, right.path));
+}
+
+export function generatePublicMarketplaceDistribution({
+    repositoryRoot = defaultRepositoryRoot,
+    outputRoot,
+    version,
+} = {}) {
+    if (!outputRoot || !/^0\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$/.test(version ?? ""))
+        throw new Error("outputRoot and an exact 0.x.y version are required");
+    const root = resolve(outputRoot);
+    if (existsSync(root)) throw new Error(`Marketplace output already exists: ${root}`);
+    const temporaryRoot = mkdtempSync(join(tmpdir(), "cratis-marketplace-"));
+    mkdirSync(root, { recursive: false });
+    try {
+        const authority = loadPassiveCandidateAuthority(
+            repositoryRoot,
+            "candidate-passive-public-package",
+        );
+        if (authority.targets.length !== 34)
+            throw new Error("Public marketplace target inventory changed");
+        const adaptersRoot = join(temporaryRoot, "adapters");
+        const adapters = generatePassiveProfileAdapters({
+            outputRoot: adaptersRoot,
+            version,
+            profileId,
+            packageName,
+            description,
+            skills: authority.skills,
+            codexInstallationPolicy: "AVAILABLE",
+            piPrivate: false,
+            homepage,
+            repositoryUrl,
+        });
+        const origins = new Map();
+        for (const harness of selectedHarnesses) {
+            const harnessRoot = adapters.roots[harness];
+            if (!harnessRoot) throw new Error(`Missing marketplace harness: ${harness}`);
+            mergeRoot(join(adaptersRoot, harnessRoot), root, origins, harness);
+        }
+        writeFileSync(join(root, "LICENSE"), readFileSync(join(repositoryRoot, "LICENSE")), {
+            flag: "wx",
+        });
+        writeFileSync(join(root, "README.md"), marketplaceReadme(version), {
+            flag: "wx",
+        });
+        mkdirSync(join(root, "submissions"), { recursive: false });
+        writeJson(join(root, "submissions/openai.json"), openAiSubmission(version));
+        writeJson(join(root, "submissions/cursor.json"), cursorSubmission(version));
+
+        const sourceCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+            cwd: repositoryRoot,
+            encoding: "utf8",
+        }).trim();
+        const canonicalFiles = canonicalFileRecords(authority, root);
+        const provenance = {
+            schemaVersion: "1.0.0",
+            state: "PUBLIC_EVALUATION_MARKETPLACE_NOT_SUPPORT",
+            canonicalRepository: "Cratis/AI",
+            distributionRepository: "Cratis/AI.Distribution",
+            sourceCommit,
+            generator: "tooling/generate-public-marketplace-distribution.mjs",
+            version,
+            profileId,
+            selectedHarnesses,
+            targetIds: authority.targets.map((target) => target.id).sort(compareOrdinal),
+            targetExclusions: authority.artifact.targetExclusions ?? [],
+            repositoryOnlySkillExclusions: authority.repositoryOnlySkills,
+            nativeComponentsIncluded: false,
+            nativeComponentsReason:
+                "Native rules and instructions retain separate semantic artifacts and are not repackaged as skills.",
+            canonicalFiles,
+            installationAvailable: true,
+            installationSupported: false,
+            behaviorSupported: false,
+            supportGranted: false,
+            promotionEligible: false,
+        };
+        writeJson(join(root, "provenance.json"), provenance);
+        const releaseSchemaPath =
+            "distribution/public-marketplace-release.schema.json";
+        const release = {
+            schemaVersion: "1.0.0",
+            schemaPath: releaseSchemaPath,
+            schemaSha256: sha256(
+                readFileSync(join(repositoryRoot, releaseSchemaPath)),
+            ),
+            state: "PUBLIC_EVALUATION_MARKETPLACE",
+            version,
+            profileId,
+            packageName,
+            description,
+            sourceCommit,
+            targetCount: authority.targets.length,
+            skillCount: authority.skills.length,
+            selectedHarnesses,
+            marketplaceChannels: [
+                "agent-skills",
+                "agent-plugin",
+                "claude-code",
+                "codex-openai-submission",
+                "github-copilot",
+                "cursor-submission",
+                "gemini-cli",
+                "kiro",
+                "pi-git-package",
+            ],
+            installationAvailable: true,
+            installationSupported: false,
+            supportGranted: false,
+            promotionEligible: false,
+        };
+        writeJson(join(root, "marketplace-release.json"), release);
+
+        const checksumPaths = walkFiles(root).sort(compareOrdinal);
+        writeFileSync(
+            join(root, "SHA256SUMS"),
+            `${checksumPaths
+                .map((path) => `${sha256(readFileSync(join(root, path)))}  ${path}`)
+                .join("\n")}\n`,
+            { flag: "wx" },
+        );
+        const manifestPaths = walkFiles(root).sort(compareOrdinal);
+        const manifest = {
+            schemaVersion: "1.0.0",
+            state: "PUBLIC_EVALUATION_MARKETPLACE",
+            version,
+            profileId,
+            generatedTargets: selectedHarnesses,
+            files: manifestPaths.map((path) => {
+                const content = readFileSync(join(root, path));
+                return { path, sha256: sha256(content), size: content.length };
+            }),
+            publicationEligible: true,
+            installationSupported: false,
+            supportGranted: false,
+            promotionEligible: false,
+        };
+        writeJson(join(root, "distribution-manifest.json"), manifest);
+        return { manifest, provenance, release };
+    } catch (error) {
+        rmSync(root, { recursive: true, force: true });
+        throw error;
+    } finally {
+        rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+}
+
+function main() {
+    const [outputRoot, version] = process.argv.slice(2);
+    try {
+        const result = generatePublicMarketplaceDistribution({ outputRoot, version });
+        process.stdout.write(
+            `Generated ${result.release.profileId}@${result.release.version} for ${result.release.marketplaceChannels.length} marketplace channels.\n`,
+        );
+    } catch (error) {
+        process.stderr.write(
+            `${error instanceof Error ? error.message : "Marketplace generation failed"}\n`,
+        );
+        process.exitCode = 1;
+    }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/tooling/generate-repository-inventory.mjs
+++ b/tooling/generate-repository-inventory.mjs
@@ -533,6 +533,7 @@ const definitions = [
             ".github/workflows/engineering-distribution-fixture.yml",
             ".github/workflows/distribution-generated-update.yml",
             ".github/workflows/distribution-npm-stage.yml",
+            ".github/workflows/distribution-public-marketplace.yml",
             ".github/workflows/package-passive-candidate-assets.yml",
             ".github/workflows/release-approved-ai-profiles.yml",
             ".github/workflows/release-passive-previews.yml",

--- a/tooling/package-public-marketplace-submissions.mjs
+++ b/tooling/package-public-marketplace-submissions.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+    cpSync,
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const pluginName = "public-cratis-ai";
+
+function sha256(content) {
+    return createHash("sha256").update(content).digest("hex");
+}
+
+function readJson(path) {
+    try {
+        return JSON.parse(readFileSync(path, "utf8"));
+    } catch (error) {
+        throw new Error(`Unable to read JSON: ${path}`, { cause: error });
+    }
+}
+
+function writeJson(path, value) {
+    writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, { flag: "wx" });
+}
+
+export function packagePublicMarketplaceSubmissions({
+    marketplaceRoot,
+    outputRoot,
+} = {}) {
+    if (!marketplaceRoot || !existsSync(marketplaceRoot))
+        throw new Error("marketplaceRoot must exist");
+    if (!outputRoot) throw new Error("outputRoot is required");
+    const sourceRoot = resolve(marketplaceRoot);
+    const root = resolve(outputRoot);
+    if (existsSync(root)) throw new Error(`Submission output already exists: ${root}`);
+    const temporaryRoot = mkdtempSync(join(tmpdir(), "cratis-submission-"));
+    mkdirSync(root, { recursive: false });
+    try {
+        const release = readJson(join(sourceRoot, "marketplace-release.json"));
+        const openAi = readJson(join(sourceRoot, "submissions/openai.json"));
+        const cursor = readJson(join(sourceRoot, "submissions/cursor.json"));
+        if (
+            release.state !== "PUBLIC_EVALUATION_MARKETPLACE" ||
+            openAi.submissionType !== "skills-only" ||
+            openAi.positiveTests?.length < 5 ||
+            openAi.negativeTests?.length < 3 ||
+            openAi.portalReadiness !==
+                "OWNER_IDENTITY_AND_LISTING_ASSETS_REQUIRED" ||
+            !Array.isArray(openAi.requiredOwnerInputs) ||
+            openAi.requiredOwnerInputs.length === 0 ||
+            openAi.supportGranted !== false ||
+            cursor.supportGranted !== false
+        )
+            throw new Error("Marketplace submission metadata is incomplete");
+        const pluginRoot = join(temporaryRoot, pluginName);
+        mkdirSync(pluginRoot, { recursive: true });
+        cpSync(
+            join(sourceRoot, `plugins/${pluginName}/.codex-plugin`),
+            join(pluginRoot, ".codex-plugin"),
+            { recursive: true, errorOnExist: true },
+        );
+        cpSync(
+            join(sourceRoot, `plugins/${pluginName}/skills`),
+            join(pluginRoot, "skills"),
+            { recursive: true, errorOnExist: true },
+        );
+        cpSync(join(sourceRoot, "LICENSE"), join(pluginRoot, "LICENSE"), {
+            errorOnExist: true,
+        });
+        cpSync(join(sourceRoot, "README.md"), join(pluginRoot, "README.md"), {
+            errorOnExist: true,
+        });
+        const archiveName = `${pluginName}-${release.version}-openai.zip`;
+        const archivePath = join(root, archiveName);
+        const python = String.raw`
+import os, pathlib, stat, sys, zipfile
+source = pathlib.Path(sys.argv[1])
+destination = pathlib.Path(sys.argv[2])
+base = source.parent
+files = sorted(path for path in source.rglob('*') if path.is_file())
+with zipfile.ZipFile(destination, 'w', compression=zipfile.ZIP_DEFLATED, compresslevel=9) as archive:
+    for path in files:
+        relative = path.relative_to(base).as_posix()
+        info = zipfile.ZipInfo(relative, date_time=(1980, 1, 1, 0, 0, 0))
+        info.compress_type = zipfile.ZIP_DEFLATED
+        info.external_attr = (stat.S_IFREG | 0o644) << 16
+        archive.writestr(info, path.read_bytes(), compress_type=zipfile.ZIP_DEFLATED, compresslevel=9)
+`;
+        execFileSync("python3", ["-c", python, pluginRoot, archivePath], {
+            stdio: ["ignore", "pipe", "pipe"],
+        });
+        const archive = readFileSync(archivePath);
+        const manifest = {
+            schemaVersion: "1.0.0",
+            state: "VENDOR_PORTAL_HANDOFF_PREPARED",
+            version: release.version,
+            sourceCommit: release.sourceCommit,
+            openAi: {
+                archive: archiveName,
+                sha256: sha256(archive),
+                pluginRoot: pluginName,
+                positiveTestCount: openAi.positiveTests.length,
+                negativeTestCount: openAi.negativeTests.length,
+                interactivePortalRequired: true,
+                ownerMetadataRequired: true,
+                requiredOwnerInputs: openAi.requiredOwnerInputs,
+                reviewRequired: true,
+            },
+            cursor: {
+                repository: cursor.repository,
+                pluginManifest: cursor.pluginManifest,
+                interactivePortalRequired: true,
+                reviewRequired: true,
+            },
+            supportGranted: false,
+            promotionEligible: false,
+        };
+        writeJson(join(root, "vendor-portal-handoff.json"), manifest);
+        writeFileSync(
+            join(root, "SHA256SUMS"),
+            `${manifest.openAi.sha256}  ${archiveName}\n${sha256(
+                readFileSync(join(root, "vendor-portal-handoff.json")),
+            )}  vendor-portal-handoff.json\n`,
+            { flag: "wx" },
+        );
+        return manifest;
+    } catch (error) {
+        rmSync(root, { recursive: true, force: true });
+        throw error;
+    } finally {
+        rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+}
+
+function main() {
+    const [marketplaceRoot, outputRoot] = process.argv.slice(2);
+    try {
+        const result = packagePublicMarketplaceSubmissions({
+            marketplaceRoot,
+            outputRoot,
+        });
+        process.stdout.write(
+            `Packaged OpenAI and Cursor portal handoffs for ${result.version}.\n`,
+        );
+    } catch (error) {
+        process.stderr.write(
+            `${error instanceof Error ? error.message : "Submission packaging failed"}\n`,
+        );
+        process.exitCode = 1;
+    }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/tooling/passive-profile-adapters.mjs
+++ b/tooling/passive-profile-adapters.mjs
@@ -60,7 +60,13 @@ export function createClaudePluginManifest({ name, version, description }) {
     };
 }
 
-export function createAgentPluginManifest({ name, version, description }) {
+export function createAgentPluginManifest({
+    name,
+    version,
+    description,
+    homepage = "https://cratis.io/ai",
+    repository = "https://github.com/Cratis/AI",
+}) {
     return {
         $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
         name,
@@ -70,8 +76,8 @@ export function createAgentPluginManifest({ name, version, description }) {
             name: "Cratis",
             url: "https://cratis.io",
         },
-        homepage: "https://cratis.io/ai",
-        repository: "https://github.com/Cratis/AI",
+        homepage,
+        repository,
         license: "MIT",
         keywords: ["cratis", "agent-skills"],
     };
@@ -180,6 +186,8 @@ function metadataFilesForHarness(harness, options) {
         description,
         codexInstallationPolicy,
         piPrivate,
+        homepage = "https://cratis.io/ai",
+        repositoryUrl = "https://github.com/Cratis/AI",
     } = options;
     const files = [];
     const add = (path, value) => {
@@ -194,6 +202,8 @@ function metadataFilesForHarness(harness, options) {
                     name: profileId,
                     version,
                     description,
+                    homepage,
+                    repository: repositoryUrl,
                 }),
             );
             break;
@@ -270,6 +280,8 @@ function metadataFilesForHarness(harness, options) {
                     name: profileId,
                     version,
                     description,
+                    homepage,
+                    repository: repositoryUrl,
                 }),
             );
             break;
@@ -290,9 +302,9 @@ function metadataFilesForHarness(harness, options) {
                 license: "MIT",
                 repository: {
                     type: "git",
-                    url: "https://github.com/Cratis/AI",
+                    url: repositoryUrl,
                 },
-                homepage: "https://cratis.io/ai",
+                homepage,
                 files: ["skills"],
                 keywords: ["pi-package", "cratis"],
                 pi: { skills: ["./skills"] },

--- a/tooling/specs/distribution-repository-verification.spec.mjs
+++ b/tooling/specs/distribution-repository-verification.spec.mjs
@@ -16,6 +16,7 @@ import { dirname, join, resolve } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 import { generateDistributionFixture } from "../generate-distribution-fixture.mjs";
+import { generatePublicMarketplaceDistribution } from "../generate-public-marketplace-distribution.mjs";
 import { packagePassiveCandidateAssets } from "../package-passive-candidate-assets.mjs";
 import {
     distributionCheckNames,
@@ -101,6 +102,62 @@ test("generated repository verification runs every exact non-supporting check", 
                 supporting: false,
             });
         }
+    });
+});
+
+test("generated repository verification accepts the public marketplace transition", () => {
+    withTemporaryDirectory((root) => {
+        const beforeRoot = join(root, "before");
+        const marketplaceRoot = join(root, "marketplace");
+        generateDistributionFixture({
+            repositoryRoot,
+            outputRoot: beforeRoot,
+            version: "0.0.1-fixture",
+        });
+        generatePublicMarketplaceDistribution({
+            repositoryRoot,
+            outputRoot: marketplaceRoot,
+            version: "0.2.0",
+        });
+        installControlPlane(marketplaceRoot);
+        for (const check of distributionCheckNames) {
+            const result = verifyDistributionCheck({
+                root: marketplaceRoot,
+                check,
+                beforeRoot,
+            });
+            assert.deepEqual(result, {
+                check,
+                status: "PASS",
+                supporting: false,
+            });
+        }
+    });
+});
+
+test("generated repository verification rejects marketplace support drift", () => {
+    withTemporaryDirectory((root) => {
+        const marketplaceRoot = join(root, "marketplace");
+        generatePublicMarketplaceDistribution({
+            repositoryRoot,
+            outputRoot: marketplaceRoot,
+            version: "0.2.0",
+        });
+        const manifestPath = join(
+            marketplaceRoot,
+            "distribution-manifest.json",
+        );
+        const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+        manifest.supportGranted = true;
+        writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+        assert.throws(
+            () =>
+                verifyDistributionCheck({
+                    root: marketplaceRoot,
+                    check: "fixture-provenance-record",
+                }),
+            /Marketplace provenance or eligibility state changed/,
+        );
     });
 });
 

--- a/tooling/specs/distribution-rollout.spec.mjs
+++ b/tooling/specs/distribution-rollout.spec.mjs
@@ -47,6 +47,12 @@ test("rollout policy keeps production promotion and retirement blocked", () => {
         "cratis-fundamentals-concept-preview",
     ]);
     assert.equal(policy.generatedRepository.botOnlyWrites, true);
+    assert.equal(policy.publicEvaluationMarketplace.enabled, true);
+    assert.equal(policy.publicEvaluationMarketplace.profileId, "public-cratis-ai");
+    assert.equal(policy.publicEvaluationMarketplace.publicationEligible, true);
+    assert.equal(policy.publicEvaluationMarketplace.installationSupported, false);
+    assert.equal(policy.publicEvaluationMarketplace.supportGranted, false);
+    assert.equal(policy.publicEvaluationMarketplace.promotionEligible, false);
     assert.equal(policy.canary.productionTargetsEnabled, false);
     assert.equal(policy.releaseOnMergeAutomation.mergeToMainIsApproval, true);
     assert.equal(policy.releaseOnMergeAutomation.canaryBeforePublication, true);

--- a/tooling/specs/generated-distribution-repository.spec.mjs
+++ b/tooling/specs/generated-distribution-repository.spec.mjs
@@ -102,6 +102,33 @@ test("generated repository contract keeps remote authority and production blocke
         preserveDuringPayloadReplacement: true,
         releaseEligible: false,
     });
+    assert.deepEqual(contract.publicEvaluationMarketplace, {
+        enabled: true,
+        profileId: "public-cratis-ai",
+        packageName: "@cratis/ai",
+        versionPattern: "^0\\.(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)$",
+        generator: "tooling/generate-public-marketplace-distribution.mjs",
+        stager: "tooling/stage-public-marketplace-repository.mjs",
+        sourceArtifactId: "candidate-passive-public-package",
+        targetCount: 34,
+        selfHostedChannels: [
+            "agent-skills",
+            "agent-plugin",
+            "claude-code",
+            "github-copilot",
+            "gemini-cli",
+            "kiro",
+            "pi-git-package",
+        ],
+        vendorPortalHandoffs: [
+            "openai-skills-only-plugin",
+            "cursor-agent-plugin",
+        ],
+        publicationEligible: true,
+        installationSupported: false,
+        supportGranted: false,
+        promotionEligible: false,
+    });
     assert.deepEqual(contract.requiredChecks, [
         ...rolloutPolicy.candidate.requiredChecks,
         "canary-rollback-simulation",

--- a/tooling/specs/public-marketplace-distribution.spec.mjs
+++ b/tooling/specs/public-marketplace-distribution.spec.mjs
@@ -1,0 +1,273 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert from "node:assert/strict";
+import {
+    mkdtempSync,
+    readFileSync,
+    readdirSync,
+    rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { execFileSync } from "node:child_process";
+import { validateAgainstSchema } from "../catalog-validation.mjs";
+import { generateDistributionFixture } from "../generate-distribution-fixture.mjs";
+import { generatePublicMarketplaceDistribution } from "../generate-public-marketplace-distribution.mjs";
+import { packagePublicMarketplaceSubmissions } from "../package-public-marketplace-submissions.mjs";
+import { stagePublicMarketplaceRepository } from "../stage-public-marketplace-repository.mjs";
+import {
+    distributionCheckNames,
+    verifyDistributionCheck,
+} from "../../distribution/repository-control-plane/.github/scripts/verify-generated-distribution.mjs";
+
+function withTemporaryDirectory(callback) {
+    const root = mkdtempSync(join(tmpdir(), "cratis-marketplace-spec-"));
+    try {
+        return callback(root);
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+}
+
+function readJson(path) {
+    return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function skillNames(root) {
+    return readdirSync(join(root, "skills"), { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name)
+        .sort();
+}
+
+test("public marketplace distribution is deterministic and support-free", () => {
+    withTemporaryDirectory((temporaryRoot) => {
+        const firstRoot = join(temporaryRoot, "first");
+        const secondRoot = join(temporaryRoot, "second");
+        const first = generatePublicMarketplaceDistribution({
+            outputRoot: firstRoot,
+            version: "0.2.0",
+        });
+        const second = generatePublicMarketplaceDistribution({
+            outputRoot: secondRoot,
+            version: "0.2.0",
+        });
+        assert.deepEqual(second, first);
+        const firstManifest = readFileSync(
+            join(firstRoot, "distribution-manifest.json"),
+        );
+        assert.deepEqual(
+            readFileSync(join(secondRoot, "distribution-manifest.json")),
+            firstManifest,
+        );
+        assert.equal(first.release.targetCount, 34);
+        assert.equal(first.release.skillCount, 34);
+        assert.equal(first.release.installationAvailable, true);
+        assert.equal(first.release.installationSupported, false);
+        assert.equal(first.release.supportGranted, false);
+        assert.equal(first.release.promotionEligible, false);
+        assert.equal(skillNames(firstRoot).length, 34);
+    });
+});
+
+test("marketplace root contains every first-class install shape", () => {
+    withTemporaryDirectory((temporaryRoot) => {
+        const root = join(temporaryRoot, "marketplace");
+        const generated = generatePublicMarketplaceDistribution({
+            outputRoot: root,
+            version: "0.2.0",
+        });
+        for (const path of [
+            "plugin.json",
+            "package.json",
+            "gemini-extension.json",
+            ".claude-plugin/marketplace.json",
+            ".github/plugin/marketplace.json",
+            ".cursor-plugin/marketplace.json",
+            ".agents/plugins/marketplace.json",
+            "plugins/public-cratis-ai/.claude-plugin/plugin.json",
+            "plugins/public-cratis-ai/.codex-plugin/plugin.json",
+            "plugins/public-cratis-ai/plugin.json",
+            "README.md",
+            "submissions/openai.json",
+            "submissions/cursor.json",
+            "SHA256SUMS",
+            "provenance.json",
+            "marketplace-release.json",
+        ]) {
+            assert(
+                generated.manifest.files.some((file) => file.path === path),
+                path,
+            );
+        }
+        const packageJson = readJson(join(root, "package.json"));
+        assert.equal(packageJson.name, "@cratis/ai");
+        assert.equal(packageJson.private, false);
+        assert.equal(packageJson.repository.url, "https://github.com/Cratis/AI.Distribution");
+        assert.deepEqual(packageJson.pi.skills, ["./skills"]);
+        for (const forbidden of [
+            "scripts",
+            "dependencies",
+            "devDependencies",
+            "optionalDependencies",
+        ])
+            assert.equal(packageJson[forbidden], undefined, forbidden);
+        const readme = readFileSync(join(root, "README.md"), "utf8");
+        for (const command of [
+            "/plugin marketplace add Cratis/AI.Distribution",
+            "codex plugin marketplace add Cratis/AI.Distribution --ref v0.2.0",
+            "copilot plugin marketplace add Cratis/AI.Distribution",
+            "gemini extensions install https://github.com/Cratis/AI.Distribution --ref v0.2.0",
+            "pi install git:github.com/Cratis/AI.Distribution@v0.2.0",
+        ])
+            assert(readme.includes(command), command);
+    });
+});
+
+test("canonical skills and plugin copies remain byte-identical", () => {
+    withTemporaryDirectory((temporaryRoot) => {
+        const root = join(temporaryRoot, "marketplace");
+        const { provenance } = generatePublicMarketplaceDistribution({
+            outputRoot: root,
+            version: "0.2.0",
+        });
+        assert(provenance.canonicalFiles.length > 34);
+        for (const file of provenance.canonicalFiles) {
+            assert.deepEqual(file.copies, [
+                file.path,
+                `plugins/public-cratis-ai/${file.path}`,
+            ]);
+            assert.deepEqual(
+                readFileSync(join(root, file.copies[0])),
+                readFileSync(join(root, file.copies[1])),
+                file.path,
+            );
+        }
+        assert.equal(provenance.targetIds.length, 34);
+        assert.deepEqual(
+            provenance.targetExclusions.map((entry) => entry.targetId).sort(),
+            [
+                "cratis-arc-observable-query-http",
+                "cratis-chronicle-mcp-inspection",
+                "cratis-studio-mcp-safety-guidance",
+            ],
+        );
+        assert.equal(provenance.nativeComponentsIncluded, false);
+        assert.equal(provenance.supportGranted, false);
+    });
+});
+
+test("OpenAI and Cursor handoff metadata is complete but non-supporting", () => {
+    withTemporaryDirectory((temporaryRoot) => {
+        const root = join(temporaryRoot, "marketplace");
+        generatePublicMarketplaceDistribution({
+            outputRoot: root,
+            version: "0.2.0",
+        });
+        const openAi = readJson(join(root, "submissions/openai.json"));
+        const cursor = readJson(join(root, "submissions/cursor.json"));
+        assert.equal(openAi.submissionType, "skills-only");
+        assert.equal(openAi.positiveTests.length, 5);
+        assert.equal(openAi.negativeTests.length, 3);
+        assert.equal(
+            openAi.portalReadiness,
+            "OWNER_IDENTITY_AND_LISTING_ASSETS_REQUIRED",
+        );
+        assert(openAi.requiredOwnerInputs.includes("privacy policy URL"));
+        assert.equal(openAi.supportGranted, false);
+        assert.equal(cursor.repository, "https://github.com/Cratis/AI.Distribution");
+        assert.equal(cursor.pluginManifest, "plugin.json");
+        assert.equal(cursor.supportGranted, false);
+    });
+});
+
+test("vendor portal handoff archive is deterministic and skills-only", () => {
+    withTemporaryDirectory((temporaryRoot) => {
+        const marketplaceRoot = join(temporaryRoot, "marketplace");
+        const firstRoot = join(temporaryRoot, "first");
+        const secondRoot = join(temporaryRoot, "second");
+        generatePublicMarketplaceDistribution({
+            outputRoot: marketplaceRoot,
+            version: "0.2.0",
+        });
+        const first = packagePublicMarketplaceSubmissions({
+            marketplaceRoot,
+            outputRoot: firstRoot,
+        });
+        const second = packagePublicMarketplaceSubmissions({
+            marketplaceRoot,
+            outputRoot: secondRoot,
+        });
+        assert.deepEqual(second, first);
+        assert.deepEqual(
+            readFileSync(join(firstRoot, first.openAi.archive)),
+            readFileSync(join(secondRoot, second.openAi.archive)),
+        );
+        const python =
+            "import json,sys,zipfile; print(json.dumps(zipfile.ZipFile(sys.argv[1]).namelist()))";
+        const paths = JSON.parse(
+            execFileSync(
+                "python3",
+                ["-c", python, join(firstRoot, first.openAi.archive)],
+                { encoding: "utf8" },
+            ),
+        );
+        assert(paths.includes("public-cratis-ai/.codex-plugin/plugin.json"));
+        assert(
+            paths.includes(
+                "public-cratis-ai/skills/cratis-fundamentals-concept/SKILL.md",
+            ),
+        );
+        assert.equal(paths.some((path) => path.includes(".mcp.json")), false);
+        assert.equal(first.openAi.positiveTestCount, 5);
+        assert.equal(first.openAi.negativeTestCount, 3);
+        assert.equal(first.openAi.interactivePortalRequired, true);
+        assert.equal(first.openAi.ownerMetadataRequired, true);
+        assert(first.openAi.requiredOwnerInputs.includes("terms URL"));
+        assert.equal(first.cursor.interactivePortalRequired, true);
+        assert.equal(first.supportGranted, false);
+    });
+});
+
+test("complete staged repository passes every protected Distribution check", () => {
+    withTemporaryDirectory((temporaryRoot) => {
+        const currentRoot = join(temporaryRoot, "current");
+        const stagedRoot = join(temporaryRoot, "staged");
+        generateDistributionFixture({
+            outputRoot: currentRoot,
+            version: "0.0.1-fixture",
+        });
+        stagePublicMarketplaceRepository({
+            currentDistributionRoot: currentRoot,
+            outputRoot: stagedRoot,
+            version: "0.2.0",
+        });
+        for (const check of distributionCheckNames) {
+            assert.deepEqual(
+                verifyDistributionCheck({
+                    root: stagedRoot,
+                    check,
+                    beforeRoot: currentRoot,
+                }),
+                { check, status: "PASS", supporting: false },
+            );
+        }
+    });
+});
+
+test("marketplace release manifest matches its closed schema", () => {
+    withTemporaryDirectory((temporaryRoot) => {
+        const root = join(temporaryRoot, "marketplace");
+        generatePublicMarketplaceDistribution({
+            outputRoot: root,
+            version: "0.2.0",
+        });
+        const schema = readJson(
+            "distribution/public-marketplace-release.schema.json",
+        );
+        const manifest = readJson(join(root, "marketplace-release.json"));
+        assert.deepEqual(validateAgainstSchema(manifest, schema, schema), []);
+    });
+});

--- a/tooling/specs/workflow-safety.spec.mjs
+++ b/tooling/specs/workflow-safety.spec.mjs
@@ -227,6 +227,41 @@ test("Fundamentals preview workflow is read-only short-lived and non-publishing"
         assert.equal(workflow.includes(forbidden), false, forbidden);
 });
 
+test("public marketplace staging is read-only and runs every Distribution gate", () => {
+    const workflow = readFileSync(
+        ".github/workflows/distribution-public-marketplace.yml",
+        "utf8",
+    );
+    for (const required of [
+        "workflow_dispatch:",
+        "permissions:\n  contents: read",
+        "repository: Cratis/AI.Distribution",
+        "stage-public-marketplace-repository.mjs",
+        "package-public-marketplace-submissions.mjs",
+        "vendor-portal-handoff",
+        "exact-inventory",
+        "canonical-byte-parity",
+        "native-manifest-parse",
+        "checksums",
+        "fixture-provenance-record",
+        "pack-install-smoke-uninstall",
+        "canary-rollback-simulation",
+        "include-hidden-files: true",
+        "retention-days: 7",
+    ])
+        assert(workflow.includes(required), required);
+    for (const forbidden of [
+        "id-token: write",
+        "contents: write",
+        "pull-requests: write",
+        "secrets:",
+        "git push",
+        "gh release",
+        "npm publish",
+    ])
+        assert.equal(workflow.includes(forbidden), false, forbidden);
+});
+
 test("approved profile workflow is bot-scoped and keeps publication separate", () => {
     const workflow = readFileSync(
         ".github/workflows/distribution-approved-profile-release.yml",

--- a/tooling/stage-public-marketplace-repository.mjs
+++ b/tooling/stage-public-marketplace-repository.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import {
+    cpSync,
+    existsSync,
+    mkdirSync,
+    readFileSync,
+    rmSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { generatePublicMarketplaceDistribution } from "./generate-public-marketplace-distribution.mjs";
+
+const defaultRepositoryRoot = resolve(
+    fileURLToPath(new URL("..", import.meta.url)),
+);
+
+function readJson(path) {
+    try {
+        return JSON.parse(readFileSync(path, "utf8"));
+    } catch (error) {
+        throw new Error(`Unable to read JSON: ${path}`, { cause: error });
+    }
+}
+
+const generatedRepositoryContract = readJson(
+    new URL("../distribution/generated-repository-contract.json", import.meta.url),
+);
+
+export function stagePublicMarketplaceRepository({
+    repositoryRoot = defaultRepositoryRoot,
+    currentDistributionRoot,
+    outputRoot,
+    version,
+} = {}) {
+    if (!currentDistributionRoot || !existsSync(currentDistributionRoot))
+        throw new Error("currentDistributionRoot must exist");
+    if (!outputRoot) throw new Error("outputRoot is required");
+    const currentRoot = resolve(currentDistributionRoot);
+    const root = resolve(outputRoot);
+    if (existsSync(root)) throw new Error(`Staged repository already exists: ${root}`);
+    try {
+        const generated = generatePublicMarketplaceDistribution({
+            repositoryRoot,
+            outputRoot: root,
+            version,
+        });
+        const candidates = join(currentRoot, "candidates");
+        if (existsSync(candidates))
+            cpSync(candidates, join(root, "candidates"), {
+                recursive: true,
+                errorOnExist: true,
+            });
+        for (const path of generatedRepositoryContract.repositoryControlPlane.allowedPaths) {
+            const source = join(
+                repositoryRoot,
+                generatedRepositoryContract.repositoryControlPlane.sourceRoot,
+                path,
+            );
+            const destination = join(root, path);
+            mkdirSync(dirname(destination), { recursive: true });
+            cpSync(source, destination, { errorOnExist: true });
+        }
+        return generated;
+    } catch (error) {
+        rmSync(root, { recursive: true, force: true });
+        throw error;
+    }
+}
+
+async function main() {
+    const [currentDistributionRoot, outputRoot, version] = process.argv.slice(2);
+    try {
+        const result = await stagePublicMarketplaceRepository({
+            currentDistributionRoot,
+            outputRoot,
+            version,
+        });
+        process.stdout.write(
+            `Staged ${result.release.profileId}@${result.release.version} as a complete Distribution repository.\n`,
+        );
+    } catch (error) {
+        process.stderr.write(
+            `${error instanceof Error ? error.message : "Marketplace repository staging failed"}\n`,
+        );
+        process.exitCode = 1;
+    }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) await main();


### PR DESCRIPTION
# Summary

Generates one public `cratis-ai` Distribution root that can be installed natively by generic Agent Skills/Agent Plugin hosts, Claude Code, Codex, GitHub Copilot, Gemini CLI, Kiro, and Pi. It also prepares exact OpenAI and Cursor portal handoffs without inventing owner identity or legal metadata.

## Added

- Generate deterministic multi-marketplace manifests and 34 canonical public skills.
- Stage a complete protected Distribution repository and run all seven Distribution checks.
- Prepare deterministic OpenAI skills-only ZIP and Cursor submission metadata.
- Add a read-only workflow that uploads the exact review tree and portal handoffs.

## Changed

- Extend generated-repository verification for public evaluation marketplace provenance and byte parity.
- Record self-hosted channels separately from owner-authenticated vendor portal handoffs.

## Security

- Preserve blocked targets, repository-only skills, and native non-skill component boundaries.
- Keep scripts, dependencies, credentials, behavior support, stable promotion, and support claims absent.
