### PR TITLE
Teach the corpus what a command records on the causation chain

### DIFF
--- a/.ai/rules/concepts.md
+++ b/.ai/rules/concepts.md
@@ -39,6 +39,15 @@ does not need a `ConceptAs<T>` wrapper.
 - `NotSet` or `Empty` is optional domain policy. Add one only when the backing
   value is impossible or explicitly reserved in that domain. Do not assume
   empty string, zero, or `Guid.Empty` is universally invalid.
+- Mark a concept that holds **personal data** `[PII]` and one that holds a
+  **secret** `[NotAudited]`. Both markings travel with the type, so marking it
+  once covers every command and event that uses it - which is the point of
+  having the concept. A command's property values are written to the causation
+  chain of every event it appends, so an unmarked `ApiKey` or `AccessToken`
+  concept reaches the event log in the clear and stays there. The two are not
+  interchangeable: `[PII]` also encrypts and enrolls the value in erasure, which
+  is wrong for a password, and `[NotAudited]` does nothing for an erasure
+  request, which is wrong for a name.
 
 ```csharp
 public record AuthorName(string Value) : ConceptAs<string>(Value)

--- a/.ai/rules/glossary.md
+++ b/.ai/rules/glossary.md
@@ -32,6 +32,7 @@ One precise line per load-bearing term, so the same word means the same thing ev
 
 - **Command** — a `[Command]` record expressing an imperative **intent**; its public `Handle()` produces event(s) (or a response).
 - **Provide()** — the command method that fetches/computes data after validation/authorization and before `Handle()`; may short-circuit with a `ValidationResult`.
+- **Causation chain** — the ordered links saying how an append came about (root process → command → …), each carrying properties. A command records its **name and its property values** there, so an event says what the command was asked to do; the chain lives in the event log and is as permanent as the events.
 - **Constraint** — `IConstraint`; an **append-time** invariant (uniqueness / concurrency) enforced at the event-store level.
 - **DCB (Dynamic Consistency Boundary)** — enforcing a state-dependent rule **under concurrency** by injecting the read model into `Handle()` and returning `Result<TEvent, ValidationResult>`.
 - **Consistency boundary** — the scope within which an invariant holds atomically (an event source, or the read model a DCB rule inspects).
@@ -50,6 +51,7 @@ One precise line per load-bearing term, so the same word means the same thing ev
 
 - **Subject / `[Subject]`** — the natural person a piece of PII belongs to (for GDPR erasure); defaults to the `EventSourceId<T>` identity.
 - **`[PII]`** — marks an inherently personal value so Chronicle can manage/erase it.
+- **`[NotAudited]`** — marks a value that is secret but *not* personal data (password, token, API key) so it is never written to the causation chain. Withholds only; it does not encrypt or enroll the value in erasure the way `[PII]` does.
 - **Namespace / tenant** — Chronicle isolates tenants by **namespace**; each namespace has its own events, observers, and read models.
 
 ## Profiles

--- a/.ai/rules/vertical-slices.md
+++ b/.ai/rules/vertical-slices.md
@@ -88,6 +88,32 @@ The command carries input from the caller. `Handle()` is defined directly on the
 
 **Do not throw for normal business rejection.** A thrown exception (from `Provide()` or `Handle()`) surfaces as an exception/HTTP 500, *not* a validation result. Recoverable, user-facing rejections are validation: `ValidationResult.Error(...)` via a validator or `Result<,>`. (For step-by-step business-rule placement, invoke the **add-business-rule** skill.)
 
+### Causation — what a command records **[contract]**
+
+A command's **property values** are recorded on the causation of every event it appends, alongside the command's name, so an event says not only which command produced it but what that command was asked to do. The causation is written into the event log and stays there for as long as the events do — a value recorded there cannot be taken back out by changing code.
+
+Two markings keep a value off the chain, and both are honored on the property, the declaring type, the positional record parameter, **and the property's type**:
+
+| Marking | For | Also does |
+|---|---|---|
+| `[PII]` | personal data | encrypts it in the event, enrolls it in erasure |
+| `[NotAudited]` | a secret that is not personal data — password, token, API key, card number | nothing else; it only withholds |
+
+They are **not interchangeable**: `[PII]` on a password would encrypt it and enroll it in GDPR erasure, which is wrong; `[NotAudited]` on a name does nothing for an erasure request, which is also wrong.
+
+**Prefer marking the concept**, exactly as with `[PII]` — mark `ApiKey` once and every command taking one is covered:
+
+```csharp
+[NotAudited]
+public record ApiKey(string Value) : ConceptAs<string>(Value);
+```
+
+`[NotAudited]` on the command type excludes every property at once, which is right when a command exists only to carry secrets. The command is still **named** on the chain either way — what is withheld is the values, never the fact that it ran.
+
+`ARCCHR0009` warns on a command property whose *name* reads like a secret and is unmarked. It cannot see a secret whose name does not say so, so a clean build means "nothing obvious was missed", not "no secrets are recorded". For a false positive, **suppress the diagnostic** — marking it `[NotAudited]` would silence the warning by withholding a value you wanted recorded.
+
+Values render camel-cased; concepts unwrap to the value they hold; a value that is not set is omitted; a long one is truncated (the causation rides on *every* event the command appends).
+
 ### `Provide()` — data for `Handle()` **[contract]**
 
 `Provide()` runs after authorization and validation, before `Handle()`. Its parameters resolve from DI (like `Handle()`'s); the command instance is `this`. Return one value, or a tuple (Arc binds tuple values to `Handle(...)` parameters by type). Each provided value must be consumed by a `Handle` parameter — an unused one is the **`ARC0005`** analyzer error. Use a **named record** when the provided values form a real domain/snapshot concept; a **tuple** when they are just separate inputs to event construction. It may be sync or async.
@@ -256,6 +282,7 @@ public Task AuthorRegistered(AuthorRegistered @event, EventContext context) => .
 **[contract]** Chronicle encrypts `[PII]`-marked values per subject; decryption is transparent to observers and queries (read models injected into a `CommandValidator<T>` or `Handle()` decrypt transparently under the command's resolved subject before validation/handler logic runs).
 
 - Prefer **concept-level `[PII]`** (on the `ConceptAs<T>` type) so the marker travels everywhere automatically; use property-level `[PII]` only when a value is personal in one event context but not everywhere.
+- `[PII]` also keeps the value **off the causation chain** when it is a command property — see [Causation](#causation--what-a-command-records-contract). A secret that is not personal data needs `[NotAudited]` instead; `[PII]` is the wrong tool for a password.
 - **`[PII]` is found at any nesting depth, and may mark a whole value object.** A `[PII]` concept inside a value object is encrypted where it sits (siblings stay readable). Marking the **value object type** (or a property typed as one) with `[PII]` classifies every value it holds — Chronicle pushes the marker down to the individual values, so the document keeps its shape and each value is separately encrypted rather than fused into one blob.
 - Projection-backed read models inherit PII lineage automatically — don't add `[PII]` to their properties. Reducer-backed models: a `[PII]`-concept-typed property is detected automatically; add property-level `[PII]` only for a primitive/non-PII-concept property populated from PII source data.
 - ⚠️ **`[PII]` cannot be applied to `EventSourceId`/`EventSourceId<T>`** — Chronicle throws `PIINotSupportedOnEventSourceId` at runtime because the identifier is the encryption-key lookup. If the identifier itself is sensitive, use a random `Guid`-backed surrogate as the event source id and store the sensitive value in a `[PII]` property.

--- a/.ai/skills/cratis-command/SKILL.md
+++ b/.ai/skills/cratis-command/SKILL.md
@@ -45,6 +45,7 @@ public record DebitAccountOpened(AccountName Name, OwnerId OwnerId);
 - Name the command as an imperative action — `OpenDebitAccount`, not `OpenDebitAccountCommand`
 - All backend artifacts for the slice live in this one file; place it in the slice folder, not an `API/` or `Commands/` folder (see [vertical-slices.md](../../rules/vertical-slices.md))
 - Use concept wrappers for every domain value — **identity** concepts derive from `EventSourceId<T>`, **value** concepts from `ConceptAs<T>`; never raw `Guid`/`string`
+- Every property's **value** is recorded on the causation chain of each event the command appends — mark a secret `[NotAudited]` and personal data `[PII]` before it reaches the event log (see below)
 
 ```csharp
 // Accounts/AccountId.cs — identity concept derives from EventSourceId<T>
