### PR TITLE
Teach the migration skill about event value maps

### DIFF
--- a/.ai/skills/event-type-migrations/SKILL.md
+++ b/.ai/skills/event-type-migrations/SKILL.md
@@ -55,6 +55,21 @@ public class OrderPlacedV1ToV2 : EventTypeMigration<OrderPlaced, OrderPlacedV1>
 
 The property builder exposes `DefaultValue`, `RenamedFrom`, `Split`, and `Combine` — use them to express the change declaratively. Both `Upcast` and `Downcast` are abstract on the base, so both must be implemented (`Downcast` may be a no-op `builder.Properties(_ => { })` when no consumer needs the gen-1 shape).
 
+### 2b. When the *values* changed meaning, declare a value map
+
+The operations above move values between properties. When a value itself means something different in the new generation — an enum renumbered, a status code set replaced — override **`MapValues`** on the migration instead. It is declared once and applied forward when upcasting and inverted when downcasting:
+
+```csharp
+public override void MapValues(IEventValueMapBuilder<OrderStatusChanged, OrderStatusChangedV1> builder) =>
+    builder.For(current => current.Status, previous => previous.Status, map => map
+        .Map(OrderStatusV1.Pending, OrderStatus.Awaiting)
+        .Map(OrderStatusV1.Done, OrderStatus.Completed));
+```
+
+Values the map doesn't mention are carried across unchanged. Two values collapsing onto one take the first pair declared for that value on the way back. `MapValues` runs *before* `Upcast`/`Downcast`, so a direction that states its own transformation for the property keeps it — that's also how you express a deliberately one-way translation (`builder.Properties(pb => pb.MapValues(...))`).
+
+> **An enum gaining a member or having a member renamed needs no migration at all** — Chronicle accepts both in place and updates the registered schema, because neither changes what an already stored value means. Only a *removed* or *renumbered* member needs a new generation plus a value map.
+
 ### 3. Chain across generations
 
 For three generations, write two migrations (`1→2`, `2→3`) — each only knows its adjacent pair; Chronicle chains them.

--- a/catalog/components.json
+++ b/catalog/components.json
@@ -2421,12 +2421,12 @@
       "canonicalSources": [
         {
           "path": ".ai/skills/event-type-migrations",
-          "digest": "4019c27bef563a3268b40670774f6ed45953bc3c2d38840d0390f6b8c314cb31",
+          "digest": "010a81cb10539f66d6bf0dd782acf5bec3383dbf29f015b3eac59d5bafc114bd",
           "ownership": "owner",
           "ownerComponentId": "cratis-chronicle-event-type-migration"
         }
       ],
