### PR TITLE
Stop telling documentation PRs to ignore the release-intent check

### DIFF
--- a/.ai/rules/pull-requests.md
+++ b/.ai/rules/pull-requests.md
@@ -21,6 +21,7 @@ PR descriptions serve two purposes: they help reviewers understand the change *n
 See the full [Git Commits guide](./git-commits.md) for rules on logical grouping, message format, and staging discipline.
 
 Quick reminders:
+
 - Imperative mood: "Add author registration" not "Added author registration".
 - Each commit = one logical unit of work. No WIP commits in the final PR.
 - Never mix unrelated changes in a single commit.
@@ -61,11 +62,14 @@ Split into separate pull requests when the changes are genuinely unrelated, when
 
 ## Quality Gates
 
-**A documentation-only pull request skips this section entirely.** Nothing it changes can break a build, a spec or a lint, so there is nothing to wait for: open it and merge it. Do not monitor its checks, do not wait for green, and do not treat a red `verify` from the deliberately absent version label as a failure. Verify the content instead — links resolve, anchors exist, every code example matches real source.
+**A documentation-only pull request skips the build gates below.** Nothing it changes can break a build, a spec or a lint, so there is nothing to wait for there: open it and merge it. Do not monitor those checks and do not wait for green on them. Verify the content instead — links resolve, anchors exist, every code example matches real source.
+
+**The release-intent check is not one of the gates it skips.** A documentation-only pull request still carries `no-release`, and its release-intent run still has to be green — the label is the entire statement that nothing was meant to ship, and the check is the only place that statement is recorded. A red release-intent run on a documentation pull request therefore means the label is missing, never that the gate does not apply; treating it as expected merges a pull request that says nothing about its own release intent and leaves a failed run standing on the record.
 
 **`no-release` does not otherwise excuse a PR from this section.** A CI, tooling, or spec-only pull request ships nothing, but it is exactly the kind of change that can break the build or the pipeline for everyone else — a broken workflow or a deleted spec does its damage without ever being released. Hold it to every gate below.
 
 Before marking any other PR ready for review:
+
 - `dotnet build` — zero errors, zero warnings
 - `dotnet test` — all specs pass
 - `yarn lint` — zero errors

--- a/catalog/components.json
+++ b/catalog/components.json
@@ -8782,12 +8782,12 @@
       "canonicalSources": [
         {
           "path": ".ai/rules/pull-requests.md",
-          "digest": "660d7b67b8219eacabcb801eec09f97a0f1b7f6fe8f85f6bf71b96cf37ef8d97",
+          "digest": "d8cd50022c2e5a964f73870b8c33c5f6425748f27f4f7bc764740a21f65d761a",
           "ownership": "owner",
           "ownerComponentId": "cratis-rule-pull-requests"
         }
       ],