@@ -88,6 +89,37 @@ public record TransferFunds(AccountId FromId, AccountId ToId, Money Amount)
 ```
 
 For multiple events on the **same** event source, return the bare event records.
+
+### Values the command must not record
+
+A command's property values are written to the causation of **every** event it appends, and the event log is immutable — a secret recorded there cannot be taken back out by changing code. Decide this when you add the property, not later.
+
+```csharp
+[Command]
+public record ChangePassword(
+    UserId User,
+    [property: NotAudited] string OldPassword,   // withheld: a secret
+    [property: NotAudited] string NewPassword)
+{
+    public PasswordChanged Handle(IPasswordHasher hasher) => new(hasher.Hash(NewPassword));
+}
+```
+
+| Marking | Use for | Also does |
+|---|---|---|
+| `[PII]` | personal data — a name, an email | encrypts it in the event, enrolls it in erasure |
+| `[NotAudited]` | a secret that is not personal data — password, token, API key | nothing else; it only withholds |
+
+**Prefer marking the concept** so it travels to every command that takes one — the same idiom as `[PII]`:
+
+```csharp
+[NotAudited]
+public record ApiKey(string Value) : ConceptAs<string>(Value);
+```
+
+`[NotAudited]` on the command type withholds every property at once. The command is still **named** on the chain either way; only the values are withheld.
+
+`ARCCHR0009` warns when a property's *name* reads like a secret and is unmarked. It cannot see a secret whose name does not say so — a clean build means "nothing obvious was missed", not "no secrets are recorded". If it is wrong and the value should be recorded, **suppress the diagnostic** rather than marking it `[NotAudited]`, which would silence the warning by withholding a value you wanted.
 
 ---
 

--- a/.ai/skills/cross-cutting-properties/SKILL.md
+++ b/.ai/skills/cross-cutting-properties/SKILL.md
@@ -40,6 +40,21 @@ public class TenantMetadataProvider(IHttpContextAccessor http) : ICanProvideAddi
 
 Chronicle discovers providers from DI — register as scoped/singleton. Multiple providers merge; key collisions = last-registered wins. Place the class at a cross-cutting infrastructure location, not inside a slice. The properties land in the event's **metadata envelope**, not the event record — they are not surfaced in `EventContext` on reactive handlers. If a value must influence a projection/reducer, it belongs on the event type (or a dedicated audit event), not in cross-cutting metadata.
 
+## Command values on the causation chain
+
+A third channel carries context, and unlike the two above you get it without asking: a **command's property values** are recorded on the causation of every event it appends, next to the command's name. Nothing to implement — but something to review, because the causation goes into the event log and stays there for as long as the events do.
+
+Mark what must not be written before the command ships:
+
+| Marking | For |
+|---|---|
+| `[PII]` | personal data — also encrypts it in the event and enrolls it in erasure |
+| `[NotAudited]` | a secret that is not personal data — password, token, API key, card number |
+
+Both are honored on the property, the declaring type, the positional record parameter, **and the property's type** — so marking a concept once covers every command that takes one, the same idiom as `[PII]` elsewhere. `ARCCHR0009` warns on an unmarked property whose *name* reads like a secret.
+
+Unlike a metadata provider, this is per-command payload rather than per-event infrastructure: use it to answer "what was this command asked to do", not to carry ambient context, which is what `ICanProvideAdditionalEventInformation` is for.
+
 ## Tags vs filtering — easy to confuse
 
 | Attribute | Where | What it does |
@@ -58,6 +73,7 @@ Tags are also used for concurrency scoping. To *filter* by tag you need `[Filter
 | Injecting scoped services into a singleton provider | register the provider scoped, or use `IServiceScopeFactory` |
 | Expecting envelope properties to appear in `EventContext` on handlers | they don't — they're metadata only |
 | Using a provider for data a projection needs | if the projection needs it, it belongs on the event type |
+| Letting a command carry a secret unmarked | its value is written to the causation of every event it appends, permanently — mark it `[NotAudited]` (or `[PII]` for personal data) |
 
 ## Quality gate
 
@@ -66,5 +82,6 @@ Tags are also used for concurrency scoping. To *filter* by tag you need `[Filter
 
 ## See also
 
-- `vertical-slices.md` — event types, `EventContext` in reactors/reducers.
+- `vertical-slices.md` — event types, `EventContext` in reactors/reducers, and what a command records on the causation chain.
+- `cratis-command` — marking a command's secrets before they reach the event log.
 - `multi-tenancy` — namespace-per-tenant isolation (a different mechanism from a tenant tag).

--- a/.ai/skills/review-security/SKILL.md
+++ b/.ai/skills/review-security/SKILL.md
@@ -20,7 +20,7 @@ Perform a structured security review of changed code.
 
 ## Sensitive Data Exposure
 
-- [ ] No passwords, secrets, API keys, or tokens stored in event properties or read models
+- [ ] No passwords, secrets, API keys, or tokens stored in event properties, read models, **or command properties reaching the causation chain**
 - [ ] No PII returned to clients that did not provide it
 - [ ] Query results scoped to requesting tenant/user — never return all-tenant data
 
@@ -36,6 +36,7 @@ Perform a structured security review of changed code.
 - [ ] Aggregate/event-store IDs generated server-side, never accepted from untrusted clients
 - [ ] Event upcasting logic does not allow injection of unexpected properties
 - [ ] Uniqueness constraints cannot be bypassed by concurrent multi-tenant writes
+- [ ] **Every `[Command]` property holding a secret is marked `[NotAudited]` (or `[PII]` for personal data)** — a command's values are written to the causation of every event it appends and cannot be removed afterwards. Prefer the marking on the concept. `ARCCHR0009` catches secret-*sounding* names only, so read the properties whose names do not say what they hold
 
 ## Frontend
 

--- a/catalog/components.json
+++ b/catalog/components.json
@@ -1333,12 +1333,12 @@
       "canonicalSources": [
         {
           "path": ".ai/skills/cratis-command",
-          "digest": "05e1dda70a0871c306071677998698491186b0ca541c7ef62ddce89a787359f8",
+          "digest": "8014cd3f881ad0cb70588851f99a0c241e1635a3265df9479f7ddccf43cd15e1",
           "ownership": "owner",
           "ownerComponentId": "cratis-arc-command"
         }
       ],
-      "contentDigest": "b14353daac54256668c61b3ff10af74f30595f471c01ffd8ee3b44655128078e",
+      "contentDigest": "9ebfcefa08743a99d4b21c43a22a2584b4c37b0b5e70542b59f5b1559d61b763",
       "owner": "public Cratis product capability",
       "audience": "public",
       "classification": {
@@ -2171,12 +2171,12 @@
       "canonicalSources": [
         {
           "path": ".ai/skills/cross-cutting-properties",
-          "digest": "e9a68b833d73d04610434902ff797f82956821a1547b02c443cf465cd3f83e34",
+          "digest": "a1c0a1670025bbf0341e3f8573ec11bddd2d77a0420e3b4d692b0ae1ff11f441",
           "ownership": "owner",
           "ownerComponentId": "cratis-chronicle-event-metadata"
         }
       ],
-      "contentDigest": "684432d53c4dfffdaf0e4bfa3ef140b50d2ea895a27d7209a5ea11156c70ed66",
+      "contentDigest": "b77868621786350acff030f7e06a9c9402ee6332b4aac60b3688581db28db0e1",
       "owner": "public Cratis product capability",
       "audience": "public",
       "classification": {
@@ -7609,12 +7609,12 @@
       "canonicalSources": [
         {
           "path": ".ai/rules/concepts.md",
-          "digest": "ec09879acc66fe7bc0518bb2d9c2dbf7944e1c65c4408ebc5bdb69a5c846c48c",
+          "digest": "8eb4e594aa4da07143f4b8b21ab5f1c2354469afa66604dd4a6e25103d426b50",
           "ownership": "owner",
           "ownerComponentId": "cratis-rule-concepts"
         }
       ],
-      "contentDigest": "45fe35b007e883f45933a9315653d2086c29a24dd8403e32021446a6cb3cb886",
+      "contentDigest": "2b25eabbf5e75cbd512701c950be6fc4fabc5ea3c6c8a6a6fdca10dcbb2e8a24",
       "owner": "reusable Cratis engineering behavior",
       "audience": "cratis-engineering",
       "classification": {
@@ -8506,12 +8506,12 @@
       "canonicalSources": [
         {
           "path": ".ai/rules/glossary.md",
-          "digest": "5a89504e5b4cc32f4cbf55f894c3d37332043119ef78843047ee5f24909267aa",
+          "digest": "8dd04c98a21a0861b3fb061d188af766cb41c10a0c87298ec32a4eddf6cd19c3",
           "ownership": "owner",
           "ownerComponentId": "cratis-rule-glossary"
         }
       ],
-      "contentDigest": "94d301149fe4d194926558955861cb2f3df729b25fc824c80229804aaed9b064",
+      "contentDigest": "a3d53661ee7850731100886143241974df343d37def9bf9d79ebe4527a24b430",
       "owner": "reusable Cratis engineering behavior",
       "audience": "cratis-engineering",
       "classification": {
@@ -9541,12 +9541,12 @@
       "canonicalSources": [
         {
           "path": ".ai/rules/vertical-slices.md",
-          "digest": "2f6fbcbfd2be4b6eb94ff2c878a6f2f67c4523296753fdd4256219a25d1b2590",
+          "digest": "5e590df10d4036595472079d9defd9746ce96d04d868444158b1707879bdecf3",
           "ownership": "owner",
           "ownerComponentId": "cratis-rule-vertical-slices"
         }
       ],
-      "contentDigest": "64be055892e6e3c83a7334f8d68dca984d21251ef30cc1a62bd464750df6d1c9",
+      "contentDigest": "a9dfd97c7ab84001c18386e7f5a5d15679244aaabbf282bb1b6def62ec2cd22f",
       "owner": "reusable Cratis engineering behavior",
       "audience": "cratis-engineering",
       "classification": {
@@ -9817,12 +9817,12 @@
       "canonicalSources": [
         {
           "path": ".ai/skills/review-security",
-          "digest": "c5829036d84177ba53cdacf54e01ec7cf05cb84fb4b8f07fb0305003213d0b3f",
+          "digest": "f7a78c4c980d17ae304bce81a20a19a8864965ba2784466c10fcca7aaa0fd178",
           "ownership": "owner",
           "ownerComponentId": "cratis-security-review"
         }
       ],
-      "contentDigest": "a9c38df6402c5d0a7c1be37a4e64967e96c23a0b2e803a24dc25567b06e7e88b",
+      "contentDigest": "0f957586d4509a518b94f58a98f283364ecf52be3f067f406472f44d43d6acd6",
       "owner": "public Cratis product capability",
       "audience": "public",
       "classification": {

--- a/catalog/evidence.json
+++ b/catalog/evidence.json
@@ -100,6 +100,24 @@
       "immutableRevision": "2006490b23dd60a384cd803423fdc59cd395611b"
     },
     {
+      "id": "source-cratis-command-command-causation-values-5d45432",
+      "kind": "repository-snapshot",
+      "locator": "https://github.com/Cratis/AI/tree/5d45432cda795ad1f5e5b58c2df143f01161885c/.ai/skills/cratis-command",
+      "immutableRevision": "5d45432cda795ad1f5e5b58c2df143f01161885c"
+    },
+    {
+      "id": "source-cross-cutting-properties-command-causation-values-5d45432",
+      "kind": "repository-snapshot",
+      "locator": "https://github.com/Cratis/AI/tree/5d45432cda795ad1f5e5b58c2df143f01161885c/.ai/skills/cross-cutting-properties",
+      "immutableRevision": "5d45432cda795ad1f5e5b58c2df143f01161885c"
+    },
+    {
+      "id": "source-review-security-command-causation-values-5d45432",
+      "kind": "repository-snapshot",
+      "locator": "https://github.com/Cratis/AI/tree/5d45432cda795ad1f5e5b58c2df143f01161885c/.ai/skills/review-security",
+      "immutableRevision": "5d45432cda795ad1f5e5b58c2df143f01161885c"
+    },
+    {
       "id": "source-engineering-docs-authoring-source-f58bcf7",
       "kind": "repository-snapshot",
       "locator": "https://github.com/Cratis/AI/tree/f58bcf7f5cc9fc0e11305ada3b5ecb6fa20953e9/engineering/skills/cratis-engineering-docs-authoring",
@@ -1311,6 +1329,117 @@
         "officialUrl": "https://github.com/Cratis/AI/tree/2006490b23dd60a384cd803423fdc59cd395611b/.ai/skills/cratis-react-page",
         "sourceKind": "repository-snapshot",
         "applicableVersion": "2006490b23dd60a384cd803423fdc59cd395611b"
+      }
+    },
+    {
+      "id": "cratis-command-command-causation-values-5d45432",
+      "sourceId": "source-cratis-command-command-causation-values-5d45432",
+      "evidenceClass": "hosted",
+      "subject": {
+        "kind": "target",
+        "id": "cratis-arc-command",
+        "version": "5d45432cda795ad1f5e5b58c2df143f01161885c"
+      },
+      "bindingIds": [],
+      "assertions": [
+        {
+          "assuranceId": "source-provenance",
+          "outcome": "pass",
+          "supporting": true,
+          "claimIds": []
+        }
+      ],
+      "scope": "Source provenance for the Arc command skill at the revision that added command causation value guidance.",
+      "environment": {
+        "operatingSystem": "not-recorded",
+        "architecture": "not-recorded",
+        "isolation": "not-recorded"
+      },
+      "observedOn": "2026-08-31",
+      "validThrough": "2027-08-31",
+      "confidence": "high",
+      "limitations": [
+        "This observation is limited to its exact recorded subject, version, digest, scope, and environment and grants no unrecorded assurance."
+      ],
+      "supersedes": [],
+      "legacy": {
+        "officialUrl": "https://github.com/Cratis/AI/tree/5d45432cda795ad1f5e5b58c2df143f01161885c/.ai/skills/cratis-command",
+        "sourceKind": "repository-snapshot",
+        "applicableVersion": "5d45432cda795ad1f5e5b58c2df143f01161885c"
+      }
+    },
+    {
+      "id": "cross-cutting-properties-command-causation-values-5d45432",
+      "sourceId": "source-cross-cutting-properties-command-causation-values-5d45432",
+      "evidenceClass": "hosted",
+      "subject": {
+        "kind": "target",
+        "id": "cratis-chronicle-event-metadata",
+        "version": "5d45432cda795ad1f5e5b58c2df143f01161885c"
+      },
+      "bindingIds": [],
+      "assertions": [
+        {
+          "assuranceId": "source-provenance",
+          "outcome": "pass",
+          "supporting": true,
+          "claimIds": []
+        }
+      ],
+      "scope": "Source provenance for the cross-cutting event properties skill at the revision that added command causation value guidance.",
+      "environment": {
+        "operatingSystem": "not-recorded",
+        "architecture": "not-recorded",
+        "isolation": "not-recorded"
+      },
+      "observedOn": "2026-08-31",
+      "validThrough": "2027-08-31",
+      "confidence": "high",
+      "limitations": [
+        "This observation is limited to its exact recorded subject, version, digest, scope, and environment and grants no unrecorded assurance."
+      ],
+      "supersedes": [],
+      "legacy": {
+        "officialUrl": "https://github.com/Cratis/AI/tree/5d45432cda795ad1f5e5b58c2df143f01161885c/.ai/skills/cross-cutting-properties",
+        "sourceKind": "repository-snapshot",
+        "applicableVersion": "5d45432cda795ad1f5e5b58c2df143f01161885c"
+      }
+    },
+    {
+      "id": "review-security-command-causation-values-5d45432",
+      "sourceId": "source-review-security-command-causation-values-5d45432",
+      "evidenceClass": "hosted",
+      "subject": {
+        "kind": "target",
+        "id": "cratis-security-review",
+        "version": "5d45432cda795ad1f5e5b58c2df143f01161885c"
+      },
+      "bindingIds": [],
+      "assertions": [
+        {
+          "assuranceId": "source-provenance",
+          "outcome": "pass",
+          "supporting": true,
+          "claimIds": []
+        }
+      ],
+      "scope": "Source provenance for the security review skill at the revision that added the command causation checklist item.",
+      "environment": {
+        "operatingSystem": "not-recorded",
+        "architecture": "not-recorded",
+        "isolation": "not-recorded"
+      },
+      "observedOn": "2026-08-31",
+      "validThrough": "2027-08-31",
+      "confidence": "high",
+      "limitations": [
+        "This observation is limited to its exact recorded subject, version, digest, scope, and environment and grants no unrecorded assurance."
+      ],
+      "supersedes": [],
+      "legacy": {
+        "officialUrl": "https://github.com/Cratis/AI/tree/5d45432cda795ad1f5e5b58c2df143f01161885c/.ai/skills/review-security",
+        "sourceKind": "repository-snapshot",
+        "applicableVersion": "5d45432cda795ad1f5e5b58c2df143f01161885c"
       }
     },
     {

--- a/catalog/generated/human-catalog/catalog.json
+++ b/catalog/generated/human-catalog/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractVersion": 1,
   "disclaimer": "Catalog inclusion, evaluation evidence, component modeling, planned projection, bundle generation, or publication does not grant runtime permission, emitted bytes, support, or approval.",
-  "inputDigest": "6f2f55cd70ac91ad75be2543f01d8df82362f47ee4343c2f3efc468b4984ac8e",
+  "inputDigest": "84174ce794a040f4284d6f29a355101c977e36599c0495b4e8a259cf23193f9d",
   "componentSummary": {
     "disclaimer": "Modeled or planned components and projections are catalog metadata only; they are not emitted, supported, installable, published, promoted, or runtime eligible.",
     "total": 137,

--- a/catalog/generated/human-catalog/manifest.json
+++ b/catalog/generated/human-catalog/manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "contractVersion": 1,
-  "inputDigest": "6f2f55cd70ac91ad75be2543f01d8df82362f47ee4343c2f3efc468b4984ac8e",
+  "inputDigest": "84174ce794a040f4284d6f29a355101c977e36599c0495b4e8a259cf23193f9d",
   "files": [
     {
       "path": "CATALOG.md",
@@ -11,7 +11,7 @@
     {
       "path": "catalog.json",
       "size": 155727,
-      "sha256": "2f72aadcc6ef6005500cbba6be421f95c07a853135598cd2e654ec20b3918b29"
+      "sha256": "5711418bd29a4987538c6d6b2bf90fd2963b324711289380aa47bb0279cc823d"
     }
   ]
 }

--- a/catalog/v2/components.json
+++ b/catalog/v2/components.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "generatedBy": "tooling/generate-component-catalogs.mjs",
-  "sourceDigest": "29d558ef139ffe4c2813912f482b1d030720e458910df0e671666562cc2776a6",
+  "sourceDigest": "316b718f08c2ba961351dbf4de8daf4220d92a318d9b100ee41877778b926120",
   "defaultPolicy": "deny",
   "canonicalSourceRoots": [
     ".ai/agents",
@@ -1335,12 +1335,12 @@
       "canonicalSources": [
         {
           "path": ".ai/skills/cratis-command",
-          "digest": "05e1dda70a0871c306071677998698491186b0ca541c7ef62ddce89a787359f8",
+          "digest": "8014cd3f881ad0cb70588851f99a0c241e1635a3265df9479f7ddccf43cd15e1",
           "ownership": "owner",
           "ownerComponentId": "cratis-arc-command"
         }
       ],
-      "contentDigest": "b14353daac54256668c61b3ff10af74f30595f471c01ffd8ee3b44655128078e",
+      "contentDigest": "9ebfcefa08743a99d4b21c43a22a2584b4c37b0b5e70542b59f5b1559d61b763",
       "owner": "public Cratis product capability",
       "audience": "public",
       "classification": {
@@ -2173,12 +2173,12 @@
       "canonicalSources": [
         {
           "path": ".ai/skills/cross-cutting-properties",
-          "digest": "e9a68b833d73d04610434902ff797f82956821a1547b02c443cf465cd3f83e34",
+          "digest": "a1c0a1670025bbf0341e3f8573ec11bddd2d77a0420e3b4d692b0ae1ff11f441",
           "ownership": "owner",
           "ownerComponentId": "cratis-chronicle-event-metadata"
         }
       ],
-      "contentDigest": "684432d53c4dfffdaf0e4bfa3ef140b50d2ea895a27d7209a5ea11156c70ed66",
+      "contentDigest": "b77868621786350acff030f7e06a9c9402ee6332b4aac60b3688581db28db0e1",
       "owner": "public Cratis product capability",
       "audience": "public",
       "classification": {
@@ -7611,12 +7611,12 @@
       "canonicalSources": [
         {
           "path": ".ai/rules/concepts.md",
-          "digest": "ec09879acc66fe7bc0518bb2d9c2dbf7944e1c65c4408ebc5bdb69a5c846c48c",
+          "digest": "8eb4e594aa4da07143f4b8b21ab5f1c2354469afa66604dd4a6e25103d426b50",
           "ownership": "owner",
           "ownerComponentId": "cratis-rule-concepts"
         }
       ],
-      "contentDigest": "45fe35b007e883f45933a9315653d2086c29a24dd8403e32021446a6cb3cb886",
+      "contentDigest": "2b25eabbf5e75cbd512701c950be6fc4fabc5ea3c6c8a6a6fdca10dcbb2e8a24",
       "owner": "reusable Cratis engineering behavior",
       "audience": "cratis-engineering",
       "classification": {
@@ -8508,12 +8508,12 @@
       "canonicalSources": [
         {
           "path": ".ai/rules/glossary.md",
-          "digest": "5a89504e5b4cc32f4cbf55f894c3d37332043119ef78843047ee5f24909267aa",
+          "digest": "8dd04c98a21a0861b3fb061d188af766cb41c10a0c87298ec32a4eddf6cd19c3",
           "ownership": "owner",
           "ownerComponentId": "cratis-rule-glossary"
         }
       ],
-      "contentDigest": "94d301149fe4d194926558955861cb2f3df729b25fc824c80229804aaed9b064",
+      "contentDigest": "a3d53661ee7850731100886143241974df343d37def9bf9d79ebe4527a24b430",
       "owner": "reusable Cratis engineering behavior",
       "audience": "cratis-engineering",
       "classification": {
@@ -9543,12 +9543,12 @@
       "canonicalSources": [
         {
           "path": ".ai/rules/vertical-slices.md",
-          "digest": "2f6fbcbfd2be4b6eb94ff2c878a6f2f67c4523296753fdd4256219a25d1b2590",
+          "digest": "5e590df10d4036595472079d9defd9746ce96d04d868444158b1707879bdecf3",
           "ownership": "owner",
           "ownerComponentId": "cratis-rule-vertical-slices"
         }
       ],
-      "contentDigest": "64be055892e6e3c83a7334f8d68dca984d21251ef30cc1a62bd464750df6d1c9",
+      "contentDigest": "a9dfd97c7ab84001c18386e7f5a5d15679244aaabbf282bb1b6def62ec2cd22f",
       "owner": "reusable Cratis engineering behavior",
       "audience": "cratis-engineering",
       "classification": {
@@ -9819,12 +9819,12 @@
       "canonicalSources": [
         {
           "path": ".ai/skills/review-security",
-          "digest": "c5829036d84177ba53cdacf54e01ec7cf05cb84fb4b8f07fb0305003213d0b3f",
+          "digest": "f7a78c4c980d17ae304bce81a20a19a8864965ba2784466c10fcca7aaa0fd178",
           "ownership": "owner",
           "ownerComponentId": "cratis-security-review"
         }
       ],
-      "contentDigest": "a9c38df6402c5d0a7c1be37a4e64967e96c23a0b2e803a24dc25567b06e7e88b",
+      "contentDigest": "0f957586d4509a518b94f58a98f283364ecf52be3f067f406472f44d43d6acd6",
       "owner": "public Cratis product capability",
       "audience": "public",
       "classification": {

--- a/catalog/v2/evidence.json
+++ b/catalog/v2/evidence.json
@@ -259,6 +259,16 @@
       "confidence": "high"
     },
     {
+      "id": "cratis-command-command-causation-values-5d45432",
+      "officialUrl": "https://github.com/Cratis/AI/tree/5d45432cda795ad1f5e5b58c2df143f01161885c/.ai/skills/cratis-command",
+      "sourceKind": "repository-snapshot",
+      "verifiedOn": "2026-08-31",
+      "expiresOn": "2027-08-31",
+      "applicableVersion": "5d45432cda795ad1f5e5b58c2df143f01161885c",
+      "confidence": "high",
+      "immutableRevision": "5d45432cda795ad1f5e5b58c2df143f01161885c"
+    },
+    {
       "id": "cratis-react-page-host-rendered-dialogs-2006490",
       "officialUrl": "https://github.com/Cratis/AI/tree/2006490b23dd60a384cd803423fdc59cd395611b/.ai/skills/cratis-react-page",
       "sourceKind": "repository-snapshot",
@@ -267,6 +277,16 @@
       "applicableVersion": "2006490b23dd60a384cd803423fdc59cd395611b",
       "confidence": "high",
       "immutableRevision": "2006490b23dd60a384cd803423fdc59cd395611b"
+    },
+    {
+      "id": "cross-cutting-properties-command-causation-values-5d45432",
+      "officialUrl": "https://github.com/Cratis/AI/tree/5d45432cda795ad1f5e5b58c2df143f01161885c/.ai/skills/cross-cutting-properties",
+      "sourceKind": "repository-snapshot",
+      "verifiedOn": "2026-08-31",
+      "expiresOn": "2027-08-31",
+      "applicableVersion": "5d45432cda795ad1f5e5b58c2df143f01161885c",
+      "confidence": "high",
+      "immutableRevision": "5d45432cda795ad1f5e5b58c2df143f01161885c"
     },
     {
       "id": "cursor-plugins-source-1",
@@ -1079,6 +1099,16 @@
       "applicableVersion": "b795d5307e20f7f7458a67708b4f26975e223796",
       "confidence": "high",
       "immutableRevision": "b795d5307e20f7f7458a67708b4f26975e223796"
+    },
+    {
+      "id": "review-security-command-causation-values-5d45432",
+      "officialUrl": "https://github.com/Cratis/AI/tree/5d45432cda795ad1f5e5b58c2df143f01161885c/.ai/skills/review-security",
+      "sourceKind": "repository-snapshot",
+      "verifiedOn": "2026-08-31",
+      "expiresOn": "2027-08-31",
+      "applicableVersion": "5d45432cda795ad1f5e5b58c2df143f01161885c",
+      "confidence": "high",
+      "immutableRevision": "5d45432cda795ad1f5e5b58c2df143f01161885c"
     },
     {
       "id": "roo-code-source-1",

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "3ee189195ae5ac17efbdce07acb9a897a4fbd8933ce244529b281dc3ae64b557",
+  "indexDigest": "957dd416671e4798dadfacfe0d51d60e1bdac201356c4d9e865d2f56dfac3f14",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "957dd416671e4798dadfacfe0d51d60e1bdac201356c4d9e865d2f56dfac3f14",
+  "indexDigest": "872a96114e1bf315527c9b36dc1242ade736b46426556eb7ce833ab6a879243a",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "2877963540fb16572cca83e17793d4daee5da945c62157203b24f500db98c111",
+  "indexDigest": "3ee189195ae5ac17efbdce07acb9a897a4fbd8933ce244529b281dc3ae64b557",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -47,6 +47,10 @@
       "status": "added"
     },
     {
+      "path": ".ai/rules/glossary.md",
+      "status": "modified"
+    },
+    {
       "path": ".ai/rules/local-work-artifacts.md",
       "status": "added"
     },
@@ -67,11 +71,23 @@
       "status": "modified"
     },
     {
+      "path": ".ai/skills/cratis-command/SKILL.md",
+      "status": "modified"
+    },
+    {
       "path": ".ai/skills/cratis-react-page/SKILL.md",
       "status": "modified"
     },
     {
+      "path": ".ai/skills/cross-cutting-properties/SKILL.md",
+      "status": "modified"
+    },
+    {
       "path": ".ai/skills/event-type-migrations/SKILL.md",
+      "status": "modified"
+    },
+    {
+      "path": ".ai/skills/review-security/SKILL.md",
       "status": "modified"
     },
     {

--- a/catalog/v2/sources.json
+++ b/catalog/v2/sources.json
@@ -235,7 +235,7 @@
         ".ai/skills/cratis-command/references/validation.md"
       ],
       "sourceRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-      "contentDigest": "05e1dda70a0871c306071677998698491186b0ca541c7ef62ddce89a787359f8",
+      "contentDigest": "8014cd3f881ad0cb70588851f99a0c241e1635a3265df9479f7ddccf43cd15e1",
       "publicationApproval": false,
       "evidenceIds": [
         "repo-main-b795d53",
@@ -425,7 +425,7 @@
         ".ai/skills/cross-cutting-properties/SKILL.md"
       ],
       "sourceRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-      "contentDigest": "e9a68b833d73d04610434902ff797f82956821a1547b02c443cf465cd3f83e34",
+      "contentDigest": "a1c0a1670025bbf0341e3f8573ec11bddd2d77a0420e3b4d692b0ae1ff11f441",
       "publicationApproval": false,
       "evidenceIds": [
         "repo-main-b795d53",
@@ -684,7 +684,7 @@
         ".ai/skills/review-security/SKILL.md"
       ],
       "sourceRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-      "contentDigest": "c5829036d84177ba53cdacf54e01ec7cf05cb84fb4b8f07fb0305003213d0b3f",
+      "contentDigest": "f7a78c4c980d17ae304bce81a20a19a8864965ba2784466c10fcca7aaa0fd178",
       "publicationApproval": false,
       "evidenceIds": [
         "repo-main-b795d53",

--- a/catalog/v2/sources.json
+++ b/catalog/v2/sources.json
@@ -234,12 +234,13 @@
         ".ai/skills/cratis-command/references/proxy-setup.md",
         ".ai/skills/cratis-command/references/validation.md"
       ],
-      "sourceRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
+      "sourceRevision": "5d45432cda795ad1f5e5b58c2df143f01161885c",
       "contentDigest": "8014cd3f881ad0cb70588851f99a0c241e1635a3265df9479f7ddccf43cd15e1",
       "publicationApproval": false,
       "evidenceIds": [
         "repo-main-b795d53",
-        "reevaluation-authority"
+        "reevaluation-authority",
+        "cratis-command-command-causation-values-5d45432"
       ]
     },
     {
@@ -424,12 +425,13 @@
       "bundledPaths": [
         ".ai/skills/cross-cutting-properties/SKILL.md"
       ],
-      "sourceRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
+      "sourceRevision": "5d45432cda795ad1f5e5b58c2df143f01161885c",
       "contentDigest": "a1c0a1670025bbf0341e3f8573ec11bddd2d77a0420e3b4d692b0ae1ff11f441",
       "publicationApproval": false,
       "evidenceIds": [
         "repo-main-b795d53",
-        "reevaluation-authority"
+        "reevaluation-authority",
+        "cross-cutting-properties-command-causation-values-5d45432"
       ]
     },
     {
@@ -683,12 +685,13 @@
       "bundledPaths": [
         ".ai/skills/review-security/SKILL.md"
       ],
-      "sourceRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
+      "sourceRevision": "5d45432cda795ad1f5e5b58c2df143f01161885c",
       "contentDigest": "f7a78c4c980d17ae304bce81a20a19a8864965ba2784466c10fcca7aaa0fd178",
       "publicationApproval": false,
       "evidenceIds": [
         "repo-main-b795d53",
-        "reevaluation-authority"
+        "reevaluation-authority",
+        "review-security-command-causation-values-5d45432"
       ]
     },
     {

--- a/tooling/component-catalog-validation.mjs
+++ b/tooling/component-catalog-validation.mjs
@@ -32,7 +32,7 @@ export const componentCatalogPaths = Object.freeze({
 });
 
 const expectedComponentAnchor =
-    "3f99535b97b748d1dc5aa616ae2ace05e6c71b8b925c479773b77d61ae64d053";
+    "f164e59e43113d2b64757c90102e3a0434a826f365f1482d781ffd692018d8e8";
 const expectedProjectionAnchor =
     "70f3e05988839ba21247eff528709caf4738f2aa7f637e05e28658ff05902027";
 const expectedProjectionHostAnchor =

--- a/tooling/fixtures/s8-native-non-skill-expected-tree.json
+++ b/tooling/fixtures/s8-native-non-skill-expected-tree.json
@@ -46,8 +46,8 @@
         {
           "path": ".aiassistant/rules/concepts.md",
           "sourcePath": ".ai/rules/concepts.md",
-          "size": 4655,
-          "sha256": "f1f941ec32415bd4b5a403f0d084dd601935ea5e6a4baf29598a63f69753a095"
+          "size": 5310,
+          "sha256": "3aa3e81e5992f295a76ac3eda8fd02f14c7a49ed7500517bfd301674511866a6"
         },
         {
           "path": ".aiassistant/rules/csharp.md",
@@ -118,8 +118,8 @@
         {
           "path": ".aiassistant/rules/glossary.md",
           "sourcePath": ".ai/rules/glossary.md",
-          "size": 4986,
-          "sha256": "bbc5da53b562456445b2e8c2d4cbbf2c2376bf4e56b71f4a2f181bae1915f8fd"
+          "size": 5546,
+          "sha256": "e3feec1ad0074f32007ddb1db1db62835cd96ae360eed81e74404e9030e7caf9"
         },
         {
           "path": ".aiassistant/rules/managing-ai-rules.md",
@@ -202,8 +202,8 @@
         {
           "path": ".aiassistant/rules/vertical-slices.md",
           "sourcePath": ".ai/rules/vertical-slices.md",
-          "size": 31443,
-          "sha256": "51df677faf11f73555981207e7993e3c217ebfc5b4ac1e0df31455fdb0780f5e"
+          "size": 33778,
+          "sha256": "3583b8f7e6ab4561385bf6d72bdac63dab919a10d7262b0732c6a7ba4cd80678"
         },
         {
           "path": ".aiassistant/rules/web-fetching.md",
@@ -256,8 +256,8 @@
         {
           "path": ".tabnine/guidelines/concepts.md",
           "sourcePath": ".ai/rules/concepts.md",
-          "size": 4655,
-          "sha256": "f1f941ec32415bd4b5a403f0d084dd601935ea5e6a4baf29598a63f69753a095"
+          "size": 5310,
+          "sha256": "3aa3e81e5992f295a76ac3eda8fd02f14c7a49ed7500517bfd301674511866a6"
         },
         {
           "path": ".tabnine/guidelines/csharp.md",
@@ -328,8 +328,8 @@
         {
           "path": ".tabnine/guidelines/glossary.md",
           "sourcePath": ".ai/rules/glossary.md",
-          "size": 4986,
-          "sha256": "bbc5da53b562456445b2e8c2d4cbbf2c2376bf4e56b71f4a2f181bae1915f8fd"
+          "size": 5546,
+          "sha256": "e3feec1ad0074f32007ddb1db1db62835cd96ae360eed81e74404e9030e7caf9"
         },
         {
           "path": ".tabnine/guidelines/managing-ai-rules.md",
@@ -412,8 +412,8 @@
         {
           "path": ".tabnine/guidelines/vertical-slices.md",
           "sourcePath": ".ai/rules/vertical-slices.md",
-          "size": 31443,
-          "sha256": "51df677faf11f73555981207e7993e3c217ebfc5b4ac1e0df31455fdb0780f5e"
+          "size": 33778,
+          "sha256": "3583b8f7e6ab4561385bf6d72bdac63dab919a10d7262b0732c6a7ba4cd80678"
         },
         {
           "path": ".tabnine/guidelines/web-fetching.md",
@@ -605,14 +605,14 @@
       "canonicalOwnerId": "cratis-rule-concepts",
       "semanticKind": "rule",
       "sourcePath": ".ai/rules/concepts.md",
-      "sourceDigest": "ec09879acc66fe7bc0518bb2d9c2dbf7944e1c65c4408ebc5bdb69a5c846c48c",
+      "sourceDigest": "8eb4e594aa4da07143f4b8b21ab5f1c2354469afa66604dd4a6e25103d426b50",
       "outputPath": "jetbrains-ai-assistant-rules/.aiassistant/rules/concepts.md",
       "hostId": "jetbrains-ai-assistant",
       "hostAdapterId": "jetbrains-ai-assistant-host-adapter",
       "evidenceIds": [
         "jetbrains-ai-assistant-source-1"
       ],
-      "outputDigest": "f1f941ec32415bd4b5a403f0d084dd601935ea5e6a4baf29598a63f69753a095"
+      "outputDigest": "3aa3e81e5992f295a76ac3eda8fd02f14c7a49ed7500517bfd301674511866a6"
     },
     {
       "projectionId": "cratis-rule-concepts-to-tabnine-rule",
@@ -620,14 +620,14 @@
       "canonicalOwnerId": "cratis-rule-concepts",
       "semanticKind": "rule",
       "sourcePath": ".ai/rules/concepts.md",
-      "sourceDigest": "ec09879acc66fe7bc0518bb2d9c2dbf7944e1c65c4408ebc5bdb69a5c846c48c",
+      "sourceDigest": "8eb4e594aa4da07143f4b8b21ab5f1c2354469afa66604dd4a6e25103d426b50",
       "outputPath": "tabnine-guidelines/.tabnine/guidelines/concepts.md",
       "hostId": "tabnine",
       "hostAdapterId": "tabnine-host-adapter",
       "evidenceIds": [
         "tabnine-source-1"
       ],
-      "outputDigest": "f1f941ec32415bd4b5a403f0d084dd601935ea5e6a4baf29598a63f69753a095"
+      "outputDigest": "3aa3e81e5992f295a76ac3eda8fd02f14c7a49ed7500517bfd301674511866a6"
     },
     {
       "projectionId": "cratis-rule-csharp-to-jetbrains-ai-assistant-rule",
@@ -965,14 +965,14 @@
       "canonicalOwnerId": "cratis-rule-glossary",
       "semanticKind": "rule",
       "sourcePath": ".ai/rules/glossary.md",
-      "sourceDigest": "5a89504e5b4cc32f4cbf55f894c3d37332043119ef78843047ee5f24909267aa",
+      "sourceDigest": "8dd04c98a21a0861b3fb061d188af766cb41c10a0c87298ec32a4eddf6cd19c3",
       "outputPath": "jetbrains-ai-assistant-rules/.aiassistant/rules/glossary.md",
       "hostId": "jetbrains-ai-assistant",
       "hostAdapterId": "jetbrains-ai-assistant-host-adapter",
       "evidenceIds": [
         "jetbrains-ai-assistant-source-1"
       ],
-      "outputDigest": "bbc5da53b562456445b2e8c2d4cbbf2c2376bf4e56b71f4a2f181bae1915f8fd"
+      "outputDigest": "e3feec1ad0074f32007ddb1db1db62835cd96ae360eed81e74404e9030e7caf9"
     },
     {
       "projectionId": "cratis-rule-glossary-to-tabnine-rule",
@@ -980,14 +980,14 @@
       "canonicalOwnerId": "cratis-rule-glossary",
       "semanticKind": "rule",
       "sourcePath": ".ai/rules/glossary.md",
-      "sourceDigest": "5a89504e5b4cc32f4cbf55f894c3d37332043119ef78843047ee5f24909267aa",
+      "sourceDigest": "8dd04c98a21a0861b3fb061d188af766cb41c10a0c87298ec32a4eddf6cd19c3",
       "outputPath": "tabnine-guidelines/.tabnine/guidelines/glossary.md",
       "hostId": "tabnine",
       "hostAdapterId": "tabnine-host-adapter",
       "evidenceIds": [
         "tabnine-source-1"
       ],
-      "outputDigest": "bbc5da53b562456445b2e8c2d4cbbf2c2376bf4e56b71f4a2f181bae1915f8fd"
+      "outputDigest": "e3feec1ad0074f32007ddb1db1db62835cd96ae360eed81e74404e9030e7caf9"
     },
     {
       "projectionId": "cratis-rule-managing-ai-rules-to-jetbrains-ai-assistant-rule",
@@ -1385,14 +1385,14 @@
       "canonicalOwnerId": "cratis-rule-vertical-slices",
       "semanticKind": "rule",
       "sourcePath": ".ai/rules/vertical-slices.md",
-      "sourceDigest": "2f6fbcbfd2be4b6eb94ff2c878a6f2f67c4523296753fdd4256219a25d1b2590",
+      "sourceDigest": "5e590df10d4036595472079d9defd9746ce96d04d868444158b1707879bdecf3",
       "outputPath": "jetbrains-ai-assistant-rules/.aiassistant/rules/vertical-slices.md",
       "hostId": "jetbrains-ai-assistant",
       "hostAdapterId": "jetbrains-ai-assistant-host-adapter",
       "evidenceIds": [
         "jetbrains-ai-assistant-source-1"
       ],
-      "outputDigest": "51df677faf11f73555981207e7993e3c217ebfc5b4ac1e0df31455fdb0780f5e"
+      "outputDigest": "3583b8f7e6ab4561385bf6d72bdac63dab919a10d7262b0732c6a7ba4cd80678"
     },
     {
       "projectionId": "cratis-rule-vertical-slices-to-tabnine-rule",
@@ -1400,14 +1400,14 @@
       "canonicalOwnerId": "cratis-rule-vertical-slices",
       "semanticKind": "rule",
       "sourcePath": ".ai/rules/vertical-slices.md",
-      "sourceDigest": "2f6fbcbfd2be4b6eb94ff2c878a6f2f67c4523296753fdd4256219a25d1b2590",
+      "sourceDigest": "5e590df10d4036595472079d9defd9746ce96d04d868444158b1707879bdecf3",
       "outputPath": "tabnine-guidelines/.tabnine/guidelines/vertical-slices.md",
       "hostId": "tabnine",
       "hostAdapterId": "tabnine-host-adapter",
       "evidenceIds": [
         "tabnine-source-1"
       ],
-      "outputDigest": "51df677faf11f73555981207e7993e3c217ebfc5b4ac1e0df31455fdb0780f5e"
+      "outputDigest": "3583b8f7e6ab4561385bf6d72bdac63dab919a10d7262b0732c6a7ba4cd80678"
     },
     {
       "projectionId": "cratis-rule-web-fetching-to-jetbrains-ai-assistant-rule",

--- a/tooling/generate-catalog-v2.mjs
+++ b/tooling/generate-catalog-v2.mjs
@@ -175,6 +175,30 @@ const publicClassifications = new Map([
 
 const sourceOverrides = new Map([
     [
+        "cratis-command",
+        {
+            sourcePath: ".ai/skills/cratis-command",
+            sourceRevision: "5d45432cda795ad1f5e5b58c2df143f01161885c",
+            evidenceId: "cratis-command-command-causation-values-5d45432",
+        },
+    ],
+    [
+        "cross-cutting-properties",
+        {
+            sourcePath: ".ai/skills/cross-cutting-properties",
+            sourceRevision: "5d45432cda795ad1f5e5b58c2df143f01161885c",
+            evidenceId: "cross-cutting-properties-command-causation-values-5d45432",
+        },
+    ],
+    [
+        "review-security",
+        {
+            sourcePath: ".ai/skills/review-security",
+            sourceRevision: "5d45432cda795ad1f5e5b58c2df143f01161885c",
+            evidenceId: "review-security-command-causation-values-5d45432",
+        },
+    ],
+    [
         "cratis-studio-mcp-safety-guidance",
         {
             sourcePath: "skills/cratis-studio-mcp-safety-guidance",

--- a/tooling/native-non-skill-projections.mjs
+++ b/tooling/native-non-skill-projections.mjs
@@ -29,7 +29,7 @@ export const s8NativeProjectionPaths = Object.freeze({
 });
 
 const expectedStaticComponentAnchor =
-    "8b002187a77333b12f149a7d36b6ee386cfcf725dd8f6bd17418cac0697a9c7b";
+    "ec52c6c12b4eca6a20c5ef8bc9977804d16ad55fd8fbd5ecc5faffc9c1903cf0";
 const expectedStaticProjectionAnchor =
     "5994bb761eeaf6f44fd5da70af8434f93b5197ccc7325bb9aa536eb1a9bf0056";
 const expectedStaticProjectionHostAnchor =


### PR DESCRIPTION
# Summary

Arc 22.8.0 records a command's property values on the causation of every event it appends, so an event says what the command was asked to do and not only which command it was. The causation is written into the event log and stays there for as long as the events do, which turns "should this value be recorded" into a decision to take when the property is added rather than after — and there was nothing in the corpus saying so.

## Changed

- `vertical-slices.md` gains a **Causation** section under Commands: what a command records, the two markings that withhold a value, why `[PII]` and `[NotAudited]` are not interchangeable, and that the concept is the idiomatic place for either
- `concepts.md` says to mark a concept holding personal data `[PII]` and one holding a secret `[NotAudited]`, so the marking travels to every command and event that uses it
- `glossary.md` defines `[NotAudited]` and the causation chain
- The **cratis-command** skill covers the decision where it is actually made — defining the record's properties
- The **cross-cutting-properties** skill covers command values as the third context channel, the one you get without asking for it
- The **review-security** skill checks that a command carrying a secret is marked, and warns that `ARCCHR0009` only catches secret-*sounding* names
