### PR TITLE
Stop the governed assurance specs expiring on a date

### DIFF
--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "752e61c19b489e6c54a25fb627cf522c6bb4f0d6ca7cbb7872ac336e9966370e",
+  "indexDigest": "796cccdcf7d964db1c065aa5251c0be23624ebeaac9cef88b5dc1a46235fc9fd",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/tooling/specs/support-validation.spec.mjs
+++ b/tooling/specs/support-validation.spec.mjs
@@ -21,6 +21,15 @@ import {
 } from "../support-validation.mjs";
 
 const clone = (value) => structuredClone(value);
+// The catalogs are evaluated as of one authored date. Fixtures derive their dates
+// from it so a fixture stays active as the corpus advances, instead of silently
+// expiring and turning these specs red on a date rather than on a behavior.
+const activeDate = loadSupportCatalogs().evidence.asOf;
+const shiftDate = (days) => {
+    const [year, month, day] = activeDate.split("-").map(Number);
+    const shifted = new Date(Date.UTC(year, month - 1, day + days));
+    return shifted.toISOString().slice(0, 10);
+};
 const digestA = "a".repeat(64);
 const digestB = "b".repeat(64);
 const bindingId = "gemini-cli-extensions-artifact-binding";
@@ -56,8 +65,8 @@ function hasError(errors, text) {
 function configuredCatalogs({
     assurances = allTechnicalAssurances,
     evidenceClass = "local",
-    observedOn = "2026-08-25",
-    validThrough = "2026-08-25",
+    observedOn = activeDate,
+    validThrough = activeDate,
     outcome = "pass",
 } = {}) {
     const catalogs = clone(loadSupportCatalogs());
@@ -142,9 +151,9 @@ test("all authored evidence and support policy schemas reject unknown properties
     }
 });
 
-test("all 152 observations, 172 fact IDs, 11 legacy gaps, 108 official sources, and 22 distribution evidence files are accounted exactly", () => {
+test("all 163 observations, 172 fact IDs, 11 legacy gaps, 108 official sources, and 23 distribution evidence files are accounted exactly", () => {
     const catalogs = loadSupportCatalogs();
-    assert.equal(catalogs.evidence.observations.length, 152);
+    assert.equal(catalogs.evidence.observations.length, 163);
     assert.equal(catalogs.evidence.legacyFacts.length, 172);
     assert.equal(catalogs.evidence.legacyGaps.length, 11);
     assert.equal(
@@ -154,7 +163,7 @@ test("all 152 observations, 172 fact IDs, 11 legacy gaps, 108 official sources, 
         ),
         108,
     );
-    assert.equal(catalogs.evidence.distributionEvidenceFiles.length, 22);
+    assert.equal(catalogs.evidence.distributionEvidenceFiles.length, 23);
     assert.deepEqual(
         catalogs.evidence.distributionEvidenceFiles
             .map((record) => record.repositoryPath)
@@ -365,8 +374,8 @@ test("synthetic fixture evidence never satisfies install-tested or above", () =>
 test("future evidence cannot satisfy a gate", () => {
     const record = supportRecord(
         configuredCatalogs({
-            observedOn: "2026-08-26",
-            validThrough: "2026-09-26",
+            observedOn: shiftDate(1),
+            validThrough: shiftDate(31),
         }),
     );
     assert.equal(record.effectiveTier, "documented");
@@ -377,8 +386,8 @@ test("future evidence cannot satisfy a gate", () => {
 test("expired evidence remains history but cannot satisfy a gate", () => {
     const record = supportRecord(
         configuredCatalogs({
-            observedOn: "2026-08-01",
-            validThrough: "2026-08-23",
+            observedOn: shiftDate(-32),
+            validThrough: shiftDate(-1),
         }),
     );
     assert.equal(record.effectiveTier, "documented");


### PR DESCRIPTION
The Advanced Assurance Audit was red on `main` behind the S10 evidence-baseline anchor.
With #244 landed, the audit ran again and surfaced the next failure underneath it.

## What was wrong

Six `support-validation` specs build their fixtures with hard-coded dates (`2026-08-25`).
The catalogs are evaluated as of their own authored date, which has since moved to
`2026-09-02` — so evidence those specs treat as *active* is now evaluated as *expired*,
and every tier collapses to `documented`. Nothing about the code changed; the calendar did.

The exact-accounting tripwire had drifted the same way: 152 observations and 22
distribution evidence files, against an actual 163 and 23.

## What changes

- Fixture dates derive from the catalogs authored as-of date, so a fixture stays active
  as the corpus advances.
- The future and expired cases are expressed as offsets from that date, so each keeps
  testing the behavior it is named for instead of passing by accident.
- The accounting tripwire moves to the current counts, keeping its exactness.

## Verification

- `node tooling/run-spec-suite.mjs --governed` — 564 tests, 553 pass, 0 fail (was 6 failing).
- `node tooling/run-spec-suite.mjs --basic` — 498 tests, 487 pass, 0 fail.
- `node tooling/validate-catalogs.mjs --basic` — passes.
- `node tooling/s10-release-gate-validation.mjs` — passes, state BLOCKED (unchanged).

Closes #236.