-      "contentDigest": "679091f0610da1785da4df98d08d06107267ce113454da4adc7ae1420c75021b",
+      "contentDigest": "f1bdbb75ed87cc97d9421dae480fa637317e4b826f76bc8766d826111264d3db",
       "owner": "public Cratis product capability",
       "audience": "public",
       "classification": {

--- a/catalog/ecosystem-versions.json
+++ b/catalog/ecosystem-versions.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "verifiedOn": "2026-08-25",
+  "verifiedOn": "2026-08-31",
   "policy": "official-sources-only",
   "ecosystems": [
     {
@@ -200,7 +200,7 @@
         {
           "url": "https://registry.npmjs.org/@github/copilot/latest",
           "kind": "registry",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ],
       "localEvidence": [
@@ -233,7 +233,7 @@
         {
           "url": "https://registry.npmjs.org/@openai/codex/latest",
           "kind": "registry",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ]
     },
@@ -273,7 +273,7 @@
         {
           "url": "https://registry.npmjs.org/@anthropic-ai/claude-code/latest",
           "kind": "registry",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ],
       "localEvidence": [
@@ -311,7 +311,7 @@
         {
           "url": "https://registry.npmjs.org/@google/gemini-cli/latest",
           "kind": "registry",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ],
       "localEvidence": [
@@ -499,7 +499,7 @@
         {
           "url": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/latest",
           "kind": "registry",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ],
       "localEvidence": [
@@ -730,17 +730,17 @@
         {
           "url": "https://docs.cline.bot/customization/skills",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         },
         {
           "url": "https://docs.cline.bot/features/cline-rules",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         },
         {
           "url": "https://github.com/cline/cline/blob/main/apps/cli/CHANGELOG.md",
           "kind": "official-repository",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ]
     },
@@ -757,12 +757,12 @@
         {
           "url": "https://github.com/RooCodeInc/Roo-Code",
           "kind": "official-repository",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         },
         {
           "url": "https://roocodeinc.github.io/Roo-Code/features/skills/",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ]
     },
@@ -779,12 +779,12 @@
         {
           "url": "https://github.com/Kilo-Org/kilocode/blob/main/packages/kilo-docs/pages/customize/skills.md",
           "kind": "official-repository",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         },
         {
           "url": "https://github.com/Kilo-Org/kilocode/releases/tag/v7.4.23",
           "kind": "official-repository",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ]
     },
@@ -801,12 +801,12 @@
         {
           "url": "https://goose-docs.ai/docs/guides/context-engineering/using-skills/",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         },
         {
           "url": "https://github.com/block/goose/releases/tag/v1.47.0",
           "kind": "official-repository",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ]
     },
@@ -823,17 +823,17 @@
         {
           "url": "https://github.com/QwenLM/qwen-code/blob/main/docs/users/features/skills.md",
           "kind": "official-repository",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         },
         {
           "url": "https://github.com/QwenLM/qwen-code/blob/main/docs/users/features/agent-plugins.md",
           "kind": "official-repository",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         },
         {
           "url": "https://registry.npmjs.org/@qwen-code/qwen-code/latest",
           "kind": "registry",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ]
     },
@@ -850,12 +850,12 @@
         {
           "url": "https://docs.windsurf.com/windsurf/cascade/skills",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         },
         {
           "url": "https://docs.windsurf.com/windsurf/cascade/mcp",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ]
     },
@@ -872,12 +872,12 @@
         {
           "url": "https://docs.replit.com/learn/agent-skills",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         },
         {
           "url": "https://docs.replit.com/build/connect-via-mcp",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ]
     },
@@ -894,12 +894,12 @@
         {
           "url": "https://docs.augmentcode.com/cli/skills",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         },
         {
           "url": "https://docs.augmentcode.com/cli/plugins",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ]
     },
@@ -916,12 +916,12 @@
         {
           "url": "https://ampcode.com/manual",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         },
         {
           "url": "https://ampcode.com/news/neo",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ]
     },
@@ -938,12 +938,12 @@
         {
           "url": "https://docs.factory.ai/harness/skills",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         },
         {
           "url": "https://docs.factory.ai/harness/plugins",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ]
     },
@@ -960,12 +960,12 @@
         {
           "url": "https://docs.openhands.dev/overview/skills",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         },
         {
           "url": "https://github.com/OpenHands/OpenHands/releases/tag/v1.15.0",
           "kind": "official-repository",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ]
     },
@@ -982,12 +982,12 @@
         {
           "url": "https://aider.chat/docs/usage/conventions.html",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         },
         {
           "url": "https://pypi.org/pypi/aider-chat/0.86.2/json",
           "kind": "registry",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ]
     },
@@ -1004,12 +1004,12 @@
         {
           "url": "https://docs.continue.dev/index",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         },
         {
           "url": "https://github.com/continuedev/continue/blob/main/README.md",
           "kind": "official-repository",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ]
     },
@@ -1026,12 +1026,12 @@
         {
           "url": "https://aws.amazon.com/blogs/devops/amazon-q-developer-end-of-support-announcement/",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         },
         {
           "url": "https://kiro.dev/docs/cli/migrating-from-q-developer/",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ]
     },