-      "contentDigest": "89a97c9dd55762a40464fd4546360e2097cb57a611e7d50d4bc457c612eff77d",
+      "contentDigest": "89e72d3b5d92afd66a3929dc223cfca29c81828774258b223c213a80706f62be",
       "owner": "reusable Cratis engineering behavior",
       "audience": "cratis-engineering",
       "classification": {

--- a/catalog/generated/human-catalog/catalog.json
+++ b/catalog/generated/human-catalog/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractVersion": 1,
   "disclaimer": "Catalog inclusion, evaluation evidence, component modeling, planned projection, bundle generation, or publication does not grant runtime permission, emitted bytes, support, or approval.",
-  "inputDigest": "13eaa87be38c58b83d2f766d331eac3ab552cade557e6dacda7e0ba795cfb52b",
+  "inputDigest": "fe298228d64d6e23af3270e86a4606c10b1f56206cc7720111b9336d04fdf0c9",
   "componentSummary": {
     "disclaimer": "Modeled or planned components and projections are catalog metadata only; they are not emitted, supported, installable, published, promoted, or runtime eligible.",
     "total": 137,

--- a/catalog/generated/human-catalog/manifest.json
+++ b/catalog/generated/human-catalog/manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "contractVersion": 1,
-  "inputDigest": "13eaa87be38c58b83d2f766d331eac3ab552cade557e6dacda7e0ba795cfb52b",
+  "inputDigest": "fe298228d64d6e23af3270e86a4606c10b1f56206cc7720111b9336d04fdf0c9",
   "files": [
     {
       "path": "CATALOG.md",
@@ -11,7 +11,7 @@
     {
       "path": "catalog.json",
       "size": 155727,
-      "sha256": "77d44a5d878b5a8609125958bb1697745533958e6197c0d01af9f48065643c53"
+      "sha256": "c143dc041ffa715e62cc07a4dfdd9f315eef924fd7749d4320ca94f7d8c4d0e3"
     }
   ]
 }

--- a/catalog/v2/components.json
+++ b/catalog/v2/components.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "generatedBy": "tooling/generate-component-catalogs.mjs",
-  "sourceDigest": "f6ffb03847510e9007c063915a82530a74c21f04ff792ab207dafca18ebb4b0e",
+  "sourceDigest": "3da6ffd9f925d39476c169ca10ca986c88004eba064dda49502097bd2a7cc297",
   "defaultPolicy": "deny",
   "canonicalSourceRoots": [
     ".ai/agents",
@@ -8784,12 +8784,12 @@
       "canonicalSources": [
         {
           "path": ".ai/rules/pull-requests.md",
-          "digest": "660d7b67b8219eacabcb801eec09f97a0f1b7f6fe8f85f6bf71b96cf37ef8d97",
+          "digest": "d8cd50022c2e5a964f73870b8c33c5f6425748f27f4f7bc764740a21f65d761a",
           "ownership": "owner",
           "ownerComponentId": "cratis-rule-pull-requests"
         }
       ],
-      "contentDigest": "89a97c9dd55762a40464fd4546360e2097cb57a611e7d50d4bc457c612eff77d",
+      "contentDigest": "89e72d3b5d92afd66a3929dc223cfca29c81828774258b223c213a80706f62be",
       "owner": "reusable Cratis engineering behavior",
       "audience": "cratis-engineering",
       "classification": {

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "e5874c8f59314448c2ed16507346334411fddb614b48380dfc95d0ac90afa683",
+  "indexDigest": "1c2fe2cf2398174a5b7f19130f158a0cb9cb7070ce88c49f52d739e4e279704d",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "7f859ac0ec5a70c7c278e458dd650aaf33f82301a959e52532bf4296da2593ba",
+  "indexDigest": "7dc4b27bafa3da0c282354241150776578345326d66373a005fe12e6af2697a0",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -716,7 +716,7 @@
     },
     {
       "path": "catalog/v2/repository-inventory.json",
-      "status": "unmerged"
+      "status": "added"
     },
     {
       "path": "catalog/v2/source-contracts.json",
@@ -4515,8 +4515,8 @@
         "reevaluation-authority"
       ],
       "generator": "tooling/generate-catalog-v2.mjs, tooling/generate-component-catalogs.mjs, tooling/generate-support.mjs, tooling/generate-ecosystem-artifact-coverage.mjs, and tooling/generate-repository-inventory.mjs",
-      "expectedPathCount": 13,
-      "expectedPathsDigest": "235a23d4ee9b013cda25b00cc6d287a85de92e4ce6ff52ed933ddd769b67dcf7"
+      "expectedPathCount": 11,
+      "expectedPathsDigest": "13e5cefbee41ff9fea3e2d5980b943de02937e695290e80b4ae9d9c6bee866fa"
     },
     {
       "excludePathPatterns": [],

--- a/tooling/component-catalog-validation.mjs
+++ b/tooling/component-catalog-validation.mjs
@@ -32,7 +32,7 @@ export const componentCatalogPaths = Object.freeze({
 });
 
 const expectedComponentAnchor =
-    "b8f980743e62da44f1009126b742bb03eddccefac7369ab7ff173b538fefd02f";
+    "33be0c98f85c3343669e0c5247aa696681073f9da9eb8bdacbaa5a24f6b7e7fd";
 const expectedProjectionAnchor =
     "70f3e05988839ba21247eff528709caf4738f2aa7f637e05e28658ff05902027";
 const expectedProjectionHostAnchor =

--- a/tooling/fixtures/s8-native-non-skill-expected-tree.json
+++ b/tooling/fixtures/s8-native-non-skill-expected-tree.json
@@ -136,8 +136,8 @@
         {
           "path": ".aiassistant/rules/pull-requests.md",
           "sourcePath": ".ai/rules/pull-requests.md",
-          "size": 7842,
-          "sha256": "d8f7eabf9df2d34fee048fd3cb90d80444770ae90446c594c97f25451ae6eb1c"
+          "size": 8351,
+          "sha256": "e4bd4be4adbeb371abf8634e8b0afe0fb82bdfb97bb859a8813915893c255b4c"
         },
         {
           "path": ".aiassistant/rules/react.md",
@@ -346,8 +346,8 @@
         {
           "path": ".tabnine/guidelines/pull-requests.md",
           "sourcePath": ".ai/rules/pull-requests.md",
-          "size": 7842,
-          "sha256": "d8f7eabf9df2d34fee048fd3cb90d80444770ae90446c594c97f25451ae6eb1c"
+          "size": 8351,
+          "sha256": "e4bd4be4adbeb371abf8634e8b0afe0fb82bdfb97bb859a8813915893c255b4c"
         },
         {
           "path": ".tabnine/guidelines/react.md",
@@ -1055,14 +1055,14 @@
       "canonicalOwnerId": "cratis-rule-pull-requests",
       "semanticKind": "rule",
       "sourcePath": ".ai/rules/pull-requests.md",
-      "sourceDigest": "660d7b67b8219eacabcb801eec09f97a0f1b7f6fe8f85f6bf71b96cf37ef8d97",
+      "sourceDigest": "d8cd50022c2e5a964f73870b8c33c5f6425748f27f4f7bc764740a21f65d761a",
       "outputPath": "jetbrains-ai-assistant-rules/.aiassistant/rules/pull-requests.md",
       "hostId": "jetbrains-ai-assistant",
       "hostAdapterId": "jetbrains-ai-assistant-host-adapter",
       "evidenceIds": [
         "jetbrains-ai-assistant-source-1"
       ],
-      "outputDigest": "d8f7eabf9df2d34fee048fd3cb90d80444770ae90446c594c97f25451ae6eb1c"
+      "outputDigest": "e4bd4be4adbeb371abf8634e8b0afe0fb82bdfb97bb859a8813915893c255b4c"
     },
     {
       "projectionId": "cratis-rule-pull-requests-to-tabnine-rule",
@@ -1070,14 +1070,14 @@
       "canonicalOwnerId": "cratis-rule-pull-requests",
       "semanticKind": "rule",
       "sourcePath": ".ai/rules/pull-requests.md",
-      "sourceDigest": "660d7b67b8219eacabcb801eec09f97a0f1b7f6fe8f85f6bf71b96cf37ef8d97",
+      "sourceDigest": "d8cd50022c2e5a964f73870b8c33c5f6425748f27f4f7bc764740a21f65d761a",
       "outputPath": "tabnine-guidelines/.tabnine/guidelines/pull-requests.md",
       "hostId": "tabnine",
       "hostAdapterId": "tabnine-host-adapter",
       "evidenceIds": [
         "tabnine-source-1"
       ],
-      "outputDigest": "d8f7eabf9df2d34fee048fd3cb90d80444770ae90446c594c97f25451ae6eb1c"
+      "outputDigest": "e4bd4be4adbeb371abf8634e8b0afe0fb82bdfb97bb859a8813915893c255b4c"
     },
     {
       "projectionId": "cratis-rule-react-to-jetbrains-ai-assistant-rule",

--- a/tooling/native-non-skill-projections.mjs
+++ b/tooling/native-non-skill-projections.mjs
@@ -29,7 +29,7 @@ export const s8NativeProjectionPaths = Object.freeze({
 });
 
 const expectedStaticComponentAnchor =
-    "70f465a07e95ec844af3778b2eec8da20875383349bff88fe6837110f5bf41c7";
+    "8a38df5616c90d99e7a8c23984db52831127dd9a311785f7da33f7d6eaa43ffe";
 const expectedStaticProjectionAnchor =
     "5994bb761eeaf6f44fd5da70af8434f93b5197ccc7325bb9aa536eb1a9bf0056";
 const expectedStaticProjectionHostAnchor =


### PR DESCRIPTION
Replays PR #228 onto current `main`, which it could no longer merge into. The rule change is
cherry-picked with authorship preserved; the generated catalogs are regenerated here rather
than carried over stale.

## The problem

`.ai/rules/pull-requests.md` told agents that a documentation-only pull request skips the
Quality Gates section *entirely*, and to treat a red `release-intent` run as expected. That
is wrong in a way that compounds: the `no-release` label is the entire statement that nothing
was meant to ship, and the release-intent check is the only place that statement is recorded.
Reading its failure as "does not apply" merges pull requests that say nothing about their own
release intent and leaves failed runs standing on the record — which is how several of the
open bot-filed failure issues came to exist.

## What changes

- A documentation-only pull request skips the **build** gates, not the release-intent check.
- It still carries `no-release`, and that run still has to be green.
- A red release-intent run on a documentation pull request means the label is missing — never
  that the gate does not apply.

## Verification

- `node tooling/validate-catalogs.mjs --basic` — passes.
- AI corpus validation — passes.
- Basic spec suite — 498 tests, 487 pass, 11 skipped, 0 fail.

Supersedes #228 and #229.