### PR TITLE
Add a governed-release methodology profile

### DIFF
--- a/Documentation/profile-reference.md
+++ b/Documentation/profile-reference.md
@@ -264,6 +264,21 @@ language selection imply Chronicle, which is the same coupling the Arc and
 Chronicle meta-profiles exist to avoid. Chronicle-specific language guidance
 stays in the Chronicle client profiles above.
 
+## Cross-cutting methodology profiles
+
+Some behavior is neither a product nor a language. It is engineering method that
+holds no matter what the repository ships or what it is written in.
+
+| Profile | Intended package | Scope |
+| --- | --- | --- |
+| `public-methodology-governed-releases` | `@cratis/ai-methodology-governed-releases` | Assurance tiers, evidence ladders, lifecycle phases, supply-chain receipts, semantic-version release intent, canaries, recovery disposition |
+
+This profile carries `products: []` and `languages: []` deliberately, and
+composes nothing, for the same reason the language profiles do: a repository
+that wants release methodology must not be handed Arc, Chronicle, or a language
+profile along with it. `tooling/specs/resolve-profiles.spec.mjs` asserts that
+resolving it alone returns exactly itself and its one capability.
+
 ## Public-safe engineering profiles
 
 All shared engineering packages are public-safe. Confidential facts remain in

--- a/catalog/components.json
+++ b/catalog/components.json
@@ -56,6 +56,7 @@
     "engineering/skills/cratis-engineering-docs-edit-page",
     "skills/cratis-chronicle-mcp-inspection",
     "skills/cratis-fundamentals-concept",
