### PR TITLE
Teach the corpus what a command records on the causation chain

### DIFF
--- a/.ai/rules/concepts.md
+++ b/.ai/rules/concepts.md
@@ -39,6 +39,15 @@ does not need a `ConceptAs<T>` wrapper.
 - `NotSet` or `Empty` is optional domain policy. Add one only when the backing
   value is impossible or explicitly reserved in that domain. Do not assume
   empty string, zero, or `Guid.Empty` is universally invalid.
+- Mark a concept that holds **personal data** `[PII]` and one that holds a
+  **secret** `[NotAudited]`. Both markings travel with the type, so marking it
+  once covers every command and event that uses it - which is the point of
+  having the concept. A command's property values are written to the causation
+  chain of every event it appends, so an unmarked `ApiKey` or `AccessToken`
+  concept reaches the event log in the clear and stays there. The two are not
+  interchangeable: `[PII]` also encrypts and enrolls the value in erasure, which
+  is wrong for a password, and `[NotAudited]` does nothing for an erasure
+  request, which is wrong for a name.
 
 ```csharp
 public record AuthorName(string Value) : ConceptAs<string>(Value)

--- a/.ai/rules/glossary.md
+++ b/.ai/rules/glossary.md
@@ -32,6 +32,7 @@ One precise line per load-bearing term, so the same word means the same thing ev
 
 - **Command** — a `[Command]` record expressing an imperative **intent**; its public `Handle()` produces event(s) (or a response).
 - **Provide()** — the command method that fetches/computes data after validation/authorization and before `Handle()`; may short-circuit with a `ValidationResult`.
+- **Causation chain** — the ordered links saying how an append came about (root process → command → …), each carrying properties. A command records its **name and its property values** there, so an event says what the command was asked to do; the chain lives in the event log and is as permanent as the events.
 - **Constraint** — `IConstraint`; an **append-time** invariant (uniqueness / concurrency) enforced at the event-store level.
 - **DCB (Dynamic Consistency Boundary)** — enforcing a state-dependent rule **under concurrency** by injecting the read model into `Handle()` and returning `Result<TEvent, ValidationResult>`.
 - **Consistency boundary** — the scope within which an invariant holds atomically (an event source, or the read model a DCB rule inspects).
@@ -50,6 +51,7 @@ One precise line per load-bearing term, so the same word means the same thing ev
 
 - **Subject / `[Subject]`** — the natural person a piece of PII belongs to (for GDPR erasure); defaults to the `EventSourceId<T>` identity.
 - **`[PII]`** — marks an inherently personal value so Chronicle can manage/erase it.
+- **`[NotAudited]`** — marks a value that is secret but *not* personal data (password, token, API key) so it is never written to the causation chain. Withholds only; it does not encrypt or enroll the value in erasure the way `[PII]` does.
 - **Namespace / tenant** — Chronicle isolates tenants by **namespace**; each namespace has its own events, observers, and read models.
 
 ## Profiles

--- a/.ai/rules/vertical-slices.md
+++ b/.ai/rules/vertical-slices.md
@@ -88,6 +88,32 @@ The command carries input from the caller. `Handle()` is defined directly on the
 
 **Do not throw for normal business rejection.** A thrown exception (from `Provide()` or `Handle()`) surfaces as an exception/HTTP 500, *not* a validation result. Recoverable, user-facing rejections are validation: `ValidationResult.Error(...)` via a validator or `Result<,>`. (For step-by-step business-rule placement, invoke the **add-business-rule** skill.)
 
+### Causation — what a command records **[contract]**
+
+A command's **property values** are recorded on the causation of every event it appends, alongside the command's name, so an event says not only which command produced it but what that command was asked to do. The causation is written into the event log and stays there for as long as the events do — a value recorded there cannot be taken back out by changing code.
+
+Two markings keep a value off the chain, and both are honored on the property, the declaring type, the positional record parameter, **and the property's type**:
+
+| Marking | For | Also does |
+| --- | --- | --- |
+| `[PII]` | personal data | encrypts it in the event, enrolls it in erasure |
+| `[NotAudited]` | a secret that is not personal data — password, token, API key, card number | nothing else; it only withholds |
+
+They are **not interchangeable**: `[PII]` on a password would encrypt it and enroll it in GDPR erasure, which is wrong; `[NotAudited]` on a name does nothing for an erasure request, which is also wrong.
+
+**Prefer marking the concept**, exactly as with `[PII]` — mark `ApiKey` once and every command taking one is covered:
+
+```csharp
+[NotAudited]
+public record ApiKey(string Value) : ConceptAs<string>(Value);
+```
+
+`[NotAudited]` on the command type excludes every property at once, which is right when a command exists only to carry secrets. The command is still **named** on the chain either way — what is withheld is the values, never the fact that it ran.
+
+`ARCCHR0009` warns on a command property whose *name* reads like a secret and is unmarked. It cannot see a secret whose name does not say so, so a clean build means "nothing obvious was missed", not "no secrets are recorded". For a false positive, **suppress the diagnostic** — marking it `[NotAudited]` would silence the warning by withholding a value you wanted recorded.
+
+Values render camel-cased; concepts unwrap to the value they hold; a value that is not set is omitted; a long one is truncated (the causation rides on *every* event the command appends).
+
 ### `Provide()` — data for `Handle()` **[contract]**
 
 `Provide()` runs after authorization and validation, before `Handle()`. Its parameters resolve from DI (like `Handle()`'s); the command instance is `this`. Return one value, or a tuple (Arc binds tuple values to `Handle(...)` parameters by type). Each provided value must be consumed by a `Handle` parameter — an unused one is the **`ARC0005`** analyzer error. Use a **named record** when the provided values form a real domain/snapshot concept; a **tuple** when they are just separate inputs to event construction. It may be sync or async.
@@ -256,6 +282,7 @@ public Task AuthorRegistered(AuthorRegistered @event, EventContext context) => .
 **[contract]** Chronicle encrypts `[PII]`-marked values per subject; decryption is transparent to observers and queries (read models injected into a `CommandValidator<T>` or `Handle()` decrypt transparently under the command's resolved subject before validation/handler logic runs).
 
 - Prefer **concept-level `[PII]`** (on the `ConceptAs<T>` type) so the marker travels everywhere automatically; use property-level `[PII]` only when a value is personal in one event context but not everywhere.
+- `[PII]` also keeps the value **off the causation chain** when it is a command property — see [Causation](#causation--what-a-command-records-contract). A secret that is not personal data needs `[NotAudited]` instead; `[PII]` is the wrong tool for a password.
 - **`[PII]` is found at any nesting depth, and may mark a whole value object.** A `[PII]` concept inside a value object is encrypted where it sits (siblings stay readable). Marking the **value object type** (or a property typed as one) with `[PII]` classifies every value it holds — Chronicle pushes the marker down to the individual values, so the document keeps its shape and each value is separately encrypted rather than fused into one blob.
 - Projection-backed read models inherit PII lineage automatically — don't add `[PII]` to their properties. Reducer-backed models: a `[PII]`-concept-typed property is detected automatically; add property-level `[PII]` only for a primitive/non-PII-concept property populated from PII source data.
 - ⚠️ **`[PII]` cannot be applied to `EventSourceId`/`EventSourceId<T>`** — Chronicle throws `PIINotSupportedOnEventSourceId` at runtime because the identifier is the encryption-key lookup. If the identifier itself is sensitive, use a random `Guid`-backed surrogate as the event source id and store the sensitive value in a `[PII]` property.

--- a/.ai/skills/cratis-command/SKILL.md
+++ b/.ai/skills/cratis-command/SKILL.md
@@ -39,12 +39,14 @@ public record DebitAccountOpened(AccountName Name, OwnerId OwnerId);
 ```
 
 **Rules:**
