### PR TITLE
Fix the S10 evidence baseline anchor

### DIFF
--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "e5874c8f59314448c2ed16507346334411fddb614b48380dfc95d0ac90afa683",
+  "indexDigest": "76717c44d550f9e1ea7f7bf0b1d764479f3e8a5d1ad413418efee1c04d984ab5",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/tooling/s10-release-gate-validation.mjs
+++ b/tooling/s10-release-gate-validation.mjs
@@ -20,7 +20,7 @@ import { computeEvidenceIdentityAnchors } from "./support-validation.mjs";
 const expectedPolicyDigest =
     "02982ff7a36eb77025f7eda8e82d41ab671e695f7faa8dafc0d3dbcd665474ed";
 const expectedEvidenceBaselineDigest =
-    "b28d8e4b0d813fd5e5c4546b5ce0b06e84222a4160f3a3b2e4437c9ee7b3cdad";
+    "8041cb8c0c9b442d9528a3779a0449b50cedadd4efa056191a993f5d5bc9374b";
 const sideEffectJobs = [
     "canary",
     "distribute",


### PR DESCRIPTION
Replays PR #238 onto current `main`, which it could no longer merge into.

`catalog/evidence-baseline.json` was updated in `1cb6223` to record the Samples AI package
canary, but `expectedEvidenceBaselineDigest` in `tooling/s10-release-gate-validation.mjs`
was never moved with it. The Advanced Assurance Audit workflow has been failing on `main`
ever since with `S10 evidence baseline differs from the reviewed anchor`.

The digest in the original fix is still the correct one for current `main`:
`8041cb8c0c9b442d9528a3779a0449b50cedadd4efa056191a993f5d5bc9374b`.

Original commit cherry-picked with authorship preserved. The inventory index digest tracks
the git index, so it moves with the anchor and is regenerated here.

## Verification

- `node tooling/s10-release-gate-validation.mjs` — passes, state `BLOCKED` (unchanged).
- `node tooling/validate-catalogs.mjs --basic` — passes.
- Basic spec suite — 498 tests, 487 pass, 11 skipped, 0 fail.

Closes #237. Supersedes #238 and #239.