+    "skills/cratis-governed-release-methodology",
     "skills/cratis-studio-mcp-safety-guidance"
   ],
   "declaredEmptyKinds": [
@@ -5347,6 +5348,86 @@
         "state": "modeled",
         "evidenceIds": [
           "reevaluation-authority",
+          "repo-main-b795d53"
+        ]
+      },
+      "releaseBoundary": "public-passive",
+      "allowedProjections": [
+        {
+          "hostContract": "any-passive-host",
+          "kinds": [
+            "skill"
+          ],
+          "artifactClasses": [
+            "passive-private-fixture",
+            "passive-public-package",
+            "provider-compatibility"
+          ]
+        },
+        {
+          "hostContract": "portable-agent-plugins-1-0",
+          "kinds": [
+            "skill"
+          ],
+          "artifactClasses": [
+            "passive-public-package"
+          ]
+        }
+      ],
+      "forbiddenProjections": [
+        "agent",
+        "subagent",
+        "command",
+        "prompt",
+        "rule",
+        "instruction",
+        "hook",
+        "mcp",
+        "lsp",
+        "executable-host-extension",
+        "static-asset"
+      ],
+      "requiredCanaries": [
+        "projection-shape",
+        "semantic-identity",
+        "source-digest"
+      ],
+      "securityRequirements": {
+        "threatModel": false,
+        "securityReview": false,
+        "executableAssuranceProfile": false
+      }
+    },
+    {
+      "id": "cratis-governed-release-methodology",
+      "kind": "skill",
+      "semanticIdentity": "cratis-governed-release-methodology",
+      "semanticName": "Product-independent governed release methodology",
+      "lifecycle": "active",
+      "distributionTargetId": "cratis-governed-release-methodology",
+      "canonicalSources": [
+        {
+          "path": "skills/cratis-governed-release-methodology",
+          "digest": "7cefb600826715cee05f59ec93f5ff3d9dcbf063e8b2b2ccdbb26560170899d5",
+          "ownership": "owner",
+          "ownerComponentId": "cratis-governed-release-methodology"
+        }
+      ],
+      "contentDigest": "5789e7a4fb0974cb29f6c2fc64a3a9066ad31a53a5e072e0799eaf89bf3d96c9",
+      "owner": "public Cratis product capability",
+      "audience": "public",
+      "classification": {
+        "artifactClass": "passive-content",
+        "trust": "passive",
+        "passive": true,
+        "executable": false,
+        "effect": "guided-read"
+      },
+      "dependencies": [],
+      "hostNeutralPurpose": "Choose the assurance tier a release needs, gather the evidence that tier requires, label release intent by semantic-version impact, and structure a canary-before-promotion path with an explicit recovery disposition",
+      "approval": {
+        "state": "modeled",
+        "evidenceIds": [
           "repo-main-b795d53"
         ]
       },

--- a/catalog/ecosystem-versions.json
+++ b/catalog/ecosystem-versions.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "verifiedOn": "2026-09-02",
+  "verifiedOn": "2026-09-06",
   "policy": "official-sources-only",
   "ecosystems": [
     {

--- a/catalog/evidence.json
+++ b/catalog/evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "asOf": "2026-09-02",
+  "asOf": "2026-09-06",
   "defaultPolicy": "deny",
   "sources": [
     {
@@ -711,6 +711,12 @@
       "immutableRevision": "914a84984f7a53663740b8ea1711871e0e294620",
       "repositoryPath": "distribution/evidence/s5b-passive-host-static-generation-2026-08-25.json",
       "digest": "d619e16b71976284c5812319a27abc612a92645d817e8a6d88aa27929c75ea9e"
+    },
+    {
+      "id": "source-governed-release-methodology-source-59f47a6",
+      "kind": "repository-snapshot",
+      "locator": "https://github.com/Cratis/AI/tree/59f47a614bd2317ca379d99adfd8036b42d2e64e/skills/cratis-governed-release-methodology",
+      "immutableRevision": "59f47a614bd2317ca379d99adfd8036b42d2e64e"
     },
     {
       "id": "source-chronicle-mcp-inspection-source-5997b28",
@@ -7395,6 +7401,43 @@
         "officialUrl": "https://github.com/Cratis/AI/tree/914a84984f7a53663740b8ea1711871e0e294620",
         "sourceKind": "local-evidence-report",
         "applicableVersion": "0.0.0-fixture"
+      }
+    },
+    {
+      "id": "governed-release-methodology-source-59f47a6",
+      "sourceId": "source-governed-release-methodology-source-59f47a6",
+      "evidenceClass": "hosted",
+      "subject": {
+        "kind": "target",
+        "id": "cratis-governed-release-methodology",
+        "version": "59f47a614bd2317ca379d99adfd8036b42d2e64e"
+      },
+      "bindingIds": [],
+      "assertions": [
+        {
+          "assuranceId": "source-provenance",
+          "outcome": "pass",
+          "supporting": true,
+          "claimIds": []
+        }
+      ],
+      "scope": "Immutable provenance for the Cratis-authored, product- and language-independent release-engineering methodology source. This observation makes no release, publication, promotion, marketplace, installation, runtime, or support claim.",
+      "environment": {
+        "operatingSystem": "not-recorded",
+        "architecture": "not-recorded",
+        "isolation": "not-recorded"
+      },
+      "observedOn": "2026-09-06",
+      "validThrough": "2027-09-06",
+      "confidence": "high",
+      "limitations": [
+        "Provenance covers only the exact skill bytes at this revision. The guidance is advisory: it grants no release authority and no behavior, trigger, collision, or host evidence exists for it."
+      ],
+      "supersedes": [],
+      "legacy": {
+        "officialUrl": "https://github.com/Cratis/AI/tree/59f47a614bd2317ca379d99adfd8036b42d2e64e/skills/cratis-governed-release-methodology",
+        "sourceKind": "repository-snapshot",
+        "applicableVersion": "59f47a614bd2317ca379d99adfd8036b42d2e64e"
       }
     },
     {

--- a/catalog/generated/human-catalog/CATALOG.md
+++ b/catalog/generated/human-catalog/CATALOG.md
@@ -55,7 +55,7 @@ Modeled or planned components and projections are catalog metadata only; they ar
 
 ## Computed ecosystem support
 
-As of 2026-09-02, technical tiers are computed from active normalized evidence; expired and future evidence cannot satisfy gates. Marketplace listing is orthogonal.
+As of 2026-09-06, technical tiers are computed from active normalized evidence; expired and future evidence cannot satisfy gates. Marketplace listing is orthogonal.
 
 - unsupported: 0
 - documented: 24

--- a/catalog/generated/human-catalog/CATALOG.md
+++ b/catalog/generated/human-catalog/CATALOG.md
@@ -6,8 +6,8 @@ This catalog is generated from reviewed catalog metadata. Use it to find
 the right package and understand its skills. It is not source authority
 and does not make a planned package installable.
 
-- Profiles: 60
-- Capabilities: 45
+- Profiles: 61
+- Capabilities: 46
 - Installable profiles: 0
 - Ecosystem bindings with support claims: 0
 
@@ -15,8 +15,8 @@ and does not make a planned package installable.
 
 Modeled or planned components and projections are catalog metadata only; they are not emitted, supported, installable, published, promoted, or runtime eligible.
 
-- Components: 137
-- Passive: 134
+- Components: 138
+- Passive: 135
 - Executable: 3
 - Legacy-retained: 4
 - Existing adapter records: 316
@@ -30,7 +30,7 @@ Modeled or planned components and projections are catalog metadata only; they ar
 
 ### Components by kind
 
-- skill: 49
+- skill: 50
 - agent: 12
 - subagent: 0
 - command: 18
@@ -966,6 +966,31 @@ AI guidance for developers building with Cratis Lens.
 #### Included capabilities
 
 - No approved or candidate capabilities yet
+
+#### Composed profiles
+
+- None
+
+### Cratis Governed Release Methodology
+
+- **Profile ID:** `public-methodology-governed-releases`
+- **Audience:** public
+- **Package:** `@cratis/ai-methodology-governed-releases`
+- **State:** owner-review-pending
+- **Installable:** no
+- **Materialization:** candidate-package
+
+Product- and language-independent release-engineering methodology: assurance tiers, evidence ladders, lifecycle phases, supply-chain receipts, semantic-version release intent, canaries, and recovery disposition.
+
+**Intended for:** Maintainers planning a release in any repository, for any artifact format, without selecting a Cratis product or language profile.
+
+- Products: shared engineering behavior
+- Languages: language-agnostic
+- Repository kinds: consumer projects
+
+#### Included capabilities
+
+- cratis-governed-release-methodology
 
 #### Composed profiles
 
@@ -3732,6 +3757,69 @@ Use when a service must enumerate all implementations through IInstancesOf&lt;T&
 #### Profile membership — cratis-fundamentals-type-discovery
 
 - None
+
+### cratis-governed-release-methodology
+
+- **ID:** `cratis-governed-release-methodology`
+- **Audience:** public
+- **Lifecycle:** candidate
+- **Approval:** candidate
+- **Runtime eligible:** no
+
+#### Purpose — cratis-governed-release-methodology
+
+Governed release methodology
+
+#### When to use — cratis-governed-release-methodology
+
+Use when choosing the assurance tier a release needs, deciding whether checksums, provenance, or an SBOM are warranted, labeling release intent, or judging whether a support claim is backed by evidence.
+
+#### When not to use — cratis-governed-release-methodology
+
+- Do not use for a registry's publish command syntax or credentials.
+- Do not use to run a publish, tag, or promotion operation.
+
+#### Invocation — cratis-governed-release-methodology
+
+- Capability kind: unclassified
+- Invocation: unclassified
+
+#### Applicability — cratis-governed-release-methodology
+
+- Products: cross-product
+- Languages: language-agnostic
+- Architectures: Unclassified — Architecture requires reviewed target classification.
+- Personas: Unclassified — Persona requires reviewed target classification.
+- Surfaces: Unclassified — Surface requires reviewed target classification.
+- Repository profiles: Unclassified — Repository profile requires reviewed target classification.
+
+#### Dependencies — cratis-governed-release-methodology
+
+- Unclassified
+
+#### Trust and effects — cratis-governed-release-methodology
+
+- Trust class: passive
+- Assessment: unclassified
+- No assessed effects
+
+#### Evidence and support — cratis-governed-release-methodology
+
+- Authoring contract unclassified
+- Evidence: reevaluation-authority
+- Evidence: repo-main-b795d53
+
+#### Related capabilities — cratis-governed-release-methodology
+
+- None
+
+#### Bundle membership — cratis-governed-release-methodology
+
+- None
+
+#### Profile membership — cratis-governed-release-methodology
+
+- public-methodology-governed-releases
 
 ### cratis-performance-review
 

--- a/catalog/generated/human-catalog/catalog.json
+++ b/catalog/generated/human-catalog/catalog.json
@@ -2,12 +2,12 @@
   "schemaVersion": 2,
   "contractVersion": 1,
   "disclaimer": "Catalog inclusion, evaluation evidence, component modeling, planned projection, bundle generation, or publication does not grant runtime permission, emitted bytes, support, or approval.",
-  "inputDigest": "046ecad3a2f3fa219c3883f75dd70708fb59d37990dd818420731c5f21c23605",
+  "inputDigest": "64bb868a15eb0eb67772cbcde24f0b820b5269d4b3b3a90c6b11fe5dc3ac1258",
   "componentSummary": {
     "disclaimer": "Modeled or planned components and projections are catalog metadata only; they are not emitted, supported, installable, published, promoted, or runtime eligible.",
-    "total": 137,
+    "total": 138,
     "byKind": {
-      "skill": 49,
+      "skill": 50,
       "agent": 12,
       "subagent": 0,
       "command": 18,
@@ -21,16 +21,16 @@
       "static-asset": 0
     },
     "byTrust": {
-      "passive": 134,
+      "passive": 135,
       "executable": 3
     },
     "byAudience": {
-      "public": 37,
+      "public": 38,
       "cratis-engineering": 100,
       "repository-only": 0
     },
     "byLifecycle": {
-      "active": 133,
+      "active": 134,
       "legacy-retained": 4
     },
     "projections": {
@@ -895,6 +895,27 @@
       "composes": [],
       "directTargetIds": [],
       "targetIds": []
+    },
+    {
+      "id": "public-methodology-governed-releases",
+      "displayName": "Cratis Governed Release Methodology",
+      "description": "Product- and language-independent release-engineering methodology: assurance tiers, evidence ladders, lifecycle phases, supply-chain receipts, semantic-version release intent, canaries, and recovery disposition.",
+      "intendedFor": "Maintainers planning a release in any repository, for any artifact format, without selecting a Cratis product or language profile.",
+      "audience": "public",
+      "packageName": "@cratis/ai-methodology-governed-releases",
+      "state": "owner-review-pending",
+      "installable": false,
+      "materialization": "candidate-package",
+      "products": [],
+      "languages": [],
+      "repositoryKinds": [],
+      "composes": [],
+      "directTargetIds": [
+        "cratis-governed-release-methodology"
+      ],
+      "targetIds": [
+        "cratis-governed-release-methodology"
+      ]
     },
     {
       "id": "public-modeling-screenplay-stage",
@@ -3618,6 +3639,64 @@
         "cratis-core-review"
       ],
       "profileIds": []
+    },
+    {
+      "id": "cratis-governed-release-methodology",
+      "semanticName": "cratis-governed-release-methodology",
+      "audience": "public",
+      "purpose": "Governed release methodology",
+      "whenToUse": "Use when choosing the assurance tier a release needs, deciding whether checksums, provenance, or an SBOM are warranted, labeling release intent, or judging whether a support claim is backed by evidence.",
+      "whenNotToUse": [
+        "Do not use for a registry's publish command syntax or credentials.",
+        "Do not use to run a publish, tag, or promotion operation."
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "approvalState": "candidate",
+      "runtimeEligible": false,
+      "products": [
+        "cross-product"
+      ],
+      "languages": [
+        "language-agnostic"
+      ],
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencies": [],
+      "authoringContractIds": [],
+      "evidenceIds": [
+        "reevaluation-authority",
+        "repo-main-b795d53"
+      ],
+      "relatedTargetIds": [],
+      "bundleIds": [],
+      "profileIds": [
+        "public-methodology-governed-releases"
+      ]
     },
     {
       "id": "cratis-performance-review",

--- a/catalog/generated/human-catalog/catalog.json
+++ b/catalog/generated/human-catalog/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractVersion": 1,
   "disclaimer": "Catalog inclusion, evaluation evidence, component modeling, planned projection, bundle generation, or publication does not grant runtime permission, emitted bytes, support, or approval.",
-  "inputDigest": "64bb868a15eb0eb67772cbcde24f0b820b5269d4b3b3a90c6b11fe5dc3ac1258",
+  "inputDigest": "3acc1104bb245f89dc5f2e94bb579437d922b488e890fae4f55318b51f056c19",
   "componentSummary": {
     "disclaimer": "Modeled or planned components and projections are catalog metadata only; they are not emitted, supported, installable, published, promoted, or runtime eligible.",
     "total": 138,

--- a/catalog/generated/human-catalog/manifest.json
+++ b/catalog/generated/human-catalog/manifest.json
@@ -1,17 +1,17 @@
 {
   "schemaVersion": 2,
   "contractVersion": 1,
-  "inputDigest": "046ecad3a2f3fa219c3883f75dd70708fb59d37990dd818420731c5f21c23605",
+  "inputDigest": "64bb868a15eb0eb67772cbcde24f0b820b5269d4b3b3a90c6b11fe5dc3ac1258",
   "files": [
     {
       "path": "CATALOG.md",
-      "size": 127121,
-      "sha256": "76f3d238d14ec762af265f22944088ae4cc44f787b297c0c268f936408d2dc8b"
+      "size": 129911,
+      "sha256": "3f128000b745768ad2646f498caf2e48979e5a455760e844daeeb2fc9d89051c"
     },
     {
       "path": "catalog.json",
-      "size": 162756,
-      "sha256": "021742a6000636916327808cb7fe1f8e23a17ac3f075a5b6a492875e4390c43a"
+      "size": 165658,
+      "sha256": "2ea3a10380b2e78598d57e2c650073b8fbb20ae9841b032271749e2fff3a4978"
     }
   ]
 }

--- a/catalog/generated/human-catalog/manifest.json
+++ b/catalog/generated/human-catalog/manifest.json
@@ -1,17 +1,17 @@
 {
   "schemaVersion": 2,
   "contractVersion": 1,
-  "inputDigest": "64bb868a15eb0eb67772cbcde24f0b820b5269d4b3b3a90c6b11fe5dc3ac1258",
+  "inputDigest": "3acc1104bb245f89dc5f2e94bb579437d922b488e890fae4f55318b51f056c19",
   "files": [
     {
       "path": "CATALOG.md",
       "size": 129911,
-      "sha256": "3f128000b745768ad2646f498caf2e48979e5a455760e844daeeb2fc9d89051c"
+      "sha256": "dbe3e6f29bf43ff69d7f595920529ce6e1b111d6823103573321039edd5ec47b"
     },
     {
       "path": "catalog.json",
       "size": 165658,
-      "sha256": "2ea3a10380b2e78598d57e2c650073b8fbb20ae9841b032271749e2fff3a4978"
+      "sha256": "0a0428edd884d9c0fc88f5e04bf13b2df754f974a6438ce3e1a5f0f890da5787"
     }
   ]
 }

--- a/catalog/public-skills.yml
+++ b/catalog/public-skills.yml
@@ -24,8 +24,8 @@
   },
   "audit": {
     "verifiedOn": "2026-08-20",
-    "currentInventoryCount": 45,
-    "publicCandidateCount": 37,
+    "currentInventoryCount": 46,
+    "publicCandidateCount": 38,
     "internalSkillCount": 8,
     "internalSkills": [
       {
@@ -349,6 +349,28 @@
       },
       "reviewNotes": [
         "Classification-only public-safe guidance. No Studio MCP implementation authority, operation, prompt, resource, schema, transport, or invocation is admitted."
+      ]
+    },
+    {
+      "currentName": "cratis-governed-release-methodology",
+      "source": "skills/cratis-governed-release-methodology",
+      "proposedName": "cratis-governed-release-methodology",
+      "disposition": "retain",
+      "publicationStatus": "candidate",
+      "includeInRuntime": false,
+      "products": [
+        "cross-product"
+      ],
+      "languages": [
+        "language-agnostic"
+      ],
+      "dependencies": {
+        "skills": [],
+        "internalArtifacts": [],
+        "externalTools": []
+      },
+      "reviewNotes": [
+        "Product- and language-independent release-engineering methodology. Advisory only: it grants no release, publication, promotion, or support authority and performs no release operation."
       ]
     },
     {

--- a/catalog/support-policy.json
+++ b/catalog/support-policy.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "asOf": "2026-09-02",
+  "asOf": "2026-09-06",
   "defaultPolicy": "deny",
   "evidenceClasses": [
     "synthetic-fixture",

--- a/catalog/v2/artifacts.json
+++ b/catalog/v2/artifacts.json
@@ -58,6 +58,7 @@
           "cratis-event-model-diagram",
           "cratis-fundamentals-concept",
           "cratis-fundamentals-type-discovery",
+          "cratis-governed-release-methodology",
           "cratis-performance-review",
           "cratis-security-review",
           "cratis-specifications-csharp",
@@ -210,6 +211,7 @@
           "cratis-event-model-diagram",
           "cratis-fundamentals-concept",
           "cratis-fundamentals-type-discovery",
+          "cratis-governed-release-methodology",
           "cratis-performance-review",
           "cratis-security-review",
           "cratis-specifications-csharp",
@@ -314,7 +316,9 @@
         ".ai/skills/write-specs/evals/evals.json",
         ".ai/skills/write-specs/references/EXAMPLES.md",
         "skills/cratis-fundamentals-concept/LICENSE",
-        "skills/cratis-fundamentals-concept/SKILL.md"
+        "skills/cratis-fundamentals-concept/SKILL.md",
+        "skills/cratis-governed-release-methodology/LICENSE",
+        "skills/cratis-governed-release-methodology/SKILL.md"
       ],
       "allowedPathPatterns": [
         "skills/<candidate-source>/SKILL.md",

--- a/catalog/v2/components.json
+++ b/catalog/v2/components.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "generatedBy": "tooling/generate-component-catalogs.mjs",
-  "sourceDigest": "161a3f34a340dbe8c85a6ca016a9a9842b823d721c36a976901e2053ac2a13a6",
+  "sourceDigest": "c699c7a51c46dd5b9f677e80f0a2df8d932818299e3e31d442d4ec59ec842e01",
   "defaultPolicy": "deny",
   "canonicalSourceRoots": [
     ".ai/agents",
@@ -58,6 +58,7 @@
     "engineering/skills/cratis-engineering-docs-edit-page",
     "skills/cratis-chronicle-mcp-inspection",
     "skills/cratis-fundamentals-concept",
+    "skills/cratis-governed-release-methodology",
     "skills/cratis-studio-mcp-safety-guidance"
   ],
   "declaredEmptyKinds": [
@@ -5349,6 +5350,86 @@
         "state": "modeled",
         "evidenceIds": [
           "reevaluation-authority",
+          "repo-main-b795d53"
+        ]
+      },
+      "releaseBoundary": "public-passive",
+      "allowedProjections": [
+        {
+          "hostContract": "any-passive-host",
+          "kinds": [
+            "skill"
+          ],
+          "artifactClasses": [
+            "passive-private-fixture",
+            "passive-public-package",
+            "provider-compatibility"
+          ]
+        },
+        {
+          "hostContract": "portable-agent-plugins-1-0",
+          "kinds": [
+            "skill"
+          ],
+          "artifactClasses": [
+            "passive-public-package"
+          ]
+        }
+      ],
+      "forbiddenProjections": [
+        "agent",
+        "subagent",
+        "command",
+        "prompt",
+        "rule",
+        "instruction",
+        "hook",
+        "mcp",
+        "lsp",
+        "executable-host-extension",
+        "static-asset"
+      ],
+      "requiredCanaries": [
+        "projection-shape",
+        "semantic-identity",
+        "source-digest"
+      ],
+      "securityRequirements": {
+        "threatModel": false,
+        "securityReview": false,
+        "executableAssuranceProfile": false
+      }
+    },
+    {
+      "id": "cratis-governed-release-methodology",
+      "kind": "skill",
+      "semanticIdentity": "cratis-governed-release-methodology",
+      "semanticName": "Product-independent governed release methodology",
+      "lifecycle": "active",
+      "distributionTargetId": "cratis-governed-release-methodology",
+      "canonicalSources": [
+        {
+          "path": "skills/cratis-governed-release-methodology",
+          "digest": "7cefb600826715cee05f59ec93f5ff3d9dcbf063e8b2b2ccdbb26560170899d5",
+          "ownership": "owner",
+          "ownerComponentId": "cratis-governed-release-methodology"
+        }
+      ],
+      "contentDigest": "5789e7a4fb0974cb29f6c2fc64a3a9066ad31a53a5e072e0799eaf89bf3d96c9",
+      "owner": "public Cratis product capability",
+      "audience": "public",
+      "classification": {
+        "artifactClass": "passive-content",
+        "trust": "passive",
+        "passive": true,
+        "executable": false,
+        "effect": "guided-read"
+      },
+      "dependencies": [],
+      "hostNeutralPurpose": "Choose the assurance tier a release needs, gather the evidence that tier requires, label release intent by semantic-version impact, and structure a canary-before-promotion path with an explicit recovery disposition",
+      "approval": {
+        "state": "modeled",
+        "evidenceIds": [
           "repo-main-b795d53"
         ]
       },

--- a/catalog/v2/ecosystem-contracts.json
+++ b/catalog/v2/ecosystem-contracts.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "asOf": "2026-09-02",
+  "asOf": "2026-09-06",
   "defaultPolicy": "deny",
   "ecosystems": [
     {

--- a/catalog/v2/evidence.json
+++ b/catalog/v2/evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "asOf": "2026-09-02",
+  "asOf": "2026-09-06",
   "generatedBy": "tooling/generate-catalog-v2.mjs",
   "evidence": [
     {
@@ -628,6 +628,16 @@
       "expiresOn": "2026-11-23",
       "applicableVersion": "goose-1.47.0-release",
       "confidence": "high"
+    },
+    {
+      "id": "governed-release-methodology-source-59f47a6",
+      "officialUrl": "https://github.com/Cratis/AI/tree/59f47a614bd2317ca379d99adfd8036b42d2e64e/skills/cratis-governed-release-methodology",
+      "sourceKind": "repository-snapshot",
+      "verifiedOn": "2026-09-06",
+      "expiresOn": "2027-09-06",
+      "applicableVersion": "59f47a614bd2317ca379d99adfd8036b42d2e64e",
+      "confidence": "high",
+      "immutableRevision": "59f47a614bd2317ca379d99adfd8036b42d2e64e"
     },
     {
       "id": "grok-bot-plugins-source-1",

--- a/catalog/v2/migrations.json
+++ b/catalog/v2/migrations.json
@@ -199,6 +199,21 @@
       ]
     },
     {
+      "id": "rename-cratis-governed-release-methodology",
+      "kind": "retain",
+      "sourceIds": [
+        "cratis-governed-release-methodology"
+      ],
+      "targetIds": [
+        "cratis-governed-release-methodology"
+      ],
+      "state": "proposed",
+      "evaluationEvidenceIds": [],
+      "evidenceIds": [
+        "reevaluation-authority"
+      ]
+    },
+    {
       "id": "rename-cratis-react-page",
       "kind": "rename",
       "sourceIds": [

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "837caec6ce1804a88e7554ccf2f309babdb3a75797280dab8fdb634fa260b8b3",
+  "indexDigest": "951c7a8bfe5c5ced24d089c5f05db1f99e86a4fbd4d41861454ccbc42c037f8f",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "2c4e94f465249738c9ca230f74294f61d8d6a7b03e20572d31b1d508527e0fb5",
+  "indexDigest": "837caec6ce1804a88e7554ccf2f309babdb3a75797280dab8fdb634fa260b8b3",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -2639,6 +2639,10 @@
       "status": "added"
     },
     {
+      "path": "profiles/public/public-methodology-governed-releases.json",
+      "status": "added"
+    },
+    {
       "path": "profiles/public/public-modeling-screenplay-stage.json",
       "status": "added"
     },
@@ -2688,6 +2692,14 @@
     },
     {
       "path": "skills/cratis-fundamentals-concept/SKILL.md",
+      "status": "added"
+    },
+    {
+      "path": "skills/cratis-governed-release-methodology/LICENSE",
+      "status": "added"
+    },
+    {
+      "path": "skills/cratis-governed-release-methodology/SKILL.md",
       "status": "added"
     },
     {
@@ -3718,6 +3730,7 @@
         ".ai/skills/call-command-from-code/**",
         "skills/cratis-chronicle-mcp-inspection/**",
         ".ai/skills/cratis-command/**",
+        "skills/cratis-governed-release-methodology/**",
         ".ai/skills/cratis-react-page/**",
         ".ai/skills/cratis-readmodel/**",
         ".ai/skills/cratis-specs-csharp/**",
@@ -3764,8 +3777,8 @@
         "workflows-68",
         "reevaluation-authority"
       ],
-      "expectedPathCount": 68,
-      "expectedPathsDigest": "10b4b75a7848dc8b47f553b6f0158fdf8ac2ce6e57b2db3228e5fd8bbf97a73f"
+      "expectedPathCount": 70,
+      "expectedPathsDigest": "c53fea49098a20db4bb01762a9ec596bf83980f198aba1cad4f9bdb77690ce22"
     },
     {
       "excludePathPatterns": [],
@@ -4923,8 +4936,8 @@
         "option-a-plus-authority",
         "reevaluation-authority"
       ],
-      "expectedPathCount": 61,
-      "expectedPathsDigest": "16be14192b5d23958408a644ef0771a961688edb9be69c96ab5eb9da25e7fb44"
+      "expectedPathCount": 62,
+      "expectedPathsDigest": "56c656675ca6a2879022607d33d638d5e69c5197a1486aeffaba24094dd04b8f"
     },
     {
       "excludePathPatterns": [],

--- a/catalog/v2/sources.json
+++ b/catalog/v2/sources.json
@@ -272,6 +272,25 @@
       ]
     },
     {
+      "id": "cratis-governed-release-methodology",
+      "sourcePath": "skills/cratis-governed-release-methodology",
+      "artifactType": "agent-skill-source",
+      "currentOwner": "reusable Cratis engineering behavior",
+      "targetOwner": "public Cratis product capability",
+      "audience": "public",
+      "bundledPaths": [
+        "skills/cratis-governed-release-methodology/LICENSE",
+        "skills/cratis-governed-release-methodology/SKILL.md"
+      ],
+      "sourceRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
+      "contentDigest": "7cefb600826715cee05f59ec93f5ff3d9dcbf063e8b2b2ccdbb26560170899d5",
+      "publicationApproval": false,
+      "evidenceIds": [
+        "repo-main-b795d53",
+        "reevaluation-authority"
+      ]
+    },
+    {
       "id": "cratis-react-page",
       "sourcePath": ".ai/skills/cratis-react-page",
       "artifactType": "agent-skill-source",

--- a/catalog/v2/sources.json
+++ b/catalog/v2/sources.json
@@ -282,12 +282,13 @@
         "skills/cratis-governed-release-methodology/LICENSE",
         "skills/cratis-governed-release-methodology/SKILL.md"
       ],
-      "sourceRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
+      "sourceRevision": "59f47a614bd2317ca379d99adfd8036b42d2e64e",
       "contentDigest": "7cefb600826715cee05f59ec93f5ff3d9dcbf063e8b2b2ccdbb26560170899d5",
       "publicationApproval": false,
       "evidenceIds": [
         "repo-main-b795d53",
-        "reevaluation-authority"
+        "reevaluation-authority",
+        "governed-release-methodology-source-59f47a6"
       ]
     },
     {

--- a/catalog/v2/support.json
+++ b/catalog/v2/support.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "asOf": "2026-09-02",
+  "asOf": "2026-09-06",
   "generatedBy": "tooling/generate-support.mjs",
   "defaultPolicy": "deny",
   "publicationEligible": false,

--- a/catalog/v2/targets.json
+++ b/catalog/v2/targets.json
@@ -5250,6 +5250,123 @@
       "includeInRuntime": false
     },
     {
+      "id": "cratis-governed-release-methodology",
+      "semanticName": "cratis-governed-release-methodology",
+      "sourceSkillIds": [
+        "cratis-governed-release-methodology"
+      ],
+      "owner": "public Cratis product capability",
+      "audience": "public",
+      "products": [
+        "cross-product"
+      ],
+      "languages": [
+        "language-agnostic"
+      ],
+      "capabilityKind": "unclassified",
+      "invocation": "unclassified",
+      "lifecycle": "candidate",
+      "architectures": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Architecture requires reviewed target classification."
+      },
+      "personas": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Persona requires reviewed target classification."
+      },
+      "surfaces": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Surface requires reviewed target classification."
+      },
+      "repositoryProfiles": {
+        "state": "unclassified",
+        "ids": [],
+        "reason": "Repository profile requires reviewed target classification."
+      },
+      "trust": {
+        "class": "passive",
+        "assessmentState": "unclassified",
+        "effects": []
+      },
+      "dependencyClassificationState": "unclassified",
+      "dependencyEdges": [],
+      "sourceContractState": "unclassified",
+      "sourceContractIds": [],
+      "sourceAuthoritySubjects": [],
+      "authoringContractState": "unclassified",
+      "authoringContractIds": [],
+      "capability": "Governed release methodology",
+      "positiveTriggerIntent": "Use when choosing the assurance tier a release needs, deciding whether checksums, provenance, or an SBOM are warranted, labeling release intent, or judging whether a support claim is backed by evidence.",
+      "nearMissExclusions": [
+        "Do not use to run a publish, tag, or promotion operation.",
+        "Do not use for a registry's publish command syntax or credentials."
+      ],
+      "collisionSet": [],
+      "dependencies": {
+        "targets": [],
+        "internalArtifacts": [],
+        "externalTools": []
+      },
+      "runtimePayloadPolicy": {
+        "allowed": [
+          "SKILL.md",
+          "references/**",
+          "assets/**",
+          "LICENSE*"
+        ],
+        "forbidden": [
+          "scripts/**",
+          "evals/**",
+          "rules/**",
+          "agents/**",
+          "prompts/**",
+          "commands/**",
+          "hooks/**",
+          "lsp/**",
+          "tooling/**",
+          "workflows/**",
+          "local-configuration/**"
+        ]
+      },
+      "security": {
+        "executable": false,
+        "destructive": false,
+        "risk": "low",
+        "disposition": "pending",
+        "evidenceIds": []
+      },
+      "evaluations": {
+        "behavior": {
+          "status": "missing",
+          "evidenceIds": []
+        },
+        "positiveTrigger": {
+          "status": "missing",
+          "evidenceIds": []
+        },
+        "negativeTrigger": {
+          "status": "missing",
+          "evidenceIds": []
+        },
+        "collision": {
+          "status": "missing",
+          "evidenceIds": []
+        }
+      },
+      "approval": {
+        "state": "candidate",
+        "evidenceIds": []
+      },
+      "evidenceIds": [
+        "repo-main-b795d53",
+        "reevaluation-authority"
+      ],
+      "includeInRuntime": false
+    },
+    {
       "id": "cratis-performance-review",
       "semanticName": "cratis-performance-review",
       "sourceSkillIds": [

--- a/distribution/candidate-component-coverage.schema.json
+++ b/distribution/candidate-component-coverage.schema.json
@@ -36,7 +36,7 @@
         "artifacts": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
       }
     },
-    "componentCount": { "const": 137 },
+    "componentCount": { "const": 138 },
     "byKind": {
       "type": "object",
       "additionalProperties": false,
@@ -49,7 +49,7 @@
         "instruction": { "const": 1 },
         "prompt": { "const": 18 },
         "rule": { "const": 36 },
-        "skill": { "const": 49 }
+        "skill": { "const": 50 }
       }
     },
     "byDisposition": {
@@ -69,15 +69,15 @@
         "native-static-review-projected": { "const": 35 },
         "native-static-unprojected": { "const": 2 },
         "repository-host-adapter-only": { "const": 48 },
-        "skill-blocked-candidate": { "type": "integer", "minimum": 0, "maximum": 49 },
+        "skill-blocked-candidate": { "type": "integer", "minimum": 0, "maximum": 50 },
         "skill-legacy-repository-only": { "const": 4 },
-        "skill-packaged-candidate": { "type": "integer", "minimum": 0, "maximum": 49 }
+        "skill-packaged-candidate": { "type": "integer", "minimum": 0, "maximum": 50 }
       }
     },
     "records": {
       "type": "array",
-      "minItems": 137,
-      "maxItems": 137,
+      "minItems": 138,
+      "maxItems": 138,
       "uniqueItems": true,
       "items": {
         "type": "object",

--- a/distribution/candidate-review-batch.schema.json
+++ b/distribution/candidate-review-batch.schema.json
@@ -14,7 +14,7 @@
     "state": { "const": "CANDIDATE_REVIEW_BATCH_ONLY" },
     "version": { "type": "string", "pattern": "^0\\.0\\.(?:0|[1-9][0-9]*)-candidate\\.(?:0|[1-9][0-9]*)$" },
     "sourceCommit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
-    "componentCount": { "const": 137 },
+    "componentCount": { "const": 138 },
     "packagedSkillTargetCount": { "type": "integer", "minimum": 0, "maximum": 49 },
     "blockedSkillTargetCount": { "type": "integer", "minimum": 0, "maximum": 49 },
     "repositoryOnlyLegacySkillCount": { "const": 4 },

--- a/distribution/profile-catalog.json
+++ b/distribution/profile-catalog.json
@@ -590,6 +590,18 @@
       "gapSummary": "Needs Lens-owned setup, diagnostics, inspection, interpretation, safety, and contribution journeys."
     },
     {
+      "id": "public-methodology-governed-releases",
+      "packageName": "@cratis/ai-methodology-governed-releases",
+      "version": "0.0.0",
+      "products": [],
+      "languages": [],
+      "state": "owner-review-pending",
+      "availableTargets": [
+        "cratis-governed-release-methodology"
+      ],
+      "gapSummary": "Complete release-engineering methodology awaiting owner review; the remaining gap is review and catalog-v2 target classification, not content. Products and languages are deliberately empty and this entry deliberately composes nothing: assurance tiers, evidence ladders, lifecycle phases, supply-chain receipts, semver release-intent labeling, canary-before-promotion, and recovery disposition are independent of which product ships and which language builds it, so selecting it must never imply Arc, Chronicle, or a language profile."
+    },
+    {
       "id": "public-modeling-screenplay-stage",
       "packageName": "@cratis/ai-modeling-screenplay-stage",
       "version": "0.0.0",

--- a/distribution/public-evaluation-eligibility.json
+++ b/distribution/public-evaluation-eligibility.json
@@ -82,6 +82,10 @@
       "reason": "effect-assessment-required"
     },
     {
+      "targetId": "cratis-governed-release-methodology",
+      "reason": "effect-assessment-required"
+    },
+    {
       "targetId": "cratis-studio-mcp-safety-guidance",
       "reason": "mcp-guidance-materialization-blocked"
     }

--- a/profiles/public/public-methodology-governed-releases.json
+++ b/profiles/public/public-methodology-governed-releases.json
@@ -1,0 +1,12 @@
+{
+  "id": "public-methodology-governed-releases",
+  "packageName": "@cratis/ai-methodology-governed-releases",
+  "version": "0.0.0",
+  "products": [],
+  "languages": [],
+  "state": "owner-review-pending",
+  "availableTargets": [
+    "cratis-governed-release-methodology"
+  ],
+  "gapSummary": "Complete release-engineering methodology awaiting owner review; the remaining gap is review and catalog-v2 target classification, not content. Products and languages are deliberately empty and this entry deliberately composes nothing: assurance tiers, evidence ladders, lifecycle phases, supply-chain receipts, semver release-intent labeling, canary-before-promotion, and recovery disposition are independent of which product ships and which language builds it, so selecting it must never imply Arc, Chronicle, or a language profile."
+}

--- a/skills/cratis-governed-release-methodology/LICENSE
+++ b/skills/cratis-governed-release-methodology/LICENSE
@@ -1,0 +1,2 @@
+Copyright (c) Cratis. All rights reserved.
+Licensed under the MIT license. See LICENSE file in the project root for full license information.

--- a/skills/cratis-governed-release-methodology/SKILL.md
+++ b/skills/cratis-governed-release-methodology/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: cratis-governed-release-methodology
+description: Choose the assurance tier a release needs, gather the evidence that tier requires, label release intent by semantic-version impact, and structure a canary-before-promotion path with an explicit recovery disposition. Use when planning a release or judging whether checksums, provenance, an SBOM, or a claim of support are warranted. Do not use for product code, publish-command syntax, or release credentials.
+license: MIT
+---
+
+# Governed release methodology
+
+Release engineering is the discipline of matching **ceremony to consequence**.
+Too little, and a consumer upgrades into a broken build with no way back. Too
+much, and every documentation fix drags a supply-chain ritual behind it until
+the ritual is performed without belief and stops meaning anything.
+
+This skill is product-, language-, and registry-independent. It applies to a
+Cratis repository publishing NuGet packages, one publishing npm packages, one
+pushing container images, and one whose whole delivery is a merge to `main`. It
+grants no release authority of its own: it tells you what a claim costs, not
+that you may make it.
+
+## Start with the artifact, not the process
+
+The single most expensive mistake is applying package-release ceremony to
+something that is not a package. Classify the artifact first.
+
+| Artifact | What the consumer receives | Ceremony it earns |
+| --- | --- | --- |
+| Compiled package (NuGet, npm, Maven, Hex), container image, installer | Opaque bytes built on infrastructure the consumer cannot inspect | Full supply-chain receipts |
+| Generated or bundled tree assembled by a pipeline | Bytes that do not exist in any reviewed source tree | Full supply-chain receipts |
+| Source files a host reads directly from a git ref (rules, skills, templates) | Exactly the reviewed content at a commit | Review and versioning only |
+
+The dividing question is **"can the consumer verify what they got against what
+was reviewed, without trusting our build?"** If the host clones a git ref and
+reads the files, git's own content addressing already answers that: the tree
+hash *is* the checksum, the commit *is* the provenance, and the reviewed diff
+*is* the artifact. Generating a checksum file for that content, publishing an
+SBOM of markdown, and demanding a signed attestation before a folder may be read
+adds process without adding a guarantee. Say so plainly rather than performing
+it.
+
+If the artifact is compiled or assembled, the opposite holds, and the
+supply-chain receipts below are not optional decoration.
+
+## Pick the assurance tier before you pick the checks
+
+Three tiers, each earning strictly more claim than the one below it. Default to
+the lowest tier that supports the claim you intend to make, and never let a
+lower tier's evidence be reinterpreted as a higher tier's.
+
+**Candidate review** — an internal, non-published build for review. Claim:
+"this builds deterministically from an immutable source and contains nothing it
+should not." Requires deterministic regeneration from an exact revision, static
+contract and schema validation, secret and path scanning, and an inventory
+digest. It may never be installed by a consumer or described as available.
+
+**Preview** — a real, published, low-commitment version (a `0.x.y`, a
+prerelease channel). Claim: "a consumer can install this, use it, and get back
+out." Requires everything above, plus an independent human review and a real
+**exact-artifact** lifecycle smoke: pack, install, discover, use, uninstall, and
+roll back to a prior exact version. A preview may be withdrawn, may break, and
+must never be described as supported.
+
+**Governed support** — the claim that a consumer may depend on this. Requires
+everything above, plus the full lifecycle phase set on a real host, external
+control attestations, a canary against a real consumer, a recorded recovery
+disposition, and a named human approval for that exact released artifact.
+
+Graduation between tiers does not change the artifact's format. It changes
+what has been observed about it. A preview that later graduates re-runs the
+evidence for the exact released version; earlier observations of an earlier
+build do not transfer.
+
+## Evidence is an observation, not an intention
+
+"Evidence" degrades into paperwork the moment it is allowed to mean "we
+implemented the thing that would produce it." Hold the line with a technical
+ladder where each rung names an observation someone actually made:
+
+1. **documented** — the behavior is written down.
+2. **generated** — an artifact is produced deterministically.
+3. **statically validated** — schemas, contracts, and scans pass on it.
+4. **install-tested** — it installs into a real host.
+5. **behavior-tested** — it is discovered, does the right thing on a positive
+   case, and correctly refuses a negative case.
+6. **lifecycle-tested** — install, update, rollback, uninstall, and preservation
+   of consumer-owned state all pass on that exact artifact.
+7. **release-tested** — the *released* artifact (not a local build of the same
+   commit) passed a canary.
+8. **supported** — a named human approved that exact released artifact.
+
+Two rules keep the ladder honest:
+
+- **Synthetic evidence caps out at statically validated.** A fixture, simulator,
+  or mocked host proves the pipeline, never the host. Classify every observation
+  as synthetic, local, hosted, or real-consumer, and never let a synthetic
+  observation satisfy an execution requirement.
+- **A missing or version-mismatched host is a blocked outcome, not a skip.** If
+  the canary needed host 2.1.245 and the runner had 2.1.235, the phase did not
+  pass; it did not run. A skipped phase that reports green is worse than a red
+  one, because it retires the question.
+
+## The lifecycle phases a real install cycle must cover
+
+When you claim a consumer can adopt and un-adopt your artifact, these are the
+phases that claim decomposes into. Run them against the exact artifact a
+consumer would receive.
+
+- **collision-negative** — with the artifact absent, nothing already present
+  answers to its name. This is the baseline that makes the positive result mean
+  something.
+- **install** — it installs from the published location, not a local path.
+- **discovery** — the host actually finds and lists it afterwards.
+- **behavior-positive** — it does the thing it exists to do.
+- **behavior-negative** — it declines the case it must decline. An artifact that
+  never says no has not been tested for judgment.
+- **update** — moving from the previous version to this one succeeds.
+- **rollback** — moving back to the previous exact version succeeds. This is the
+  phase teams skip and the one consumers need most.
+- **uninstall** — it removes cleanly.
+- **project-context-preservation** — consumer-owned files it never owned are
+  untouched by install, update, rollback, and uninstall. Destroying local
+  configuration during an upgrade is the most expensive failure in this list.
+- **cleanup** — no residue in caches, registries, or host state.
+
+Rollback and preservation are what convert "it works" into "it is safe to try."
+A release path without a proven way back is not a release path; it is a
+one-way door.
+
+## Supply-chain receipts and what each one proves
+
+For compiled or assembled artifacts only, and each for a distinct reason:
+
+- **Checksums** prove the bytes a consumer downloaded are the bytes that were
+  built. They defend against a corrupted or substituted download.
+- **Provenance** proves *which* build, from which source revision, on which
+  workflow, produced those bytes. It defends against a package that matches its
+  own checksum but was built from something nobody reviewed.
+- **SBOM** proves what is *inside* the artifact. It is what makes a downstream
+  vulnerability answerable at all: without it, "are we affected?" requires
+  re-deriving the dependency closure of a shipped binary.
+- **Canary receipt** proves the released artifact worked for a real consumer.
+- **Promotion receipt** proves the decision to widen the audience came after the
+  canary, and records what it was based on.
+- **Recovery disposition** records, before publication, exactly what can be
+  undone and what cannot.
+- **Support approval** is a named human accepting responsibility for that exact
+  released artifact.
+
+Each receipt is written **at the stage it describes and never backdated**. A
+publication receipt cannot be a prepublication prerequisite; a promotion receipt
+cannot be written before the canary it cites. If an earlier record has to be
+rewritten to make a later claim true, the later claim is false.
+
+Prefer registry-native provenance (trusted publishing / OIDC) over
+hand-assembled attestations. It removes the long-lived credential, and the
+consumer can verify it without trusting a file you wrote.
+
+## Automation is not a control
+
+The most common false claim in release engineering is that implemented
+automation proves a control is configured. It does not. A workflow that *would*
+publish through a protected environment says nothing about whether the
+environment exists, who can approve it, or who owns the package name.
+
+Before claiming a control, record an attestation binding: the exact subject
+(repository, branch, workflow, environment, package, or publisher account), who
+observed it and with what authority, when, how long the observation is good
+for, where revocation would be visible, and when revocation was last checked.
+An attestation without an expiry and a revocation check is a screenshot.
+
+Controls worth attesting for a real publishing pipeline: protected default
+branch with required status checks, a release-specific required status, a
+protected publication environment, repository-scoped credentials, exact package
+name ownership in the registry, and exact trusted-publisher registration.
+
+## Label release intent by outward-facing effect
+
+The version label on a pull request is not paperwork describing the change; in
+a label-driven pipeline it **is the decision to ship**. Exactly one of four
+labels belongs on every pull request:
+
+- **major** — a breaking change to public API or observable behavior.
+- **minor** — new capability, backward compatible.
+- **patch** — a fix, or a refactor with identical observable behavior.
+- **no-release** — nothing a consumer could observe by upgrading.
+
+The test is **outward-facing effect, not file location**. A change under a
+source directory that only touches tests is not shippable; a one-line change to
+a shipped package's behavior is, however small. Documentation, CI workflows,
+test-only changes, and local tooling carry `no-release`.
+
+`no-release` is a decision, not an omission — leaving the label off is
+indistinguishable from forgetting it, so an unlabeled pull request stays an
+error. Never default to `patch` when unsure: an unnecessary release burns a
+version number, ships release notes describing nothing, and buries the releases
+that matter.
+
+Two consequences worth internalizing:
+
+- **Group related small work into one pull request.** Several small merges
+  become several releases, and a stream of near-empty patch releases makes the
+  release history useless to the people it is written for. The pull request is
+  the release boundary; make it a coherent, describable change.
+- **Folding one pull request into another means relabeling it.** When branch X
+  is merged as part of Y, X auto-closes *as merged* and fires its own publish
+  run under its own label. Relabel X to `no-release`; do not close it by hand,
+  or its author loses the attribution.
+
+## Structure the release path so no step can vouch for itself
+
+The ordering below is what makes the evidence non-circular. Each step consumes
+only records that already existed when it started.
+
+1. **Prerequisites first.** Every approval, evidence record, and control
+   attestation the release will cite already exists on the protected base
+   branch. A release request may not introduce, weaken, or grant its own
+   prerequisites.
+2. **Freeze a preflight snapshot.** Bind the exact source revision, the exact
+   candidate artifact digest, and the exact prerequisite set — without including
+   the request that will cite it.
+3. **One append-only request.** One version, one artifact, referencing the
+   preflight digest. Requests are never rewritten or reused; a defect in a
+   released version is corrected by a new version, never by editing the record
+   of the old one.
+4. **Named review, then merge.** Merging is the human approval. Keep the merge
+   a true merge commit so the branch's real history survives, and bind the
+   approval to the parent commit so unrelated authority changes cannot be
+   batched in ahead of it.
+5. **Publish, then write the publication receipt** with package identity,
+   artifact digest, provenance, SBOM, and checksums.
+6. **Canary the released artifact against a real consumer** — a real downstream
+   repository or sample that actually depends on it, running its own build and
+   tests against the published version. A canary against a fixture proves the
+   pipeline; a canary against a real consumer proves the release. Publication
+   jobs must stop before promotion if it fails.
+7. **Promote only on canary evidence**, and record the promotion separately.
+8. **Support requires its own final named approval** for that exact released
+   artifact. Publication is not promotion, promotion is not support, and a
+   marketplace or registry listing is none of the three.
+
+## Write the recovery disposition before you publish
+
+Decide and record, per stage, what failure means — while you still have the
+choice.
+
+- **Before publication**, everything is reversible: delete the draft release,
+  close the index or subscriber pull request, remove the branch and tag.
+- **After publication, most registries are immutable.** A published npm, NuGet,
+  or Maven version cannot be un-published in any way a consumer can rely on.
+  The honest recovery is roll-*forward*: publish a corrected version and move
+  the moving pointer (`latest`, a floating tag) back to a known-good exact
+  version. Never describe an immutable version as rolled back.
+- **Automatic rollback is a capability, not an assumption.** Claim it only where
+  it is implemented and canaried; otherwise record it as disabled and name the
+  manual procedure.
+- **Keep failed intermediate state for inspection** rather than deleting the
+  evidence of the failure.
+
+State the disposition in terms a consumer can act on: which exact version to
+pin to, and what the pinned version does not have.
+
+## Never claim a tier you have not paid for
+
+The final discipline is linguistic. "Available", "published", "preview",
+"listed", and "supported" are different claims with different costs, and the
+gap between them is where trust is lost.
+
+- Publishing a package makes it **available**, not supported.
+- A marketplace submission is not a listing; a listing is not support.
+- Passing static validation makes an artifact **statically validated**, not
+  install-tested.
+- Automation that could produce a receipt has not produced one.
+
+When the evidence for a claim is missing, say which evidence is missing and what
+the artifact *is* — not a hedged version of the claim you wanted to make.
+
+## Verify
+
+- The artifact is classified as compiled/assembled or as source read from a git
+  ref, and the ceremony matches that classification.
+- The chosen tier is the lowest one that supports the intended claim.
+- Every phase result is pass, fail, or explicitly blocked — never a silent skip.
+- No synthetic or fixture observation is counted as install, behavior,
+  lifecycle, or canary evidence.
+- Rollback to a prior exact version and preservation of consumer-owned files
+  were both actually exercised.
+- Checksums, provenance, and SBOM exist for compiled or assembled artifacts and
+  are absent, deliberately and explainably, for git-ref source delivery.
+- Every claimed external control has an attestation with subject, issuer,
+  validity, and a revocation check.
+- The pull request carries exactly one of `major`, `minor`, `patch`, or
+  `no-release`, chosen by outward-facing effect.
+- No record was rewritten or backdated to satisfy a later stage.
+- A canary ran against a real consumer before promotion.
+- The recovery disposition is written down and does not claim an immutable
+  version can be rolled back.
+- Nothing is described as supported without a named approval of that exact
+  released artifact.

--- a/tooling/candidate-component-coverage.mjs
+++ b/tooling/candidate-component-coverage.mjs
@@ -176,9 +176,9 @@ export function buildCandidateComponentCoverage(
         ].includes(record.disposition),
     ).length;
     if (
-        records.length !== 137 ||
+        records.length !== 138 ||
         new Set(componentIds).size !== records.length ||
-        skillDispositionCount !== 49 ||
+        skillDispositionCount !== 50 ||
         records.filter(
             (record) => record.disposition === "skill-legacy-repository-only",
         ).length !== 4 ||

--- a/tooling/catalog-v2-validation.mjs
+++ b/tooling/catalog-v2-validation.mjs
@@ -226,11 +226,11 @@ export function validateSources(catalogs, root) {
     ];
     if (!equalStringSets(sourceIds, v1Ids))
         errors.push(
-            "catalog v2 sources must preserve all 45 authored skill sources exactly once",
+            "catalog v2 sources must preserve all 46 authored skill sources exactly once",
         );
-    if (sourceIds.length !== 45)
+    if (sourceIds.length !== 46)
         errors.push(
-            `catalog v2 must contain 45 sources; found ${sourceIds.length}`,
+            `catalog v2 must contain 46 sources; found ${sourceIds.length}`,
         );
     for (const source of catalogs.sources.sources) {
         if (source.publicationApproval)

--- a/tooling/component-catalog-validation.mjs
+++ b/tooling/component-catalog-validation.mjs
@@ -46,7 +46,7 @@ export const distributionPointerOutputs = new Set([
 ]);
 
 const expectedComponentAnchor =
-    "4bdaeb61b53a3e0c8d1812d6e6d0dc5dde2836d21cd9fe499568af4e29cfec4e";
+    "c7c065600c6cbef7e9b88637ce52fc35d882e3e1695e691cdc58095036b09055";
 const expectedProjectionAnchor =
     "70f3e05988839ba21247eff528709caf4738f2aa7f637e05e28658ff05902027";
 const expectedProjectionHostAnchor =

--- a/tooling/generate-catalog-v2.mjs
+++ b/tooling/generate-catalog-v2.mjs
@@ -241,10 +241,12 @@ const sourceOverrides = new Map([
         },
     ],
     [
-        // Authored in this repository and not yet rebound to its own merged
-        // revision, so it deliberately carries no extra source evidence id.
         "cratis-governed-release-methodology",
-        { sourcePath: "skills/cratis-governed-release-methodology" },
+        {
+            sourcePath: "skills/cratis-governed-release-methodology",
+            sourceRevision: "59f47a614bd2317ca379d99adfd8036b42d2e64e",
+            evidenceId: "governed-release-methodology-source-59f47a6",
+        },
     ],
     [
         "add-cratis-docs-page",

--- a/tooling/generate-catalog-v2.mjs
+++ b/tooling/generate-catalog-v2.mjs
@@ -241,6 +241,12 @@ const sourceOverrides = new Map([
         },
     ],
     [
+        // Authored in this repository and not yet rebound to its own merged
+        // revision, so it deliberately carries no extra source evidence id.
+        "cratis-governed-release-methodology",
+        { sourcePath: "skills/cratis-governed-release-methodology" },
+    ],
+    [
         "add-cratis-docs-page",
         {
             sourcePath: "engineering/skills/cratis-engineering-docs-add-page",
@@ -567,6 +573,17 @@ const engineeringClassifications = new Map([
 ]);
 
 const profiles = {
+    "cratis-governed-release-methodology": [
+        "Governed release methodology",
+        "Use when choosing the assurance tier a release needs, deciding whether checksums, provenance, or an SBOM are warranted, labeling release intent, or judging whether a support claim is backed by evidence.",
+        [
+            "Do not use to run a publish, tag, or promotion operation.",
+            "Do not use for a registry's publish command syntax or credentials.",
+        ],
+        [],
+        "low",
+        false,
+    ],
     "cratis-studio-mcp-safety-guidance": [
         "Studio MCP classification-only safety guidance",
         "Use when classifying a Studio MCP request or interpreting already-redacted output without discovering or invoking an operation.",
@@ -1173,7 +1190,7 @@ const sources = allSkillNames.map((name) => {
         evidenceIds: [
             "repo-main-b795d53",
             "reevaluation-authority",
-            ...(sourceOverride ? [sourceOverride.evidenceId] : []),
+            ...(sourceOverride?.evidenceId ? [sourceOverride.evidenceId] : []),
         ],
     };
 });

--- a/tooling/package-candidate-review-batch.mjs
+++ b/tooling/package-candidate-review-batch.mjs
@@ -126,7 +126,7 @@ export function packageCandidateReviewBatch({
             state: "CANDIDATE_REVIEW_BATCH_ONLY",
             version,
             sourceCommit: publicManifest.sourceCommit,
-            componentCount: 137,
+            componentCount: 138,
             packagedSkillTargetCount:
                 publicManifest.targetIds.length +
                 engineeringManifest.targetIds.length,

--- a/tooling/profile-presentation.mjs
+++ b/tooling/profile-presentation.mjs
@@ -70,6 +70,10 @@ const displayNameOverrides = new Map([
         "Cratis Chronicle TypeScript Client",
     ],
     ["public-modeling-screenplay-stage", "Cratis Screenplay → Stage"],
+    [
+        "public-methodology-governed-releases",
+        "Cratis Governed Release Methodology",
+    ],
     ["public-language-csharp", "Cratis C# Language Conventions"],
     ["public-language-elixir", "Cratis Elixir Language Conventions"],
     ["public-language-kotlin", "Cratis Kotlin Language Conventions"],
@@ -113,6 +117,10 @@ const descriptionOverrides = new Map([
         "Public-safe documentation authoring guidance for maintainers working across Cratis product repositories.",
     ],
     [
+        "public-methodology-governed-releases",
+        "Product- and language-independent release-engineering methodology: assurance tiers, evidence ladders, lifecycle phases, supply-chain receipts, semantic-version release intent, canaries, and recovery disposition.",
+    ],
+    [
         "cratis/application",
         "The namespaced suite for building a full Cratis application with Arc, Chronicle, Arc React, Components, and Specifications.",
     ],
@@ -134,12 +142,16 @@ const descriptionOverrides = new Map([
     ]),
 ]);
 
-const intendedForOverrides = new Map(
-    [...languageProfileLabels].map(([id, label]) => [
+const intendedForOverrides = new Map([
+    [
+        "public-methodology-governed-releases",
+        "Maintainers planning a release in any repository, for any artifact format, without selecting a Cratis product or language profile.",
+    ],
+    ...[...languageProfileLabels].map(([id, label]) => [
         id,
         `Developers who want ${label} conventions without selecting a Cratis product profile.`,
     ]),
-);
+]);
 
 function joinNatural(values) {
     if (values.length === 0) return "Cratis";

--- a/tooling/specs/candidate-contract-schemas.spec.mjs
+++ b/tooling/specs/candidate-contract-schemas.spec.mjs
@@ -120,7 +120,7 @@ test("candidate contract schemas reject grants count drift and unknown fields", 
         const coverageErrors = validate(coverage, schemas.coverage);
         assert(
             coverageErrors.some((error) =>
-                error.includes("componentCount: expected constant 137"),
+                error.includes("componentCount: expected constant 138"),
             ),
         );
         assert(

--- a/tooling/specs/candidate-review-batch.spec.mjs
+++ b/tooling/specs/candidate-review-batch.spec.mjs
@@ -34,8 +34,8 @@ test("candidate review batch is deterministic complete and non-releasing", () =>
         const second = packageCandidateReviewBatch({ outputRoot: secondRoot });
         assert.deepEqual(second, first);
         assert.equal(first.state, "CANDIDATE_REVIEW_BATCH_ONLY");
-        assert.equal(first.componentCount, 137);
-        assert.equal(first.packagedSkillTargetCount, 40);
+        assert.equal(first.componentCount, 138);
+        assert.equal(first.packagedSkillTargetCount, 41);
         assert.equal(first.blockedSkillTargetCount, 5);
         assert.equal(first.repositoryOnlyLegacySkillCount, 4);
         assert.equal(first.nativeProjectedComponentCount, 35);

--- a/tooling/specs/catalog-v2-validation.spec.mjs
+++ b/tooling/specs/catalog-v2-validation.spec.mjs
@@ -58,10 +58,10 @@ test("catalog v2 schemas and semantic policy pass for the repository", () => {
     assert.deepEqual(validateV2Catalogs(), []);
 });
 
-test("catalog v2 preserves all 45 sources while split and merge targets are independent", () => {
+test("catalog v2 preserves all 46 sources while split and merge targets are independent", () => {
     const catalogs = loadCatalogs();
-    assert.equal(catalogs.sources.sources.length, 45);
-    assert.equal(catalogs.targets.targets.length, 45);
+    assert.equal(catalogs.sources.sources.length, 46);
+    assert.equal(catalogs.targets.targets.length, 46);
     const split = catalogs.migrations.migrations.find(
         (migration) => migration.kind === "split",
     );
@@ -965,7 +965,7 @@ test("the accepted Option A+ decision still blocks unapproved live targets", () 
     assert.equal(publicCandidate.materializationAllowed, true);
     assert.equal(publicCandidate.runtimeEligible, false);
     assert.equal(publicCandidate.requiresApprovedTargets, false);
-    assert.equal(publicCandidate.componentInventory.skills.length, 34);
+    assert.equal(publicCandidate.componentInventory.skills.length, 35);
     assert(
         !publicCandidate.componentInventory.skills.includes(
             "cratis-chronicle-mcp-inspection",

--- a/tooling/specs/catalog-validation.spec.mjs
+++ b/tooling/specs/catalog-validation.spec.mjs
@@ -95,7 +95,7 @@ test("schema number bounds enforce both minimum and maximum", () => {
 test("public catalog starts deny-by-default with no runtime-approved candidates", () => {
     const catalog = readCatalog(publicCatalogPath);
     assert.equal(catalog.defaultPolicy, "deny");
-    assert.equal(catalog.skills.length, 37);
+    assert.equal(catalog.skills.length, 38);
     assert.equal(catalog.audit.internalSkills.length, 8);
     assert(
         catalog.skills.every(

--- a/tooling/specs/component-catalog.spec.mjs
+++ b/tooling/specs/component-catalog.spec.mjs
@@ -167,7 +167,7 @@ test("catalog records all kinds and honestly declares MCP and LSP empty", () => 
                 .length,
         ]),
     );
-    assert.equal(counts.skill, 49);
+    assert.equal(counts.skill, 50);
     assert.equal(counts.agent, 12);
     assert.equal(counts.command, 18);
     assert.equal(counts.prompt, 18);

--- a/tooling/specs/native-non-skill-review-assets.spec.mjs
+++ b/tooling/specs/native-non-skill-review-assets.spec.mjs
@@ -95,7 +95,7 @@ test("native non-skill review assets are deterministic exact and non-installable
         const coverage = JSON.parse(
             readFileSync(join(firstRoot, "component-coverage.json"), "utf8"),
         );
-        assert.equal(coverage.componentCount, 137);
+        assert.equal(coverage.componentCount, 138);
         const checksums = readFileSync(join(firstRoot, "SHA256SUMS"), "utf8");
         assert(checksums.includes("native-review-assets.json"));
         assert(checksums.includes("native-review-sbom.json"));

--- a/tooling/specs/passive-candidate-assets.spec.mjs
+++ b/tooling/specs/passive-candidate-assets.spec.mjs
@@ -73,8 +73,8 @@ test("passive candidate assets package every currently safe target and account f
         });
         assertBlocked(publicManifest);
         assertBlocked(engineeringManifest);
-        assert.equal(publicManifest.targetIds.length, 34);
-        assert.equal(publicManifest.sourceSkills.length, 34);
+        assert.equal(publicManifest.targetIds.length, 35);
+        assert.equal(publicManifest.sourceSkills.length, 35);
         assert.equal(publicManifest.targetExclusions.length, 3);
         assert.equal(engineeringManifest.targetIds.length, 6);
         assert.equal(engineeringManifest.sourceSkills.length, 6);
@@ -82,7 +82,7 @@ test("passive candidate assets package every currently safe target and account f
         assert.equal(
             publicManifest.targetIds.length +
                 publicManifest.targetExclusions.length,
-            37,
+            38,
         );
         assert.equal(
             engineeringManifest.targetIds.length +
@@ -139,7 +139,7 @@ test("passive candidate assets package every currently safe target and account f
                 (item) => item.componentId,
             ),
         ].sort();
-        assert.equal(skillComponentIds.length, 49);
+        assert.equal(skillComponentIds.length, 50);
         assert.deepEqual(accountedSkillComponentIds, skillComponentIds);
         for (const manifest of [publicManifest, engineeringManifest]) {
             assert.equal(manifest.assets.length, passiveHarnesses.length);
@@ -160,7 +160,7 @@ test("passive candidate assets package every currently safe target and account f
             assert.equal(coverage.componentCount, 138);
             assert.equal(
                 coverage.byDisposition["skill-packaged-candidate"],
-                40,
+                41,
             );
             assert.equal(coverage.byDisposition["skill-blocked-candidate"], 5);
             assert.equal(
@@ -382,7 +382,7 @@ test("passive candidate workflow is manual read-only and short-lived", () => {
 
 test("candidate component coverage closes every modeled component kind", () => {
     const coverage = buildCandidateComponentCoverage();
-    assert.equal(coverage.componentCount, 137);
+    assert.equal(coverage.componentCount, 138);
     assert.deepEqual(coverage.byKind, {
         agent: 12,
         command: 18,

--- a/tooling/specs/passive-candidate-assets.spec.mjs
+++ b/tooling/specs/passive-candidate-assets.spec.mjs
@@ -157,7 +157,7 @@ test("passive candidate assets package every currently safe target and account f
                     "utf8",
                 ),
             );
-            assert.equal(coverage.componentCount, 137);
+            assert.equal(coverage.componentCount, 138);
             assert.equal(
                 coverage.byDisposition["skill-packaged-candidate"],
                 40,
@@ -391,12 +391,12 @@ test("candidate component coverage closes every modeled component kind", () => {
         instruction: 1,
         prompt: 18,
         rule: 36,
-        skill: 49,
+        skill: 50,
     });
-    assert.equal(coverage.records.length, 137);
+    assert.equal(coverage.records.length, 138);
     assert.equal(
         new Set(coverage.records.map((record) => record.componentId)).size,
-        137,
+        138,
     );
     assert(
         coverage.records

--- a/tooling/specs/profile-subscription.spec.mjs
+++ b/tooling/specs/profile-subscription.spec.mjs
@@ -62,7 +62,7 @@ test("profile catalog and project subscriptions pass", () => {
     const catalog = readJson(
         join(repositoryRoot, "distribution/profile-catalog.json"),
     );
-    assert.equal(catalog.publicProfiles.length, 40);
+    assert.equal(catalog.publicProfiles.length, 41);
     assert.equal(catalog.engineeringProfiles.length, 20);
     assert.equal(catalog.versioning.exactPinsRequired, true);
     assert.equal(catalog.versioning.perProfileVersionStamps, true);

--- a/tooling/specs/resolve-profiles.spec.mjs
+++ b/tooling/specs/resolve-profiles.spec.mjs
@@ -342,3 +342,37 @@ test("language profiles are composable units that imply no product", () => {
         );
     }
 });
+
+test("the governed release methodology profile carries no product or language", () => {
+    // Release methodology is reusable in any repository, so selecting it must
+    // never drag in Arc, Chronicle, or a language profile the way a product
+    // profile would.
+    const profileId = "public-methodology-governed-releases";
+    const targetId = "cratis-governed-release-methodology";
+    const profileCatalog = readJson("distribution/profile-catalog.json");
+    const profile = profileCatalog.publicProfiles.find(
+        (entry) => entry.id === profileId,
+    );
+    assert(profile, profileId);
+    assert.deepEqual(profile.products, []);
+    assert.deepEqual(profile.languages, []);
+    assert.deepEqual(profile.composes ?? [], []);
+    const manifest = resolveProfiles({ profileCatalog, requested: [profileId] });
+    assert.deepEqual(
+        manifest.profiles.map((entry) => entry.id),
+        [profileId],
+    );
+    assert.deepEqual(manifest.skills, [
+        { id: targetId, includedBy: [profileId] },
+    ]);
+    assert.deepEqual(manifest.mcpServers, []);
+    assert.deepEqual(manifest.rejected, []);
+    assert.deepEqual(resolveTargetsByProfile(profileCatalog).get(profileId), [
+        targetId,
+    ]);
+    const skill = readFileSync(
+        join(repositoryRoot, `skills/${targetId}/SKILL.md`),
+        "utf8",
+    );
+    assert.match(skill, new RegExp(`^name: ${targetId}$`, "mu"));
+});

--- a/tooling/specs/support-validation.spec.mjs
+++ b/tooling/specs/support-validation.spec.mjs
@@ -151,9 +151,9 @@ test("all authored evidence and support policy schemas reject unknown properties
     }
 });
 
-test("all 163 observations, 172 fact IDs, 11 legacy gaps, 108 official sources, and 23 distribution evidence files are accounted exactly", () => {
+test("all 164 observations, 172 fact IDs, 11 legacy gaps, 108 official sources, and 23 distribution evidence files are accounted exactly", () => {
     const catalogs = loadSupportCatalogs();
-    assert.equal(catalogs.evidence.observations.length, 163);
+    assert.equal(catalogs.evidence.observations.length, 164);
     assert.equal(catalogs.evidence.legacyFacts.length, 172);
     assert.equal(catalogs.evidence.legacyGaps.length, 11);
     assert.equal(


### PR DESCRIPTION
The repository maintainer's direction after #266: release governance (semver labeling, evidence-based approval, tiered assurance, when checksums/provenance/SBOM actually matter, canary-before-promotion, recovery disposition) is real, reusable release-engineering knowledge — it was just wrongly built as infrastructure specific to distributing this repo's own markdown. This extracts the genuine methodology into a real, product- and language-independent profile any Cratis repo publishing compiled artifacts (NuGet, npm, containers) can install.

Deliberately additive: the underlying S10 assurance-lane data model (`distribution/s10-release-policy.json`, `assurance-lanes.json`, etc.) is investigated in depth but **not touched** — it turned out to be load-bearing for the basic validation lane every PR goes through and for the still-live `release-passive-previews.yml` npm publish, not dead code as assumed. A full dependency map is in this PR's implementation notes for whoever takes on retiring the genuinely-dead pieces next.

## Added

- `skills/cratis-governed-release-methodology/SKILL.md`: real, actionable release-engineering methodology — picking an assurance tier before picking checks, what each supply-chain receipt (checksums/provenance/SBOM/canary/recovery) actually proves and for which artifact types, the eight-rung evidence ladder, the ten lifecycle phases a real install cycle must cover, semver release-intent labeling, and a non-circular release-path structure where no step can vouch for itself
- `profiles/public/public-methodology-governed-releases.json`: a standalone leaf profile (composes nothing, is composed by nothing — same deliberate decoupling as the language profiles) so selecting it never implies a specific product or language
- A resolver regression spec asserting the profile pulls in exactly its one skill and nothing else

## Changed

- `catalog/v2/repository-inventory.json` and related generated catalogs regenerated for the new skill and source (46 sources, up from 45)
- `distribution/public-evaluation-eligibility.json`: the new skill is explicitly excluded from marketplace eligibility pending effect assessment — the same disposition an existing skill (`cratis-chronicle-reactor`) already has — not force-approved