@@ -1048,12 +1048,12 @@
         {
           "url": "https://sourcegraph.com/docs/cody/capabilities/prompts",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         },
         {
           "url": "https://sourcegraph.com/docs/cody/capabilities/agentic-context-fetching",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ]
     },
@@ -1070,12 +1070,12 @@
         {
           "url": "https://docs.tabnine.com/main/getting-started/tabnine-agent/guidelines",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         },
         {
           "url": "https://docs.tabnine.com/main/getting-started/tabnine-agent/mcp-intro-and-setup",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ]
     },
@@ -1092,12 +1092,12 @@
         {
           "url": "https://www.jetbrains.com/help/ai-assistant/configure-project-rules.html",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         },
         {
           "url": "https://www.jetbrains.com/help/ai-assistant/configure-agent-behavior.html",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ]
     },
@@ -1114,12 +1114,12 @@
         {
           "url": "https://learn.microsoft.com/en-us/visualstudio/ide/copilot-agent-mode?view=visualstudio",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         },
         {
           "url": "https://learn.microsoft.com/en-us/visualstudio/ide/copilot-custom-instructions?view=visualstudio",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ]
     },
@@ -1136,12 +1136,12 @@
         {
           "url": "https://docs.devin.ai/product-guides/skills",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         },
         {
           "url": "https://docs.devin.ai/onboard-devin/agents-md",
           "kind": "official-documentation",
-          "verifiedOn": "2026-08-25"
+          "verifiedOn": "2026-08-31"
         }
       ]
     }

