### PR TITLE
Renew the authority observations expiring 2026-09-19

### DIFF
--- a/catalog/ecosystem-versions.json
+++ b/catalog/ecosystem-versions.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "verifiedOn": "2026-09-02",
+  "verifiedOn": "2026-09-06",
   "policy": "official-sources-only",
   "ecosystems": [
     {

--- a/catalog/evidence.json
+++ b/catalog/evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "asOf": "2026-09-02",
+  "asOf": "2026-09-06",
   "defaultPolicy": "deny",
   "sources": [
     {
@@ -742,6 +742,20 @@
       "kind": "repository-snapshot",
       "locator": "https://github.com/Cratis/AI/tree/fbf76029e4a6593a6a24f939face32b720009198/.ai/skills/multi-tenancy",
       "immutableRevision": "fbf76029e4a6593a6a24f939face32b720009198"
+    },
+    {
+      "id": "source-workflows-68-2026-09-06",
+      "kind": "local-evidence-report",
+      "locator": "https://github.com/Cratis/Workflows/issues/68",
+      "repositoryPath": "distribution/evidence/authority-reobservation-2026-09-06.json",
+      "digest": "83635d802a9179c921fa803987f4b447ceb921c3778db7601864c8875d530f50"
+    },
+    {
+      "id": "source-reevaluation-authority-2026-09-06",
+      "kind": "local-evidence-report",
+      "locator": "https://github.com/Cratis/Workflows/issues/68#issuecomment-5363284054",
+      "repositoryPath": "distribution/evidence/authority-reobservation-2026-09-06.json",
+      "digest": "83635d802a9179c921fa803987f4b447ceb921c3778db7601864c8875d530f50"
     }
   ],
   "observations": [
@@ -7554,6 +7568,103 @@
       }
     },
     {
+      "id": "workflows-68-2026-09-06",
+      "sourceId": "source-workflows-68-2026-09-06",
+      "evidenceClass": "local",
+      "subject": {
+        "kind": "repository",
+        "id": "cratis-workflows",
+        "version": "issue-state-2026-09-06",
+        "digest": "83635d802a9179c921fa803987f4b447ceb921c3778db7601864c8875d530f50"
+      },
+      "bindingIds": [],
+      "assertions": [
+        {
+          "assuranceId": "authority",
+          "outcome": "pass",
+          "supporting": true,
+          "claimIds": []
+        }
+      ],
+      "scope": "Administrative renewal of the workflows-68 organization-authority observation. An authenticated read-only re-read on 2026-09-06 confirmed Cratis/Workflows#68 is still open, its body is byte-identical to the 2026-08-20 baseline snapshot, and both baseline comments are still present verbatim, so the recorded authority is unchanged.",
+      "environment": {
+        "operatingSystem": "macos",
+        "architecture": "arm64",
+        "isolation": "not-recorded"
+      },
+      "observedOn": "2026-09-06",
+      "validThrough": "2026-12-05",
+      "confidence": "high",
+      "limitations": [
+        "This observation is limited to its exact recorded subject, version, digest, scope, and environment and grants no unrecorded assurance.",
+        "It renews the recorded authority only. It establishes no new grant and changes nothing the superseded observation asserts.",
+        "It is bound to the exact issue state recorded in the report; a later edit, retraction, or close of Cratis/Workflows#68 invalidates it."
+      ],
+      "supersedes": [
+        "workflows-68"
+      ],
+      "correction": {
+        "reason": "Administrative renewal ahead of the 2026-09-19 expiry, on re-read evidence that the recorded authority is unchanged. The 90-day validity matches the cadence the sibling organization-authority observations already use and replaces the 30-day window that produced this expiry cliff.",
+        "reviewer": "cratis-ai-maintainers",
+        "reviewedOn": "2026-09-06",
+        "replacementIdentity": "workflows-68-2026-09-06"
+      },
+      "legacy": {
+        "officialUrl": "https://github.com/Cratis/Workflows/issues/68",
+        "sourceKind": "local-evidence-report",
+        "applicableVersion": "issue-state-2026-09-06"
+      }
+    },
+    {
+      "id": "reevaluation-authority-2026-09-06",
+      "sourceId": "source-reevaluation-authority-2026-09-06",
+      "evidenceClass": "local",
+      "subject": {
+        "kind": "repository",
+        "id": "cratis-ai",
+        "version": "authority-reobservation-2026-09-06",
+        "digest": "83635d802a9179c921fa803987f4b447ceb921c3778db7601864c8875d530f50"
+      },
+      "bindingIds": [],
+      "assertions": [
+        {
+          "assuranceId": "authority",
+          "outcome": "pass",
+          "supporting": true,
+          "claimIds": []
+        }
+      ],
+      "scope": "Administrative renewal of the reevaluation-authority observation that every generated agent-skill source record cites. An authenticated read-only re-read on 2026-09-06 confirmed the maintainer comment recording the accepted Option A+ direction and the standing authorization for autonomous execution of the redesign program is still present, byte-identical, and unretracted, and that all four recorded authority issues remain open with byte-identical bodies.",
+      "environment": {
+        "operatingSystem": "macos",
+        "architecture": "arm64",
+        "isolation": "not-recorded"
+      },
+      "observedOn": "2026-09-06",
+      "validThrough": "2026-12-05",
+      "confidence": "medium",
+      "limitations": [
+        "This observation is limited to its exact recorded subject, version, digest, scope, and environment and grants no unrecorded assurance.",
+        "It renews the recorded authority only. It establishes no new grant and changes nothing the superseded observation asserts.",
+        "Confidence is carried forward unchanged from the superseded observation; the renewal re-anchors the same grant to a live re-readable source and does not raise it.",
+        "It is bound to the exact comment and issue states recorded in the report; a later edit, retraction, or close invalidates it."
+      ],
+      "supersedes": [
+        "reevaluation-authority"
+      ],
+      "correction": {
+        "reason": "Administrative renewal ahead of the 2026-09-19 expiry, re-anchored from the untracked AI-REPOSITORY-REDESIGN-REEVALUATION.md snapshot to the live maintainer authorization comment and the in-repository 2026-08-20 authority baseline, both of which are still re-readable. The 90-day validity matches the cadence the sibling authority observations already use and replaces the 30-day window that produced this expiry cliff.",
+        "reviewer": "cratis-ai-maintainers",
+        "reviewedOn": "2026-09-06",
+        "replacementIdentity": "reevaluation-authority-2026-09-06"
+      },
+      "legacy": {
+        "officialUrl": "https://github.com/Cratis/Workflows/issues/68#issuecomment-5363284054",
+        "sourceKind": "local-evidence-report",
+        "applicableVersion": "authority-reobservation-2026-09-06"
+      }
+    },
+    {
       "id": "s8-native-non-skill-static-generation-2026-08-25",
       "sourceId": "source-s8-native-non-skill-static-generation-2026-08-25",
       "evidenceClass": "local",
@@ -9429,6 +9540,16 @@
       "role": "inventory-only",
       "observationIds": [],
       "reason": "Preserves an exact denied-egress version preflight. Gemini CLI 0.33.1 is installed; current required version is 0.56.0. Every lifecycle phase remained blocked and the report grants no assurance."
+    },
+    {
+      "repositoryPath": "distribution/evidence/authority-reobservation-2026-09-06.json",
+      "digest": "83635d802a9179c921fa803987f4b447ceb921c3778db7601864c8875d530f50",
+      "role": "supporting",
+      "observationIds": [
+        "reevaluation-authority-2026-09-06",
+        "workflows-68-2026-09-06"
+      ],
+      "reason": "Digest-bound by the two named renewal observations for only their explicit authority assertions. It records an authenticated read-only re-read of the four recorded authority issues against the 2026-08-20 in-repository baseline and grants no behavior, lifecycle, release, or support assurance."
     }
   ]
 }