+
 - `[Command]` attribute is **required** — it makes the type discoverable and the analyzer will warn without it
 - `Handle()` returns the event (or events) to append — Arc's Chronicle integration automatically appends them; **never inject `IEventLog` to append the primary event**
 - `[EventType]` takes **no arguments** — the identifier is generated from the type name
 - Name the command as an imperative action — `OpenDebitAccount`, not `OpenDebitAccountCommand`
 - All backend artifacts for the slice live in this one file; place it in the slice folder, not an `API/` or `Commands/` folder (see [vertical-slices.md](https://github.com/Cratis/AI/blob/main/.ai/rules/vertical-slices.md))
 - Use concept wrappers for every domain value — **identity** concepts derive from `EventSourceId<T>`, **value** concepts from `ConceptAs<T>`; never raw `Guid`/`string`
+- Every property's **value** is recorded on the causation chain of each event the command appends — mark a secret `[NotAudited]` and personal data `[PII]` before it reaches the event log (see below)
 
 ```csharp
 // Accounts/AccountId.cs — identity concept derives from EventSourceId<T>
@@ -88,6 +90,37 @@ public record TransferFunds(AccountId FromId, AccountId ToId, Money Amount)
 ```
 
 For multiple events on the **same** event source, return the bare event records.
+
+### Values the command must not record
+
+A command's property values are written to the causation of **every** event it appends, and the event log is immutable — a secret recorded there cannot be taken back out by changing code. Decide this when you add the property, not later.
+
+```csharp
+[Command]
+public record ChangePassword(
+    UserId User,
+    [property: NotAudited] string OldPassword,   // withheld: a secret
+    [property: NotAudited] string NewPassword)
+{
+    public PasswordChanged Handle(IPasswordHasher hasher) => new(hasher.Hash(NewPassword));
+}
+```
+
+| Marking | Use for | Also does |
+| --- | --- | --- |
+| `[PII]` | personal data — a name, an email | encrypts it in the event, enrolls it in erasure |
+| `[NotAudited]` | a secret that is not personal data — password, token, API key | nothing else; it only withholds |
+
+**Prefer marking the concept** so it travels to every command that takes one — the same idiom as `[PII]`:
+
+```csharp
+[NotAudited]
+public record ApiKey(string Value) : ConceptAs<string>(Value);
+```
+
+`[NotAudited]` on the command type withholds every property at once. The command is still **named** on the chain either way; only the values are withheld.
+
+`ARCCHR0009` warns when a property's *name* reads like a secret and is unmarked. It cannot see a secret whose name does not say so — a clean build means "nothing obvious was missed", not "no secrets are recorded". If it is wrong and the value should be recorded, **suppress the diagnostic** rather than marking it `[NotAudited]`, which would silence the warning by withholding a value you wanted.
 
 ---
 
@@ -266,6 +299,7 @@ export const AccountsPage = () => {
 ```
 
 **How it works:**
+
 - `useDialog(OpenAccountDialog)` returns a wrapper component and a `show` function
 - `showOpenAccount()` opens the dialog; it returns a Promise that resolves when the dialog closes
 - `CommandDialog` executes the command when the user confirms; it closes automatically

--- a/.ai/skills/cross-cutting-properties/SKILL.md
+++ b/.ai/skills/cross-cutting-properties/SKILL.md
@@ -40,6 +40,21 @@ public class TenantMetadataProvider(IHttpContextAccessor http) : ICanProvideAddi
 
 Chronicle discovers providers from DI — register as scoped/singleton. Multiple providers merge; key collisions = last-registered wins. Place the class at a cross-cutting infrastructure location, not inside a slice. The properties land in the event's **metadata envelope**, not the event record — they are not surfaced in `EventContext` on reactive handlers. If a value must influence a projection/reducer, it belongs on the event type (or a dedicated audit event), not in cross-cutting metadata.
 
+## Command values on the causation chain
+
+A third channel carries context, and unlike the two above you get it without asking: a **command's property values** are recorded on the causation of every event it appends, next to the command's name. Nothing to implement — but something to review, because the causation goes into the event log and stays there for as long as the events do.
+
+Mark what must not be written before the command ships:
+
+| Marking | For |
+| --- | --- |
+| `[PII]` | personal data — also encrypts it in the event and enrolls it in erasure |
+| `[NotAudited]` | a secret that is not personal data — password, token, API key, card number |
+
+Both are honored on the property, the declaring type, the positional record parameter, **and the property's type** — so marking a concept once covers every command that takes one, the same idiom as `[PII]` elsewhere. `ARCCHR0009` warns on an unmarked property whose *name* reads like a secret.
+
+Unlike a metadata provider, this is per-command payload rather than per-event infrastructure: use it to answer "what was this command asked to do", not to carry ambient context, which is what `ICanProvideAdditionalEventInformation` is for.
+
 ## Tags vs filtering — easy to confuse
 
 | Attribute | Where | What it does |
@@ -58,6 +73,7 @@ Tags are also used for concurrency scoping. To *filter* by tag you need `[Filter
 | Injecting scoped services into a singleton provider | register the provider scoped, or use `IServiceScopeFactory` |
 | Expecting envelope properties to appear in `EventContext` on handlers | they don't — they're metadata only |
 | Using a provider for data a projection needs | if the projection needs it, it belongs on the event type |
+| Letting a command carry a secret unmarked | its value is written to the causation of every event it appends, permanently — mark it `[NotAudited]` (or `[PII]` for personal data) |
 
 ## Quality gate
 
@@ -66,5 +82,6 @@ Tags are also used for concurrency scoping. To *filter* by tag you need `[Filter
 
 ## See also
 
-- [vertical-slices.md](https://github.com/Cratis/AI/blob/main/.ai/rules/vertical-slices.md) — event types, `EventContext` in reactors/reducers.
+- [vertical-slices.md](https://github.com/Cratis/AI/blob/main/.ai/rules/vertical-slices.md) — event types, `EventContext` in reactors/reducers, and what a command records on the causation chain.
+- `cratis-command` — marking a command's secrets before they reach the event log.
 - `multi-tenancy` — namespace-per-tenant isolation (a different mechanism from a tenant tag).

--- a/.ai/skills/review-security/SKILL.md
+++ b/.ai/skills/review-security/SKILL.md
@@ -20,7 +20,7 @@ Perform a structured security review of changed code.
 
 ## Sensitive Data Exposure
 
-- [ ] No passwords, secrets, API keys, or tokens stored in event properties or read models
+- [ ] No passwords, secrets, API keys, or tokens stored in event properties, read models, **or command properties reaching the causation chain**
 - [ ] No PII returned to clients that did not provide it
 - [ ] Query results scoped to requesting tenant/user — never return all-tenant data
 
@@ -36,6 +36,7 @@ Perform a structured security review of changed code.
 - [ ] Aggregate/event-store IDs generated server-side, never accepted from untrusted clients
 - [ ] Event upcasting logic does not allow injection of unexpected properties
 - [ ] Uniqueness constraints cannot be bypassed by concurrent multi-tenant writes
+- [ ] **Every `[Command]` property holding a secret is marked `[NotAudited]` (or `[PII]` for personal data)** — a command's values are written to the causation of every event it appends and cannot be removed afterwards. Prefer the marking on the concept. `ARCCHR0009` catches secret-*sounding* names only, so read the properties whose names do not say what they hold
 
 ## Frontend
 

--- a/catalog/components.json
+++ b/catalog/components.json
@@ -1333,12 +1333,12 @@
       "canonicalSources": [
         {
           "path": ".ai/skills/cratis-command",
-          "digest": "2696e19f3cb57b32666469f21951672800c98be4212c2e8aba61188495fed7fc",
+          "digest": "2f97a3c740b96273326783de74a3479d6ff972dda8df733d39dc5111da1753da",
           "ownership": "owner",
           "ownerComponentId": "cratis-arc-command"
         }
       ],
-      "contentDigest": "b7bca616a9e39c478d37ef38a2243e9192a6a0798ef3e142a59604bcf0ea113f",
+      "contentDigest": "c6b6a8e61c97187b7359c15eb01268d5ad3513fe59378d32152efbcd0c4d5fb7",
       "owner": "public Cratis product capability",
       "audience": "public",
       "classification": {
@@ -2171,12 +2171,12 @@
       "canonicalSources": [
         {
           "path": ".ai/skills/cross-cutting-properties",
-          "digest": "1aa579cdc9ea0da01477bf295f88de6a207c5ceda0aaacac4da028d8d302f091",
+          "digest": "9f32dd20867ae150d2c6342e374afec1a78c08797620b7bba41d4bf995086fd5",
           "ownership": "owner",
           "ownerComponentId": "cratis-chronicle-event-metadata"
         }
       ],
-      "contentDigest": "c96fd74eec3f89408f15d1443aa6e4ad8c98238ade98028b3cd6b4f6fdf3dc2d",
+      "contentDigest": "56927a1b16001d7852bc4a57b49350a69a8ee9163c37efb626fb1e30bc0d45b5",
       "owner": "public Cratis product capability",
       "audience": "public",
       "classification": {
@@ -7609,12 +7609,12 @@
       "canonicalSources": [
         {
           "path": ".ai/rules/concepts.md",
-          "digest": "ec09879acc66fe7bc0518bb2d9c2dbf7944e1c65c4408ebc5bdb69a5c846c48c",
+          "digest": "8eb4e594aa4da07143f4b8b21ab5f1c2354469afa66604dd4a6e25103d426b50",
           "ownership": "owner",
           "ownerComponentId": "cratis-rule-concepts"
         }
       ],
-      "contentDigest": "45fe35b007e883f45933a9315653d2086c29a24dd8403e32021446a6cb3cb886",
+      "contentDigest": "2b25eabbf5e75cbd512701c950be6fc4fabc5ea3c6c8a6a6fdca10dcbb2e8a24",
       "owner": "reusable Cratis engineering behavior",
       "audience": "cratis-engineering",
       "classification": {
@@ -8506,12 +8506,12 @@
       "canonicalSources": [
         {
           "path": ".ai/rules/glossary.md",
-          "digest": "5a89504e5b4cc32f4cbf55f894c3d37332043119ef78843047ee5f24909267aa",
+          "digest": "8dd04c98a21a0861b3fb061d188af766cb41c10a0c87298ec32a4eddf6cd19c3",
           "ownership": "owner",
           "ownerComponentId": "cratis-rule-glossary"
         }
       ],
-      "contentDigest": "94d301149fe4d194926558955861cb2f3df729b25fc824c80229804aaed9b064",
+      "contentDigest": "a3d53661ee7850731100886143241974df343d37def9bf9d79ebe4527a24b430",
       "owner": "reusable Cratis engineering behavior",
       "audience": "cratis-engineering",
       "classification": {
@@ -9541,12 +9541,12 @@
       "canonicalSources": [
         {
           "path": ".ai/rules/vertical-slices.md",
-          "digest": "2f6fbcbfd2be4b6eb94ff2c878a6f2f67c4523296753fdd4256219a25d1b2590",
+          "digest": "40ee72260db33d91dc1f2342d2bf0e3d75554102203a38d0f637c9454a3d42a7",
           "ownership": "owner",
           "ownerComponentId": "cratis-rule-vertical-slices"
         }
       ],
-      "contentDigest": "64be055892e6e3c83a7334f8d68dca984d21251ef30cc1a62bd464750df6d1c9",
+      "contentDigest": "280afbfdcef2ddb063865bae944895c3b6734a05d085fccd3cd82f417ebcb975",
       "owner": "reusable Cratis engineering behavior",
       "audience": "cratis-engineering",
       "classification": {
@@ -9817,12 +9817,12 @@
       "canonicalSources": [
         {
           "path": ".ai/skills/review-security",
-          "digest": "c5829036d84177ba53cdacf54e01ec7cf05cb84fb4b8f07fb0305003213d0b3f",
+          "digest": "f7a78c4c980d17ae304bce81a20a19a8864965ba2784466c10fcca7aaa0fd178",
           "ownership": "owner",
           "ownerComponentId": "cratis-security-review"
         }
       ],
-      "contentDigest": "a9c38df6402c5d0a7c1be37a4e64967e96c23a0b2e803a24dc25567b06e7e88b",
+      "contentDigest": "0f957586d4509a518b94f58a98f283364ecf52be3f067f406472f44d43d6acd6",
       "owner": "public Cratis product capability",
       "audience": "public",
       "classification": {

--- a/catalog/evidence.json
+++ b/catalog/evidence.json
@@ -48,6 +48,12 @@
       "immutableRevision": "c2f721c2f80321cfba352d8d2e4209a0881ccb63"
     },
     {
+      "id": "source-command-causation-guidance-source-afbe46f",
+      "kind": "repository-snapshot",
+      "locator": "https://github.com/Cratis/AI/tree/afbe46fc7c87ab110df7f1983a0ca174ef0f6aac/.ai/skills",
+      "immutableRevision": "afbe46fc7c87ab110df7f1983a0ca174ef0f6aac"
+    },
+    {
       "id": "source-public-effect-guidance-boundary-source-6ec7247",
       "kind": "repository-snapshot",
       "locator": "https://github.com/Cratis/AI/tree/6ec724752023b7c1639b01e33d700d84d04fcfc3/.ai/skills",
@@ -1044,6 +1050,43 @@
         "officialUrl": "https://github.com/Cratis/AI/tree/c2f721c2f80321cfba352d8d2e4209a0881ccb63/.ai/skills",
         "sourceKind": "repository-snapshot",
         "applicableVersion": "c2f721c2f80321cfba352d8d2e4209a0881ccb63"
+      }
+    },
+    {
+      "id": "command-causation-guidance-source-afbe46f",
+      "sourceId": "source-command-causation-guidance-source-afbe46f",
+      "evidenceClass": "hosted",
+      "subject": {
+        "kind": "artifact",
+        "id": "candidate-passive-public-package",
+        "version": "afbe46fc7c87ab110df7f1983a0ca174ef0f6aac"
+      },
+      "bindingIds": [],
+      "assertions": [
+        {
+          "assuranceId": "source-provenance",
+          "outcome": "pass",
+          "supporting": true,
+          "claimIds": []
+        }
+      ],
+      "scope": "Source provenance for the command, cross-cutting and security guidance that documents what a command records on the causation chain.",
+      "environment": {
+        "operatingSystem": "not-recorded",
+        "architecture": "not-recorded",
+        "isolation": "not-recorded"
+      },
+      "observedOn": "2026-09-02",
+      "validThrough": "2027-09-02",
+      "confidence": "high",
+      "limitations": [
+        "This observation proves source provenance only; it grants no behavior or support assurance."
+      ],
+      "supersedes": [],
+      "legacy": {
+        "officialUrl": "https://github.com/Cratis/AI/tree/afbe46fc7c87ab110df7f1983a0ca174ef0f6aac/.ai/skills",
+        "sourceKind": "repository-snapshot",
+        "applicableVersion": "afbe46fc7c87ab110df7f1983a0ca174ef0f6aac"
       }
     },
     {

--- a/catalog/generated/human-catalog/catalog.json
+++ b/catalog/generated/human-catalog/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractVersion": 1,
   "disclaimer": "Catalog inclusion, evaluation evidence, component modeling, planned projection, bundle generation, or publication does not grant runtime permission, emitted bytes, support, or approval.",
-  "inputDigest": "13eaa87be38c58b83d2f766d331eac3ab552cade557e6dacda7e0ba795cfb52b",
+  "inputDigest": "cbe88f236db073f7137d8e3fc7bc3cab945fa4d48e3e181dfe6a66c13a2c6d5b",
   "componentSummary": {
     "disclaimer": "Modeled or planned components and projections are catalog metadata only; they are not emitted, supported, installable, published, promoted, or runtime eligible.",
     "total": 137,

--- a/catalog/generated/human-catalog/manifest.json
+++ b/catalog/generated/human-catalog/manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "contractVersion": 1,
-  "inputDigest": "13eaa87be38c58b83d2f766d331eac3ab552cade557e6dacda7e0ba795cfb52b",
+  "inputDigest": "cbe88f236db073f7137d8e3fc7bc3cab945fa4d48e3e181dfe6a66c13a2c6d5b",
   "files": [
     {
       "path": "CATALOG.md",
@@ -11,7 +11,7 @@
     {
       "path": "catalog.json",
       "size": 155727,
-      "sha256": "77d44a5d878b5a8609125958bb1697745533958e6197c0d01af9f48065643c53"
+      "sha256": "cbd0036a583c33bc8558693abe137d03b6850690ad405e5cb5423fff9f3463a1"
     }
   ]
 }

--- a/catalog/v2/components.json
+++ b/catalog/v2/components.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "generatedBy": "tooling/generate-component-catalogs.mjs",
-  "sourceDigest": "f6ffb03847510e9007c063915a82530a74c21f04ff792ab207dafca18ebb4b0e",
+  "sourceDigest": "6339cfc57117f0d4d7a728587f3eaba636144b84e573288cbc83ed8945c076b3",
   "defaultPolicy": "deny",
   "canonicalSourceRoots": [
     ".ai/agents",
@@ -1335,12 +1335,12 @@
       "canonicalSources": [
         {
           "path": ".ai/skills/cratis-command",
-          "digest": "2696e19f3cb57b32666469f21951672800c98be4212c2e8aba61188495fed7fc",
+          "digest": "2f97a3c740b96273326783de74a3479d6ff972dda8df733d39dc5111da1753da",
           "ownership": "owner",
           "ownerComponentId": "cratis-arc-command"
         }
       ],
-      "contentDigest": "b7bca616a9e39c478d37ef38a2243e9192a6a0798ef3e142a59604bcf0ea113f",
+      "contentDigest": "c6b6a8e61c97187b7359c15eb01268d5ad3513fe59378d32152efbcd0c4d5fb7",
       "owner": "public Cratis product capability",
       "audience": "public",
       "classification": {
@@ -2173,12 +2173,12 @@
       "canonicalSources": [
         {
           "path": ".ai/skills/cross-cutting-properties",
-          "digest": "1aa579cdc9ea0da01477bf295f88de6a207c5ceda0aaacac4da028d8d302f091",
+          "digest": "9f32dd20867ae150d2c6342e374afec1a78c08797620b7bba41d4bf995086fd5",
           "ownership": "owner",
           "ownerComponentId": "cratis-chronicle-event-metadata"
         }
       ],
-      "contentDigest": "c96fd74eec3f89408f15d1443aa6e4ad8c98238ade98028b3cd6b4f6fdf3dc2d",
+      "contentDigest": "56927a1b16001d7852bc4a57b49350a69a8ee9163c37efb626fb1e30bc0d45b5",
       "owner": "public Cratis product capability",
       "audience": "public",
       "classification": {
@@ -7611,12 +7611,12 @@
       "canonicalSources": [
         {
           "path": ".ai/rules/concepts.md",
-          "digest": "ec09879acc66fe7bc0518bb2d9c2dbf7944e1c65c4408ebc5bdb69a5c846c48c",
+          "digest": "8eb4e594aa4da07143f4b8b21ab5f1c2354469afa66604dd4a6e25103d426b50",
           "ownership": "owner",
           "ownerComponentId": "cratis-rule-concepts"
         }
       ],
-      "contentDigest": "45fe35b007e883f45933a9315653d2086c29a24dd8403e32021446a6cb3cb886",
+      "contentDigest": "2b25eabbf5e75cbd512701c950be6fc4fabc5ea3c6c8a6a6fdca10dcbb2e8a24",
       "owner": "reusable Cratis engineering behavior",
       "audience": "cratis-engineering",
       "classification": {
@@ -8508,12 +8508,12 @@
       "canonicalSources": [
         {
           "path": ".ai/rules/glossary.md",
-          "digest": "5a89504e5b4cc32f4cbf55f894c3d37332043119ef78843047ee5f24909267aa",
+          "digest": "8dd04c98a21a0861b3fb061d188af766cb41c10a0c87298ec32a4eddf6cd19c3",
           "ownership": "owner",
           "ownerComponentId": "cratis-rule-glossary"
         }
       ],
-      "contentDigest": "94d301149fe4d194926558955861cb2f3df729b25fc824c80229804aaed9b064",
+      "contentDigest": "a3d53661ee7850731100886143241974df343d37def9bf9d79ebe4527a24b430",
       "owner": "reusable Cratis engineering behavior",
       "audience": "cratis-engineering",
       "classification": {
@@ -9543,12 +9543,12 @@
       "canonicalSources": [
         {
           "path": ".ai/rules/vertical-slices.md",
-          "digest": "2f6fbcbfd2be4b6eb94ff2c878a6f2f67c4523296753fdd4256219a25d1b2590",
+          "digest": "40ee72260db33d91dc1f2342d2bf0e3d75554102203a38d0f637c9454a3d42a7",
           "ownership": "owner",
           "ownerComponentId": "cratis-rule-vertical-slices"
         }
       ],
-      "contentDigest": "64be055892e6e3c83a7334f8d68dca984d21251ef30cc1a62bd464750df6d1c9",
+      "contentDigest": "280afbfdcef2ddb063865bae944895c3b6734a05d085fccd3cd82f417ebcb975",
       "owner": "reusable Cratis engineering behavior",
       "audience": "cratis-engineering",
       "classification": {
@@ -9819,12 +9819,12 @@
       "canonicalSources": [
         {
           "path": ".ai/skills/review-security",
-          "digest": "c5829036d84177ba53cdacf54e01ec7cf05cb84fb4b8f07fb0305003213d0b3f",
+          "digest": "f7a78c4c980d17ae304bce81a20a19a8864965ba2784466c10fcca7aaa0fd178",
           "ownership": "owner",
           "ownerComponentId": "cratis-security-review"
         }
       ],
-      "contentDigest": "a9c38df6402c5d0a7c1be37a4e64967e96c23a0b2e803a24dc25567b06e7e88b",
+      "contentDigest": "0f957586d4509a518b94f58a98f283364ecf52be3f067f406472f44d43d6acd6",
       "owner": "public Cratis product capability",
       "audience": "public",
       "classification": {

--- a/catalog/v2/evidence.json
+++ b/catalog/v2/evidence.json
@@ -241,6 +241,16 @@
       "confidence": "high"
     },
     {
+      "id": "command-causation-guidance-source-afbe46f",
+      "officialUrl": "https://github.com/Cratis/AI/tree/afbe46fc7c87ab110df7f1983a0ca174ef0f6aac/.ai/skills",
+      "sourceKind": "repository-snapshot",
+      "verifiedOn": "2026-09-02",
+      "expiresOn": "2027-09-02",
+      "applicableVersion": "afbe46fc7c87ab110df7f1983a0ca174ef0f6aac",
+      "confidence": "high",
+      "immutableRevision": "afbe46fc7c87ab110df7f1983a0ca174ef0f6aac"
+    },
+    {
       "id": "continue-source-1",
       "officialUrl": "https://docs.continue.dev/index",
       "sourceKind": "official-documentation",

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "e5874c8f59314448c2ed16507346334411fddb614b48380dfc95d0ac90afa683",
+  "indexDigest": "dd20266d8cc991e49ef0dfa880783354a9e15c251da2d87d9dc52fbd01d33e08",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -49,6 +49,10 @@
     {
       "path": ".ai/rules/github-actions.md",
       "status": "added"
+    },
+    {
+      "path": ".ai/rules/glossary.md",
+      "status": "modified"
     },
     {
       "path": ".ai/rules/local-work-artifacts.md",
@@ -144,6 +148,10 @@
     },
     {
       "path": ".ai/skills/query-paging/SKILL.md",
+      "status": "modified"
+    },
+    {
+      "path": ".ai/skills/review-security/SKILL.md",
       "status": "modified"
     },
     {

--- a/catalog/v2/sources.json
+++ b/catalog/v2/sources.json
@@ -240,13 +240,13 @@
         ".ai/skills/cratis-command/references/proxy-setup.md",
         ".ai/skills/cratis-command/references/validation.md"
       ],
-      "sourceRevision": "c2f721c2f80321cfba352d8d2e4209a0881ccb63",
-      "contentDigest": "2696e19f3cb57b32666469f21951672800c98be4212c2e8aba61188495fed7fc",
+      "sourceRevision": "afbe46fc7c87ab110df7f1983a0ca174ef0f6aac",
+      "contentDigest": "2f97a3c740b96273326783de74a3479d6ff972dda8df733d39dc5111da1753da",
       "publicationApproval": false,
       "evidenceIds": [
         "repo-main-b795d53",
         "reevaluation-authority",
-        "public-skill-reference-closure-c2f721c"
+        "command-causation-guidance-source-afbe46f"
       ]
     },
     {
@@ -433,13 +433,13 @@
       "bundledPaths": [
         ".ai/skills/cross-cutting-properties/SKILL.md"
       ],
-      "sourceRevision": "23efb73a14eb367a2dd0e745caed171f67f3d550",
-      "contentDigest": "1aa579cdc9ea0da01477bf295f88de6a207c5ceda0aaacac4da028d8d302f091",
+      "sourceRevision": "afbe46fc7c87ab110df7f1983a0ca174ef0f6aac",
+      "contentDigest": "9f32dd20867ae150d2c6342e374afec1a78c08797620b7bba41d4bf995086fd5",
       "publicationApproval": false,
       "evidenceIds": [
         "repo-main-b795d53",
         "reevaluation-authority",
-        "public-skill-markdown-normalization-source-23efb73"
+        "command-causation-guidance-source-afbe46f"
       ]
     },
     {
@@ -698,12 +698,13 @@
       "bundledPaths": [
         ".ai/skills/review-security/SKILL.md"
       ],
-      "sourceRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-      "contentDigest": "c5829036d84177ba53cdacf54e01ec7cf05cb84fb4b8f07fb0305003213d0b3f",
+      "sourceRevision": "afbe46fc7c87ab110df7f1983a0ca174ef0f6aac",
+      "contentDigest": "f7a78c4c980d17ae304bce81a20a19a8864965ba2784466c10fcca7aaa0fd178",
       "publicationApproval": false,
       "evidenceIds": [
         "repo-main-b795d53",
-        "reevaluation-authority"
+        "reevaluation-authority",
+        "command-causation-guidance-source-afbe46f"
       ]
     },
     {

--- a/tooling/component-catalog-validation.mjs
+++ b/tooling/component-catalog-validation.mjs
@@ -32,7 +32,7 @@ export const componentCatalogPaths = Object.freeze({
 });
 
 const expectedComponentAnchor =
-    "b8f980743e62da44f1009126b742bb03eddccefac7369ab7ff173b538fefd02f";
+    "5adc9680bb790b3bc36bc8cfeba1c099b90fd0b300173b087d2f9c98dbd8a02e";
 const expectedProjectionAnchor =
     "70f3e05988839ba21247eff528709caf4738f2aa7f637e05e28658ff05902027";
 const expectedProjectionHostAnchor =

--- a/tooling/fixtures/s8-native-non-skill-expected-tree.json
+++ b/tooling/fixtures/s8-native-non-skill-expected-tree.json
@@ -46,8 +46,8 @@
         {
           "path": ".aiassistant/rules/concepts.md",
           "sourcePath": ".ai/rules/concepts.md",
-          "size": 4655,
-          "sha256": "f1f941ec32415bd4b5a403f0d084dd601935ea5e6a4baf29598a63f69753a095"
+          "size": 5310,
+          "sha256": "3aa3e81e5992f295a76ac3eda8fd02f14c7a49ed7500517bfd301674511866a6"
         },
         {
           "path": ".aiassistant/rules/csharp.md",
@@ -118,8 +118,8 @@
         {
           "path": ".aiassistant/rules/glossary.md",
           "sourcePath": ".ai/rules/glossary.md",
-          "size": 4986,
-          "sha256": "bbc5da53b562456445b2e8c2d4cbbf2c2376bf4e56b71f4a2f181bae1915f8fd"
+          "size": 5546,
+          "sha256": "e3feec1ad0074f32007ddb1db1db62835cd96ae360eed81e74404e9030e7caf9"
         },
         {
           "path": ".aiassistant/rules/managing-ai-rules.md",
@@ -202,8 +202,8 @@
         {
           "path": ".aiassistant/rules/vertical-slices.md",
           "sourcePath": ".ai/rules/vertical-slices.md",
-          "size": 31443,
-          "sha256": "51df677faf11f73555981207e7993e3c217ebfc5b4ac1e0df31455fdb0780f5e"
+          "size": 33784,
+          "sha256": "dd99b7a6561406cea8051294ea8072a1d0654d74604deb5fa7b0fb8fc5b5afe8"
         },
         {
           "path": ".aiassistant/rules/web-fetching.md",
@@ -256,8 +256,8 @@
         {
           "path": ".tabnine/guidelines/concepts.md",
           "sourcePath": ".ai/rules/concepts.md",
-          "size": 4655,
-          "sha256": "f1f941ec32415bd4b5a403f0d084dd601935ea5e6a4baf29598a63f69753a095"
+          "size": 5310,
+          "sha256": "3aa3e81e5992f295a76ac3eda8fd02f14c7a49ed7500517bfd301674511866a6"
         },
         {
           "path": ".tabnine/guidelines/csharp.md",
@@ -328,8 +328,8 @@
         {
           "path": ".tabnine/guidelines/glossary.md",
           "sourcePath": ".ai/rules/glossary.md",
-          "size": 4986,
-          "sha256": "bbc5da53b562456445b2e8c2d4cbbf2c2376bf4e56b71f4a2f181bae1915f8fd"
+          "size": 5546,
+          "sha256": "e3feec1ad0074f32007ddb1db1db62835cd96ae360eed81e74404e9030e7caf9"
         },
         {
           "path": ".tabnine/guidelines/managing-ai-rules.md",
@@ -412,8 +412,8 @@
         {
           "path": ".tabnine/guidelines/vertical-slices.md",
           "sourcePath": ".ai/rules/vertical-slices.md",
-          "size": 31443,
-          "sha256": "51df677faf11f73555981207e7993e3c217ebfc5b4ac1e0df31455fdb0780f5e"
+          "size": 33784,
+          "sha256": "dd99b7a6561406cea8051294ea8072a1d0654d74604deb5fa7b0fb8fc5b5afe8"
         },
         {
           "path": ".tabnine/guidelines/web-fetching.md",
@@ -605,14 +605,14 @@
       "canonicalOwnerId": "cratis-rule-concepts",
       "semanticKind": "rule",
       "sourcePath": ".ai/rules/concepts.md",
-      "sourceDigest": "ec09879acc66fe7bc0518bb2d9c2dbf7944e1c65c4408ebc5bdb69a5c846c48c",
+      "sourceDigest": "8eb4e594aa4da07143f4b8b21ab5f1c2354469afa66604dd4a6e25103d426b50",
       "outputPath": "jetbrains-ai-assistant-rules/.aiassistant/rules/concepts.md",
       "hostId": "jetbrains-ai-assistant",
       "hostAdapterId": "jetbrains-ai-assistant-host-adapter",
       "evidenceIds": [
         "jetbrains-ai-assistant-source-1"
       ],
-      "outputDigest": "f1f941ec32415bd4b5a403f0d084dd601935ea5e6a4baf29598a63f69753a095"
+      "outputDigest": "3aa3e81e5992f295a76ac3eda8fd02f14c7a49ed7500517bfd301674511866a6"
     },
     {
       "projectionId": "cratis-rule-concepts-to-tabnine-rule",
@@ -620,14 +620,14 @@
       "canonicalOwnerId": "cratis-rule-concepts",
       "semanticKind": "rule",
       "sourcePath": ".ai/rules/concepts.md",
-      "sourceDigest": "ec09879acc66fe7bc0518bb2d9c2dbf7944e1c65c4408ebc5bdb69a5c846c48c",
+      "sourceDigest": "8eb4e594aa4da07143f4b8b21ab5f1c2354469afa66604dd4a6e25103d426b50",
       "outputPath": "tabnine-guidelines/.tabnine/guidelines/concepts.md",
       "hostId": "tabnine",
       "hostAdapterId": "tabnine-host-adapter",
       "evidenceIds": [
         "tabnine-source-1"
       ],
-      "outputDigest": "f1f941ec32415bd4b5a403f0d084dd601935ea5e6a4baf29598a63f69753a095"
+      "outputDigest": "3aa3e81e5992f295a76ac3eda8fd02f14c7a49ed7500517bfd301674511866a6"
     },
     {
       "projectionId": "cratis-rule-csharp-to-jetbrains-ai-assistant-rule",
@@ -965,14 +965,14 @@
       "canonicalOwnerId": "cratis-rule-glossary",
       "semanticKind": "rule",
       "sourcePath": ".ai/rules/glossary.md",
-      "sourceDigest": "5a89504e5b4cc32f4cbf55f894c3d37332043119ef78843047ee5f24909267aa",
+      "sourceDigest": "8dd04c98a21a0861b3fb061d188af766cb41c10a0c87298ec32a4eddf6cd19c3",
       "outputPath": "jetbrains-ai-assistant-rules/.aiassistant/rules/glossary.md",
       "hostId": "jetbrains-ai-assistant",
       "hostAdapterId": "jetbrains-ai-assistant-host-adapter",
       "evidenceIds": [
         "jetbrains-ai-assistant-source-1"
       ],
-      "outputDigest": "bbc5da53b562456445b2e8c2d4cbbf2c2376bf4e56b71f4a2f181bae1915f8fd"
+      "outputDigest": "e3feec1ad0074f32007ddb1db1db62835cd96ae360eed81e74404e9030e7caf9"
     },
     {
       "projectionId": "cratis-rule-glossary-to-tabnine-rule",
@@ -980,14 +980,14 @@
       "canonicalOwnerId": "cratis-rule-glossary",
       "semanticKind": "rule",
       "sourcePath": ".ai/rules/glossary.md",
-      "sourceDigest": "5a89504e5b4cc32f4cbf55f894c3d37332043119ef78843047ee5f24909267aa",
+      "sourceDigest": "8dd04c98a21a0861b3fb061d188af766cb41c10a0c87298ec32a4eddf6cd19c3",
       "outputPath": "tabnine-guidelines/.tabnine/guidelines/glossary.md",
       "hostId": "tabnine",
       "hostAdapterId": "tabnine-host-adapter",
       "evidenceIds": [
         "tabnine-source-1"
       ],
-      "outputDigest": "bbc5da53b562456445b2e8c2d4cbbf2c2376bf4e56b71f4a2f181bae1915f8fd"
+      "outputDigest": "e3feec1ad0074f32007ddb1db1db62835cd96ae360eed81e74404e9030e7caf9"
     },
     {
       "projectionId": "cratis-rule-managing-ai-rules-to-jetbrains-ai-assistant-rule",
@@ -1385,14 +1385,14 @@
       "canonicalOwnerId": "cratis-rule-vertical-slices",
       "semanticKind": "rule",
       "sourcePath": ".ai/rules/vertical-slices.md",
-      "sourceDigest": "2f6fbcbfd2be4b6eb94ff2c878a6f2f67c4523296753fdd4256219a25d1b2590",
+      "sourceDigest": "40ee72260db33d91dc1f2342d2bf0e3d75554102203a38d0f637c9454a3d42a7",
       "outputPath": "jetbrains-ai-assistant-rules/.aiassistant/rules/vertical-slices.md",
       "hostId": "jetbrains-ai-assistant",
       "hostAdapterId": "jetbrains-ai-assistant-host-adapter",
       "evidenceIds": [
         "jetbrains-ai-assistant-source-1"
       ],
-      "outputDigest": "51df677faf11f73555981207e7993e3c217ebfc5b4ac1e0df31455fdb0780f5e"
+      "outputDigest": "dd99b7a6561406cea8051294ea8072a1d0654d74604deb5fa7b0fb8fc5b5afe8"
     },
     {
       "projectionId": "cratis-rule-vertical-slices-to-tabnine-rule",
@@ -1400,14 +1400,14 @@
       "canonicalOwnerId": "cratis-rule-vertical-slices",
       "semanticKind": "rule",
       "sourcePath": ".ai/rules/vertical-slices.md",
-      "sourceDigest": "2f6fbcbfd2be4b6eb94ff2c878a6f2f67c4523296753fdd4256219a25d1b2590",
+      "sourceDigest": "40ee72260db33d91dc1f2342d2bf0e3d75554102203a38d0f637c9454a3d42a7",
       "outputPath": "tabnine-guidelines/.tabnine/guidelines/vertical-slices.md",
       "hostId": "tabnine",
       "hostAdapterId": "tabnine-host-adapter",
       "evidenceIds": [
         "tabnine-source-1"
       ],
-      "outputDigest": "51df677faf11f73555981207e7993e3c217ebfc5b4ac1e0df31455fdb0780f5e"
+      "outputDigest": "dd99b7a6561406cea8051294ea8072a1d0654d74604deb5fa7b0fb8fc5b5afe8"
     },
     {
       "projectionId": "cratis-rule-web-fetching-to-jetbrains-ai-assistant-rule",

--- a/tooling/generate-catalog-v2.mjs
+++ b/tooling/generate-catalog-v2.mjs
@@ -194,10 +194,14 @@ const referenceClosureSourceNames = [
     "write-specs",
     "write-specs-frontend",
 ];
+const causationGuidanceSourceNames = [
+    "cratis-command",
+    "cross-cutting-properties",
+    "review-security",
+];
 const normalizedPackagedSourceNames = [
     "call-command-from-code",
     "create-event-model",
-    "cross-cutting-properties",
     "diagnose-slice",
     "event-type-migrations",
     "query-paging",
@@ -258,6 +262,14 @@ const sourceOverrides = new Map([
             sourcePath: `.ai/skills/${name}`,
             sourceRevision: "6ec724752023b7c1639b01e33d700d84d04fcfc3",
             evidenceId: "public-effect-guidance-boundary-source-6ec7247",
+        },
+    ]),
+    ...causationGuidanceSourceNames.map((name) => [
+        name,
+        {
+            sourcePath: `.ai/skills/${name}`,
+            sourceRevision: "afbe46fc7c87ab110df7f1983a0ca174ef0f6aac",
+            evidenceId: "command-causation-guidance-source-afbe46f",
         },
     ]),
     ...normalizedPackagedSourceNames.map((name) => [

--- a/tooling/native-non-skill-projections.mjs
+++ b/tooling/native-non-skill-projections.mjs
@@ -29,7 +29,7 @@ export const s8NativeProjectionPaths = Object.freeze({
 });
 
 const expectedStaticComponentAnchor =
-    "70f465a07e95ec844af3778b2eec8da20875383349bff88fe6837110f5bf41c7";
+    "46e69847f349a982242611c0af198fc9cad1be69fffc658dece61e4cf8797dc0";
 const expectedStaticProjectionAnchor =
     "5994bb761eeaf6f44fd5da70af8434f93b5197ccc7325bb9aa536eb1a9bf0056";
 const expectedStaticProjectionHostAnchor =


### PR DESCRIPTION
Replays PR #231 onto current `main`. That branch could no longer be fetched — `git upload-pack`
died with `bad tree object 65a1ae1…` (issue #234) — so the two content commits were cherry-picked
onto a fresh branch with authorship preserved, and the catalogs regenerated here rather than
carried over stale.

## Why

A command's **property values** are written to the causation of every event it appends, next to
the command's name. The event log is immutable, so a secret recorded there cannot be taken back
out by changing code. The corpus never said so, which meant nothing told an agent to think about
it while adding a property.

## What changes

Two markings keep a value off the chain, honored on the property, the declaring type, the
positional record parameter, and the property's type:

| Marking | For | Also does |
| --- | --- | --- |
| `[PII]` | personal data | encrypts it in the event, enrolls it in erasure |
| `[NotAudited]` | a secret that is not personal data — password, token, API key | nothing else; it only withholds |

They are not interchangeable: `[PII]` on a password would enroll it in GDPR erasure, and
`[NotAudited]` on a name does nothing for an erasure request. Marking the concept once covers
every command that takes it. `ARCCHR0009` warns on an unmarked property whose *name* reads like
a secret — so a clean build means "nothing obvious was missed", not "no secrets are recorded".

Documented in `vertical-slices.md` (new Causation section), `concepts.md`, `glossary.md`, and the
`cratis-command`, `cross-cutting-properties` and `review-security` skills.

## Verification

- `node tooling/validate-catalogs.mjs --basic` — passes.
- AI corpus validation — passes.
- Basic spec suite — 498 tests, 487 pass, 11 skipped, 0 fail.

Supersedes #231. Addresses #234 (the unreachable branch is no longer needed) and #233.
