### PR TITLE
Document native marketplace installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,20 @@ S9/S10 lane, including real consumer lifecycle canaries, release evidence, and
 explicit support approval. Until those gates pass, the package remains an
 unsupported evaluation endpoint.
 
+## Native marketplace installation
+
+[Cratis/AI.Distribution v0.2.0](https://github.com/Cratis/AI.Distribution/releases/tag/v0.2.0)
+provides one 34-skill `public-cratis-ai` root for Agent Skills, Agent Plugin,
+Claude Code, Codex, GitHub Copilot, Gemini CLI, Kiro, and Pi. The Distribution
+README contains exact version-pinned commands. Claude, Codex, Copilot, and Pi
+public install/discovery/remove canaries pass; Gemini gallery discovery is
+enabled. OpenAI and Cursor packages are prepared release assets but still require
+owner-authenticated vendor submission and review.
+
+This remains an unsupported `0.x` evaluation distribution. Marketplace
+availability does not imply behavior support, broad-rollout approval, or a
+stable support claim.
+
 ## Evaluation artifacts
 
 [Cratis/AI.Distribution v0.1.0](https://github.com/Cratis/AI.Distribution/releases/tag/v0.1.0)

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "137bb537c70b4e1f6de247bdce2e10a368463525329ccc17cf03f990867f89aa",
+  "indexDigest": "c2e11d91b4df229dc76e8786ed70cbef6f97808df4d192810820cce889548504",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],


### PR DESCRIPTION
# Summary

Links the live multi-marketplace Distribution and states its tested channels, remaining vendor portal handoffs, and no-support boundary.

## Added

- Document native marketplace installation through `Cratis/AI.Distribution v0.2.0`.