--- a/catalog/generated/human-catalog/CATALOG.md
+++ b/catalog/generated/human-catalog/CATALOG.md
@@ -55,7 +55,7 @@ Modeled or planned components and projections are catalog metadata only; they ar
 
 ## Computed ecosystem support
 
-As of 2026-09-02, technical tiers are computed from active normalized evidence; expired and future evidence cannot satisfy gates. Marketplace listing is orthogonal.
+As of 2026-09-06, technical tiers are computed from active normalized evidence; expired and future evidence cannot satisfy gates. Marketplace listing is orthogonal.
 
 - unsupported: 0
 - documented: 24

--- a/catalog/generated/human-catalog/catalog.json
+++ b/catalog/generated/human-catalog/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractVersion": 1,
   "disclaimer": "Catalog inclusion, evaluation evidence, component modeling, planned projection, bundle generation, or publication does not grant runtime permission, emitted bytes, support, or approval.",
-  "inputDigest": "046ecad3a2f3fa219c3883f75dd70708fb59d37990dd818420731c5f21c23605",
+  "inputDigest": "c04fe7d098536db59545feaedf76fba77f69421f7435d7e736c4fbf1fdaba1e4",
   "componentSummary": {
     "disclaimer": "Modeled or planned components and projections are catalog metadata only; they are not emitted, supported, installable, published, promoted, or runtime eligible.",
     "total": 137,

--- a/catalog/generated/human-catalog/manifest.json
+++ b/catalog/generated/human-catalog/manifest.json
@@ -1,17 +1,17 @@
 {
   "schemaVersion": 2,
   "contractVersion": 1,
-  "inputDigest": "046ecad3a2f3fa219c3883f75dd70708fb59d37990dd818420731c5f21c23605",
+  "inputDigest": "c04fe7d098536db59545feaedf76fba77f69421f7435d7e736c4fbf1fdaba1e4",
   "files": [
     {
       "path": "CATALOG.md",
       "size": 127121,
-      "sha256": "76f3d238d14ec762af265f22944088ae4cc44f787b297c0c268f936408d2dc8b"
+      "sha256": "099a4ffdbad4304ebdecdd7b5871231fe1287026a397a3cd1b34a1ac096d40f0"
     },
     {
       "path": "catalog.json",
       "size": 162756,
-      "sha256": "021742a6000636916327808cb7fe1f8e23a17ac3f075a5b6a492875e4390c43a"
+      "sha256": "111c7cbcc6235d5a20e3bbfaefa3c90d800d009d1bfbea5a8b1e5a221e321d90"
     }
   ]
 }

--- a/catalog/support-policy.json
+++ b/catalog/support-policy.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "asOf": "2026-09-02",
+  "asOf": "2026-09-06",
   "defaultPolicy": "deny",
   "evidenceClasses": [
     "synthetic-fixture",

--- a/catalog/v2/ecosystem-contracts.json
+++ b/catalog/v2/ecosystem-contracts.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "asOf": "2026-09-02",
+  "asOf": "2026-09-06",
   "defaultPolicy": "deny",
   "ecosystems": [
     {

--- a/catalog/v2/evidence.json
+++ b/catalog/v2/evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "asOf": "2026-09-02",
+  "asOf": "2026-09-06",
   "generatedBy": "tooling/generate-catalog-v2.mjs",
   "evidence": [
     {
@@ -1133,6 +1133,17 @@
       "digest": "d0e76cea34145717ae8874a252b7d4468c43ef102cb9ddc3f2241c0960aa70d5"
     },
     {
+      "id": "reevaluation-authority-2026-09-06",
+      "officialUrl": "https://github.com/Cratis/Workflows/issues/68#issuecomment-5363284054",
+      "sourceKind": "local-evidence-report",
+      "verifiedOn": "2026-09-06",
+      "expiresOn": "2026-12-05",
+      "applicableVersion": "authority-reobservation-2026-09-06",
+      "confidence": "medium",
+      "repositoryPath": "distribution/evidence/authority-reobservation-2026-09-06.json",
+      "digest": "83635d802a9179c921fa803987f4b447ceb921c3778db7601864c8875d530f50"
+    },
+    {
       "id": "replit-agent-source-1",
       "officialUrl": "https://docs.replit.com/learn/agent-skills",
       "sourceKind": "official-documentation",
@@ -1551,6 +1562,17 @@
       "expiresOn": "2026-09-19",
       "applicableVersion": "issue-state-2026-08-20",
       "confidence": "high"
+    },
+    {
+      "id": "workflows-68-2026-09-06",
+      "officialUrl": "https://github.com/Cratis/Workflows/issues/68",
+      "sourceKind": "local-evidence-report",
+      "verifiedOn": "2026-09-06",
+      "expiresOn": "2026-12-05",
+      "applicableVersion": "issue-state-2026-09-06",
+      "confidence": "high",
+      "repositoryPath": "distribution/evidence/authority-reobservation-2026-09-06.json",
+      "digest": "83635d802a9179c921fa803987f4b447ceb921c3778db7601864c8875d530f50"
     },
     {
       "id": "zed-skills-source-1",

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "2c4e94f465249738c9ca230f74294f61d8d6a7b03e20572d31b1d508527e0fb5",
+  "indexDigest": "df8928b604f86467fd06f33908262f30d5d2d783367f33abad685155b8b1e7d3",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -812,6 +812,10 @@
     },
     {
       "path": "distribution/engineering-artifact-matrix.json",
+      "status": "added"
+    },
+    {
+      "path": "distribution/evidence/authority-reobservation-2026-09-06.json",
       "status": "added"
     },
     {
@@ -4897,8 +4901,8 @@
       "evidenceIds": [
         "option-a-plus-authority"
       ],
-      "expectedPathCount": 70,
-      "expectedPathsDigest": "2e2e109446ee4c6e0f36fa9decdbe03cecf642f1ae2def7f711ac7ec2feedaac"
+      "expectedPathCount": 71,
+      "expectedPathsDigest": "627d1e2fe9226354210f482ebad786207bbc2f29bfe09e73f654149b023d3446"
     },
     {
       "excludePathPatterns": [],

--- a/catalog/v2/support.json
+++ b/catalog/v2/support.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "asOf": "2026-09-02",
+  "asOf": "2026-09-06",
   "generatedBy": "tooling/generate-support.mjs",
   "defaultPolicy": "deny",
   "publicationEligible": false,

--- a/distribution/evidence/authority-reobservation-2026-09-06.json
+++ b/distribution/evidence/authority-reobservation-2026-09-06.json
@@ -1,0 +1,161 @@
+{
+  "schemaVersion": "1.0.0",
+  "reportId": "authority-reobservation-2026-09-06",
+  "observedOn": "2026-09-06",
+  "state": "AUTHORITY_REOBSERVATION_PASS",
+  "purpose": "Re-read the four GitHub authority issues the S0/S1 catalog recorded on 2026-08-20 and confirm the recorded authority is still in force, so the expiring workflows-68 and reevaluation-authority observations can be superseded without changing what they assert.",
+  "method": {
+    "access": "authenticated read-only GitHub API through the gh CLI",
+    "command": "gh issue view <number> --repo <owner>/<repo> --json body,comments,number,state,title,updatedAt,url",
+    "comparedAgainst": "Documentation/evidence/redesign-autonomous-execution-2026-08-20/authority/*.json",
+    "predicates": [
+      "the issue is still open",
+      "the issue body is byte-identical to the 2026-08-20 baseline snapshot",
+      "every comment in the 2026-08-20 baseline snapshot is still present with a byte-identical body",
+      "no comment added since the baseline retracts, narrows, or supersedes the recorded authority"
+    ]
+  },
+  "issues": [
+    {
+      "id": "cratis-workflows-68",
+      "repository": "Cratis/Workflows",
+      "number": 68,
+      "url": "https://github.com/Cratis/Workflows/issues/68",
+      "authorityRole": "organization-authority",
+      "baselineSnapshotPath": "Documentation/evidence/redesign-autonomous-execution-2026-08-20/authority/cratis-workflows-68.json",
+      "baselineSnapshotSha256": "aa00c39c672132d8ca3fac7af58915a070366b8a9a6979677f393ac7f7275c07",
+      "bodySha256": "fcd437ba4eb40adc815186739b1903cef846468612cb933d98670132dcff8af1",
+      "baselineState": "OPEN",
+      "observedState": "OPEN",
+      "baselineUpdatedAt": "2026-08-20T23:25:48Z",
+      "observedUpdatedAt": "2026-08-27T13:38:44Z",
+      "bodyByteIdenticalToBaseline": true,
+      "baselineCommentCount": 2,
+      "observedCommentCount": 22,
+      "baselineCommentsRetainedVerbatim": true,
+      "commentsAddedSinceBaseline": 20,
+      "authorityChangeSinceBaseline": "none"
+    },
+    {
+      "id": "cratis-dotgithub-24",
+      "repository": "Cratis/.github",
+      "number": 24,
+      "url": "https://github.com/Cratis/.github/issues/24",
+      "authorityRole": "organization-authority",
+      "baselineSnapshotPath": "Documentation/evidence/redesign-autonomous-execution-2026-08-20/authority/cratis-dotgithub-24.json",
+      "baselineSnapshotSha256": "642fbc68f31d91a5e1f8123d9cb7d5cfa4d8db8c56281c372c3dcda3a07a699b",
+      "bodySha256": "ed7684cc44b787a2273e20ee3f490da7d456f7ab7016672b6bf93d38f61a81d0",
+      "baselineState": "OPEN",
+      "observedState": "OPEN",
+      "baselineUpdatedAt": "2026-08-20T23:25:50Z",
+      "observedUpdatedAt": "2026-08-27T13:32:37Z",
+      "bodyByteIdenticalToBaseline": true,
+      "baselineCommentCount": 1,
+      "observedCommentCount": 2,
+      "baselineCommentsRetainedVerbatim": true,
+      "commentsAddedSinceBaseline": 1,
+      "authorityChangeSinceBaseline": "none"
+    },
+    {
+      "id": "cratis-ai-126",
+      "repository": "Cratis/AI",
+      "number": 126,
+      "url": "https://github.com/Cratis/AI/issues/126",
+      "authorityRole": "repository-authority",
+      "baselineSnapshotPath": "Documentation/evidence/redesign-autonomous-execution-2026-08-20/authority/cratis-ai-126.json",
+      "baselineSnapshotSha256": "3551d325bb753c0c79cd18134765843bbc0f3bb8bb6f2b448b48423bcd50b911",
+      "bodySha256": "a8b42241ffd45bc7e919f6fd2dc53a42698d4a4d34be732d3176a86bd04766fc",
+      "baselineState": "OPEN",
+      "observedState": "OPEN",
+      "baselineUpdatedAt": "2026-08-20T11:28:05Z",
+      "observedUpdatedAt": "2026-08-27T13:45:26Z",
+      "bodyByteIdenticalToBaseline": true,
+      "baselineCommentCount": 0,
+      "observedCommentCount": 22,
+      "baselineCommentsRetainedVerbatim": true,
+      "commentsAddedSinceBaseline": 22,
+      "authorityChangeSinceBaseline": "none"
+    },
+    {
+      "id": "cratis-ai-127",
+      "repository": "Cratis/AI",
+      "number": 127,
+      "url": "https://github.com/Cratis/AI/issues/127",
+      "authorityRole": "repository-authority",
+      "baselineSnapshotPath": "Documentation/evidence/redesign-autonomous-execution-2026-08-20/authority/cratis-ai-127.json",
+      "baselineSnapshotSha256": "bd5eb066d6ae264ea333df30c3aed71014705f656cf62b5cdb7e07721f983c3d",
+      "bodySha256": "cbcd869e6adffd57741d8508962c0c9baae206778b9457443345ef2fc91d3c4a",
+      "baselineState": "OPEN",
+      "observedState": "OPEN",
+      "baselineUpdatedAt": "2026-08-20T14:34:48Z",
+      "observedUpdatedAt": "2026-08-27T13:45:28Z",
+      "bodyByteIdenticalToBaseline": true,
+      "baselineCommentCount": 0,
+      "observedCommentCount": 2,
+      "baselineCommentsRetainedVerbatim": true,
+      "commentsAddedSinceBaseline": 2,
+      "authorityChangeSinceBaseline": "none"
+    }
+  ],
+  "authorityComments": [
+    {
+      "issue": "cratis-workflows-68",
+      "commentId": "IC_kwDORbufms8AAAABPz99-g",
+      "url": "https://github.com/Cratis/Workflows/issues/68#issuecomment-5356092922",
+      "author": "woksin",
+      "authorAssociation": "MEMBER",
+      "createdAt": "2026-08-20T12:48:00Z",
+      "bodySha256": "1e269c9a8b7dbf39f651af83cc5a8222a19c5517f5d068ca496196803415abf7",
+      "stillPresent": true,
+      "stillByteIdentical": true,
+      "records": "Landed propagation-control toolkit status; keeps the distribution model, canary, wrapper retirement, and freeze lifting open."
+    },
+    {
+      "issue": "cratis-workflows-68",
+      "commentId": "IC_kwDORbufms8AAAABP604Vg",
+      "url": "https://github.com/Cratis/Workflows/issues/68#issuecomment-5363284054",
+      "author": "woksin",
+      "authorAssociation": "MEMBER",
+      "createdAt": "2026-08-20T23:25:48Z",
+      "bodySha256": "801395436c9dc718562fbb07e51b3300154964c1d51f12a06c2247e53e0c24db",
+      "stillPresent": true,
+      "stillByteIdentical": true,
+      "records": "Accepted Option A+ direction and the standing maintainer authorization for autonomous execution of the redesign program that every generated agent-skill source record cites."
+    }
+  ],
+  "results": [
+    {
+      "gate": "all-four-authority-issues-still-open",
+      "status": "PASS"
+    },
+    {
+      "gate": "issue-bodies-byte-identical-to-baseline",
+      "status": "PASS"
+    },
+    {
+      "gate": "baseline-comments-retained-verbatim",
+      "status": "PASS"
+    },
+    {
+      "gate": "option-a-plus-autonomous-execution-authorization-intact",
+      "status": "PASS"
+    },
+    {
+      "gate": "no-authority-retraction-since-baseline",
+      "status": "PASS"
+    }
+  ],
+  "commentsAddedSinceBaseline": {
+    "total": 45,
+    "classification": [
+      "maintainer progress reports referencing merged Cratis/AI pull requests, which restate rather than reduce the recorded authority",
+      "automated acknowledgement comments from the cratis-direct bot, which assert nothing about authority"
+    ],
+    "retractionsOrNarrowings": 0
+  },
+  "limitations": [
+    "This is an authority re-observation only. It re-confirms that the previously recorded grants are still in force and unchanged; it establishes no new grant and changes nothing about what the superseded observations assert.",
+    "It carries no behavior, install, discovery, canary, release, or support assurance, and moves no host binding on the support ladder.",
+    "It is bound to the exact issue states listed here at the recorded timestamps; a later edit, retraction, or close of any listed issue invalidates it."
+  ]
+}

--- a/tooling/specs/support-validation.spec.mjs
+++ b/tooling/specs/support-validation.spec.mjs
@@ -151,9 +151,9 @@ test("all authored evidence and support policy schemas reject unknown properties
     }
 });
 
-test("all 163 observations, 172 fact IDs, 11 legacy gaps, 108 official sources, and 23 distribution evidence files are accounted exactly", () => {
+test("all 165 observations, 172 fact IDs, 11 legacy gaps, 108 official sources, and 24 distribution evidence files are accounted exactly", () => {
     const catalogs = loadSupportCatalogs();
-    assert.equal(catalogs.evidence.observations.length, 163);
+    assert.equal(catalogs.evidence.observations.length, 165);
     assert.equal(catalogs.evidence.legacyFacts.length, 172);
     assert.equal(catalogs.evidence.legacyGaps.length, 11);
     assert.equal(
@@ -163,7 +163,7 @@ test("all 163 observations, 172 fact IDs, 11 legacy gaps, 108 official sources, 
         ),
         108,
     );
-    assert.equal(catalogs.evidence.distributionEvidenceFiles.length, 23);
+    assert.equal(catalogs.evidence.distributionEvidenceFiles.length, 24);
     assert.deepEqual(
         catalogs.evidence.distributionEvidenceFiles
             .map((record) => record.repositoryPath)


### PR DESCRIPTION
# Summary

Two authority observations expired on 2026-09-19, and one of them backs the evidence of every generated agent-skill source record. They are renewed on real re-read evidence and the catalog as-of date moves with them. Nothing a consumer compiles against, runs, or observes changes, and no support tier moves.

## Added

- Recorded an authenticated read-only re-read of the four Cratis authority issues as `distribution/evidence/authority-reobservation-2026-09-06.json`, compared byte for byte against the in-repository 2026-08-20 authority baseline (#253)
- Appended two observations that supersede `workflows-68` and `reevaluation-authority`, each valid through 2026-12-05 on the 90-day cadence the sibling authority observations already use (#253)

## Changed

- Advanced the catalog as-of date to 2026-09-06 across `catalog/evidence.json`, `catalog/support-policy.json`, `catalog/v2/ecosystem-contracts.json` and `catalog/ecosystem-versions.json` `verifiedOn` in one atomic edit (#253)

## Fixed

- Removed the 2026-09-19 evidence-expiry cliff that would have failed the basic-lane catalog gate closed on every pull request once the as-of date advanced (#253)

---

### Evidence

`gh issue view <number> --repo <owner>/<repo> --json body,comments,number,state,title,updatedAt,url` on `Cratis/Workflows#68`, `Cratis/.github#24`, `Cratis/AI#126` and `Cratis/AI#127`, diffed against `Documentation/evidence/redesign-autonomous-execution-2026-08-20/authority/*.json`:

- all four issues are still open;
- every issue body is byte-identical to the baseline snapshot;
- every baseline comment is still present with a byte-identical body, including the maintainer comment recording the accepted Option A+ direction and the standing authorization for autonomous execution of the redesign program;
- the 45 comments added since the baseline are maintainer progress reports and bot acknowledgements; none retracts or narrows the recorded authority.

The renewals are administrative: they re-confirm grants that are still in force and change nothing about what the superseded observations assert. `reevaluation-authority-2026-09-06` carries the superseded observation's `medium` confidence forward unchanged, and re-anchors the grant from the untracked `AI-REPOSITORY-REDESIGN-REEVALUATION.md` snapshot to the live maintainer authorization comment plus the in-repository baseline, both of which are still re-readable.

`correction.reviewer` is recorded as `cratis-ai-maintainers` rather than an individual handle, because the approving review is this pull request. Change it to a specific handle if you would rather the record name one.

### Append-only

No existing observation, source, fact, gap or distribution-evidence record is edited or removed. A structural diff against `HEAD` confirms the only changes are two added sources, two added observations, one added distribution-evidence record and the as-of dates; `workflows-68` and `reevaluation-authority` are byte-identical, and the protected baseline identity anchors are unchanged.

### Known gap, deliberately not closed here

Supersession alone does not buy headroom past 2026-09-19. `tooling/generate-catalog-v2.mjs` emits every observation into `catalog/v2/evidence.json`, including superseded ones, and `validateEvidenceAndCoverage` has no supersession awareness, so the two originals still fail the gate at any as-of date after their expiry:

```
asOf 2026-09-06 -> 0 errors
asOf 2026-09-20 -> 2 errors
  reevaluation-authority: evidence expired before the catalog as-of date
  workflows-68: evidence expired before the catalog as-of date
```

Closing that needs either excluding superseded observations from the emitted evidence list or exempting them from the expiry check, plus repointing the generated `evidenceIds` at the renewals. That changes gate behavior rather than catalog data, so it belongs in its own pull request. The renewal evidence this pull request lands is the prerequisite for it.

### November cliff not touched

The 68 observations expiring 2026-11-18 and the 67 expiring 2026-11-23, which back the 24 `documented` host bindings, are deliberately left for a separate pass. Re-observing 135 documentation observations is a much larger task, and rushing it here would risk recording re-observation evidence that was never actually gathered.

### Validation

All green: `validate-ai-setup.sh`, every generator, `git diff --exit-code` on the generated artifacts, `portable-compliance-validation --verify-lock`, `release-assurance-validation`, `validate-catalogs --basic`, `run-spec-suite --basic` (484 passed, 0 failed, 11 skipped) and `run-spec-suite --governed` (550 passed, 0 failed, 11 skipped). Support tiers are unchanged: `documented=24`, `statically-validated=21`, `support=0`.

`tooling/specs/support-validation.spec.mjs` census counts move from 163/23 to 165/24, the same bump every prior evidence addition has made.