--- a/catalog/evidence.json
+++ b/catalog/evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "asOf": "2026-08-25",
+  "asOf": "2026-08-31",
   "defaultPolicy": "deny",
   "sources": [
     {
@@ -80,6 +80,12 @@
       "kind": "repository-snapshot",
       "locator": "https://github.com/Cratis/AI/tree/6b5388ddc660e8c9ddae0d7aa3ef3b5581a9f979/.ai/skills/ship-changes",
       "immutableRevision": "6b5388ddc660e8c9ddae0d7aa3ef3b5581a9f979"
+    },
+    {
+      "id": "source-chronicle-event-type-migrations-value-map-source-ed28ee6",
+      "kind": "repository-snapshot",
+      "locator": "https://github.com/Cratis/AI/tree/ed28ee63c97fbe8c1ad326f6d1b48b1e0efea837/.ai/skills/event-type-migrations",
+      "immutableRevision": "ed28ee63c97fbe8c1ad326f6d1b48b1e0efea837"
     },
     {
       "id": "source-engineering-docs-authoring-source-f58bcf7",
@@ -1182,6 +1188,43 @@
         "officialUrl": "https://github.com/Cratis/AI/tree/6b5388ddc660e8c9ddae0d7aa3ef3b5581a9f979/.ai/skills/ship-changes",
         "sourceKind": "repository-snapshot",
         "applicableVersion": "6b5388ddc660e8c9ddae0d7aa3ef3b5581a9f979"
+      }
+    },
+    {
+      "id": "chronicle-event-type-migrations-value-map-source-ed28ee6",
+      "sourceId": "source-chronicle-event-type-migrations-value-map-source-ed28ee6",
+      "evidenceClass": "hosted",
+      "subject": {
+        "kind": "target",
+        "id": "cratis-chronicle-event-type-migration",
+        "version": "ed28ee63c97fbe8c1ad326f6d1b48b1e0efea837"
+      },
+      "bindingIds": [],
+      "assertions": [
+        {
+          "assuranceId": "source-provenance",
+          "outcome": "pass",
+          "supporting": true,
+          "claimIds": []
+        }
+      ],
+      "scope": "Source provenance for the event type migration skill at the revision that added value-map guidance.",
+      "environment": {
+        "operatingSystem": "not-recorded",
+        "architecture": "not-recorded",
+        "isolation": "not-recorded"
+      },
+      "observedOn": "2026-08-31",
+      "validThrough": "2027-08-31",
+      "confidence": "high",
+      "limitations": [
+        "This observation is limited to its exact recorded subject, version, digest, scope, and environment and grants no unrecorded assurance."
+      ],
+      "supersedes": [],
+      "legacy": {
+        "officialUrl": "https://github.com/Cratis/AI/tree/ed28ee63c97fbe8c1ad326f6d1b48b1e0efea837/.ai/skills/event-type-migrations",
+        "sourceKind": "repository-snapshot",
+        "applicableVersion": "ed28ee63c97fbe8c1ad326f6d1b48b1e0efea837"
       }
     },
     {

--- a/catalog/generated/human-catalog/CATALOG.md
+++ b/catalog/generated/human-catalog/CATALOG.md
@@ -55,7 +55,7 @@ Modeled or planned components and projections are catalog metadata only; they ar
 
 ## Computed ecosystem support
 
-As of 2026-08-25, technical tiers are computed from active normalized evidence; expired and future evidence cannot satisfy gates. Marketplace listing is orthogonal.
+As of 2026-08-31, technical tiers are computed from active normalized evidence; expired and future evidence cannot satisfy gates. Marketplace listing is orthogonal.
 
 - unsupported: 0
 - documented: 24

--- a/catalog/generated/human-catalog/catalog.json
+++ b/catalog/generated/human-catalog/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractVersion": 1,
   "disclaimer": "Catalog inclusion, evaluation evidence, component modeling, planned projection, bundle generation, or publication does not grant runtime permission, emitted bytes, support, or approval.",
-  "inputDigest": "31ae90278a1747fc9ba0e2a5788c93e4294de64c531b04d4b8d50610e63b760a",
+  "inputDigest": "c68285e6e5c2d3e69417a6e482c1914aecab7873b1e34b353e5d3d3c214387b8",
   "componentSummary": {
     "disclaimer": "Modeled or planned components and projections are catalog metadata only; they are not emitted, supported, installable, published, promoted, or runtime eligible.",
     "total": 137,

--- a/catalog/generated/human-catalog/manifest.json
+++ b/catalog/generated/human-catalog/manifest.json
@@ -1,17 +1,17 @@
 {
   "schemaVersion": 2,
   "contractVersion": 1,
-  "inputDigest": "31ae90278a1747fc9ba0e2a5788c93e4294de64c531b04d4b8d50610e63b760a",
+  "inputDigest": "c68285e6e5c2d3e69417a6e482c1914aecab7873b1e34b353e5d3d3c214387b8",
   "files": [
     {
       "path": "CATALOG.md",
       "size": 121296,
-      "sha256": "6c8172feb662e5b1aa7031eee5676f8abeb2afe648aadeb0bfefc630d75b10fe"
+      "sha256": "de284a99d891aa588440f21602f6a8527dbe2d6e8eac2feac77d477d08722505"
     },
     {
       "path": "catalog.json",
       "size": 155727,
-      "sha256": "c8a114c9fc06c2739458715db531d0ee23b6cff7a25d91ad440410423959f057"
+      "sha256": "0bace1c5851225210a3911aa542c5fbfe7bb9896f3bb0b69c04a82e5bbb72e77"
     }
   ]
 }

--- a/catalog/host-adapters.json
+++ b/catalog/host-adapters.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "asOf": "2026-08-25",
+  "asOf": "2026-08-31",
   "defaultPolicy": "deny",
   "supportPolicy": "Research and compatibility dispositions are not support claims.",
   "hosts": [

--- a/catalog/support-policy.json
+++ b/catalog/support-policy.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "asOf": "2026-08-25",
+  "asOf": "2026-08-31",
   "defaultPolicy": "deny",
   "evidenceClasses": [
     "synthetic-fixture",

--- a/catalog/v2/components.json
+++ b/catalog/v2/components.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "generatedBy": "tooling/generate-component-catalogs.mjs",
-  "sourceDigest": "cf87c8104ce2bda81f577c5023ed13c00016bd2ae6fce8d2131ed807ca069983",
+  "sourceDigest": "eb4161e96f78bbeae0757d5f6074c7d8da37538929de08bee392cb7971b0a690",
   "defaultPolicy": "deny",
   "canonicalSourceRoots": [
     ".ai/agents",
@@ -2423,12 +2423,12 @@
       "canonicalSources": [
         {
           "path": ".ai/skills/event-type-migrations",
-          "digest": "4019c27bef563a3268b40670774f6ed45953bc3c2d38840d0390f6b8c314cb31",
+          "digest": "010a81cb10539f66d6bf0dd782acf5bec3383dbf29f015b3eac59d5bafc114bd",
           "ownership": "owner",
           "ownerComponentId": "cratis-chronicle-event-type-migration"
         }
       ],
-      "contentDigest": "679091f0610da1785da4df98d08d06107267ce113454da4adc7ae1420c75021b",
+      "contentDigest": "f1bdbb75ed87cc97d9421dae480fa637317e4b826f76bc8766d826111264d3db",
       "owner": "public Cratis product capability",
       "audience": "public",
       "classification": {

--- a/catalog/v2/ecosystem-contracts.json
+++ b/catalog/v2/ecosystem-contracts.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "asOf": "2026-08-25",
+  "asOf": "2026-08-31",
   "defaultPolicy": "deny",
   "ecosystems": [
     {

--- a/catalog/v2/evidence.json
+++ b/catalog/v2/evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "asOf": "2026-08-25",
+  "asOf": "2026-08-31",
   "generatedBy": "tooling/generate-catalog-v2.mjs",
   "evidence": [
     {
@@ -137,6 +137,16 @@
       "expiresOn": "2026-11-23",
       "applicableVersion": "current-documentation-2026-08-25",
       "confidence": "high"
+    },
+    {
+      "id": "chronicle-event-type-migrations-value-map-source-ed28ee6",
+      "officialUrl": "https://github.com/Cratis/AI/tree/ed28ee63c97fbe8c1ad326f6d1b48b1e0efea837/.ai/skills/event-type-migrations",
+      "sourceKind": "repository-snapshot",
+      "verifiedOn": "2026-08-31",
+      "expiresOn": "2027-08-31",
+      "applicableVersion": "ed28ee63c97fbe8c1ad326f6d1b48b1e0efea837",
+      "confidence": "high",
+      "immutableRevision": "ed28ee63c97fbe8c1ad326f6d1b48b1e0efea837"
     },
     {
       "id": "chronicle-mcp-inspection-source-5997b28",

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "e98927ab90c0385f2995747c8080269f6acefe1373169e902b6b1e47a370b199",
+  "indexDigest": "4e09938c65b6bbf90a30cd25cf610874a014a6435693f83a58e2626aab57dde7",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "03e98484786e0c9e27952218ba8a16633da626946e2c908ab333b5d39d87c57a",
+  "indexDigest": "e98927ab90c0385f2995747c8080269f6acefe1373169e902b6b1e47a370b199",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "c2e11d91b4df229dc76e8786ed70cbef6f97808df4d192810820cce889548504",
+  "indexDigest": "03e98484786e0c9e27952218ba8a16633da626946e2c908ab333b5d39d87c57a",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -60,6 +60,10 @@
     },
     {
       "path": ".ai/skills/add-concept/SKILL.md",
+      "status": "modified"
+    },
+    {
+      "path": ".ai/skills/event-type-migrations/SKILL.md",
       "status": "modified"
     },
     {

--- a/catalog/v2/sources.json
+++ b/catalog/v2/sources.json
@@ -517,7 +517,7 @@
         ".ai/skills/event-type-migrations/SKILL.md"
       ],
       "sourceRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-      "contentDigest": "4019c27bef563a3268b40670774f6ed45953bc3c2d38840d0390f6b8c314cb31",
+      "contentDigest": "010a81cb10539f66d6bf0dd782acf5bec3383dbf29f015b3eac59d5bafc114bd",
       "publicationApproval": false,
       "evidenceIds": [
         "repo-main-b795d53",

--- a/catalog/v2/sources.json
+++ b/catalog/v2/sources.json
@@ -516,12 +516,13 @@
       "bundledPaths": [
         ".ai/skills/event-type-migrations/SKILL.md"
       ],
-      "sourceRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
+      "sourceRevision": "ed28ee63c97fbe8c1ad326f6d1b48b1e0efea837",
       "contentDigest": "010a81cb10539f66d6bf0dd782acf5bec3383dbf29f015b3eac59d5bafc114bd",
       "publicationApproval": false,
       "evidenceIds": [
         "repo-main-b795d53",
-        "reevaluation-authority"
+        "reevaluation-authority",
+        "chronicle-event-type-migrations-value-map-source-ed28ee6"
       ]
     },
     {

--- a/catalog/v2/support.json
+++ b/catalog/v2/support.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "asOf": "2026-08-25",
+  "asOf": "2026-08-31",
   "generatedBy": "tooling/generate-support.mjs",
   "defaultPolicy": "deny",
   "publicationEligible": false,

--- a/tooling/component-catalog-validation.mjs
+++ b/tooling/component-catalog-validation.mjs
@@ -32,7 +32,7 @@ export const componentCatalogPaths = Object.freeze({
 });
 
 const expectedComponentAnchor =
-    "927088b7313f6a7a75a44bbd8dcb23ec1bc6c7180626dab66023631c7dc98fb1";
+    "1ca09e0da99546af33d26a97d82e3d1e3f7b37bb278387b9dcf1ff217d6dd807";
 const expectedProjectionAnchor =
     "70f3e05988839ba21247eff528709caf4738f2aa7f637e05e28658ff05902027";
 const expectedProjectionHostAnchor =

--- a/tooling/generate-catalog-v2.mjs
+++ b/tooling/generate-catalog-v2.mjs
@@ -215,6 +215,14 @@ const sourceOverrides = new Map([
         },
     ],
     [
+        "event-type-migrations",
+        {
+            sourcePath: ".ai/skills/event-type-migrations",
+            sourceRevision: "ed28ee63c97fbe8c1ad326f6d1b48b1e0efea837",
+            evidenceId: "chronicle-event-type-migrations-value-map-source-ed28ee6",
+        },
+    ],
+    [
         "ship-changes",
         {
             sourcePath: ".ai/skills/ship-changes",

--- a/tooling/specs/catalog-v2-validation.spec.mjs
+++ b/tooling/specs/catalog-v2-validation.spec.mjs
@@ -810,7 +810,7 @@ test("stale and future-dated evidence fail and unsupported local facts remain ex
         ],
     );
     catalogs.evidence.evidence[0].expiresOn = "2026-08-19";
-    catalogs.evidence.evidence[1].verifiedOn = "2026-08-26";
+    catalogs.evidence.evidence[1].verifiedOn = "2026-09-01";
     const errors = validateEvidenceAndCoverage(catalogs);
     assert(errors.some((error) => error.includes("expired")));
     assert(errors.some((error) => error.includes("verified after")));


### PR DESCRIPTION
Mirrors the corpus change made alongside Cratis/Chronicle#3905, so the shared instruction set matches what Chronicle now does.

Two things the `event-type-migrations` skill did not know about:

- **Value maps.** A migration can now declare, once, which value in one generation is which value in the other — applied forward when upcasting and inverted when downcasting.
- **Enums evolve in place.** An enum gaining a member or having a member renamed is no longer a schema change, so the skill no longer sends people to cut a generation and write a migrator for one. Only a removed or renumbered member does.

## Changed

- `event-type-migrations` skill covers value maps, and no longer treats a growing or renamed enum as needing a new generation.
