### PR TITLE
Read evidence expiry through the supersession chain

### DIFF
--- a/catalog/generated/human-catalog/catalog.json
+++ b/catalog/generated/human-catalog/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractVersion": 1,
   "disclaimer": "Catalog inclusion, evaluation evidence, component modeling, planned projection, bundle generation, or publication does not grant runtime permission, emitted bytes, support, or approval.",
-  "inputDigest": "0da7c5a76c75b905f37c2f4676465435b28e32d00665c239ba7aa22bbb26b388",
+  "inputDigest": "b34b3987f1e0e6ff58ef73706ff76bf3605a40c35268118e9e309bf21103b756",
   "componentSummary": {
     "disclaimer": "Modeled or planned components and projections are catalog metadata only; they are not emitted, supported, installable, published, promoted, or runtime eligible.",
     "total": 137,

--- a/catalog/generated/human-catalog/manifest.json
+++ b/catalog/generated/human-catalog/manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "contractVersion": 1,
-  "inputDigest": "0da7c5a76c75b905f37c2f4676465435b28e32d00665c239ba7aa22bbb26b388",
+  "inputDigest": "b34b3987f1e0e6ff58ef73706ff76bf3605a40c35268118e9e309bf21103b756",
   "files": [
     {
       "path": "CATALOG.md",
@@ -11,7 +11,7 @@
     {
       "path": "catalog.json",
       "size": 162756,
-      "sha256": "7e44c783a98098cd6e25ed3b63aa197a0144e26b574ac3ecacf4869cb22ca49c"
+      "sha256": "f5e65919763d916edf845f1fe8025961d302c55e16a965b78d81433cfc2b4e28"
     }
   ]
 }

--- a/catalog/schemas/v2/catalog-v2.schema.json
+++ b/catalog/schemas/v2/catalog-v2.schema.json
@@ -1409,6 +1409,7 @@
         "expiresOn": { "type": "string", "format": "date" },
         "applicableVersion": { "$ref": "#/$defs/nonEmptyString" },
         "confidence": { "enum": ["low", "medium", "high"] },
+        "supersedes": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "$ref": "#/$defs/id" } },
         "immutableRevision": { "$ref": "#/$defs/nonEmptyString" },
         "repositoryPath": { "$ref": "#/$defs/path" },
         "digest": { "type": "string", "pattern": "^[a-f0-9]{64}$" }

--- a/catalog/v2/evidence.json
+++ b/catalog/v2/evidence.json
@@ -276,6 +276,9 @@
       "expiresOn": "2027-09-02",
       "applicableVersion": "68616b143aeffaeda333553bb4c491f696a0018a",
       "confidence": "high",
+      "supersedes": [
+        "cratis-chronicle-multi-tenancy-source-fbf7602"
+      ],
       "immutableRevision": "68616b143aeffaeda333553bb4c491f696a0018a"
     },
     {
@@ -1092,6 +1095,9 @@
       "expiresOn": "2027-09-02",
       "applicableVersion": "c2f721c2f80321cfba352d8d2e4209a0881ccb63",
       "confidence": "high",
+      "supersedes": [
+        "public-skill-reference-closure-30c813c"
+      ],
       "immutableRevision": "c2f721c2f80321cfba352d8d2e4209a0881ccb63"
     },
     {
@@ -1140,6 +1146,9 @@
       "expiresOn": "2026-12-05",
       "applicableVersion": "authority-reobservation-2026-09-06",
       "confidence": "medium",
+      "supersedes": [
+        "reevaluation-authority"
+      ],
       "repositoryPath": "distribution/evidence/authority-reobservation-2026-09-06.json",
       "digest": "83635d802a9179c921fa803987f4b447ceb921c3778db7601864c8875d530f50"
     },
@@ -1571,6 +1580,9 @@
       "expiresOn": "2026-12-05",
       "applicableVersion": "issue-state-2026-09-06",
       "confidence": "high",
+      "supersedes": [
+        "workflows-68"
+      ],
       "repositoryPath": "distribution/evidence/authority-reobservation-2026-09-06.json",
       "digest": "83635d802a9179c921fa803987f4b447ceb921c3778db7601864c8875d530f50"
     },

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "e741710f128856516efd6ba1acace014599aa0dec22f05720e584bcde568804a",
+  "indexDigest": "7d7d2fa32c21ed0a6af9b8a5891e933c8f2067bb07e1eb49f4dda2587cb5679e",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -2779,6 +2779,10 @@
       "status": "added"
     },
     {
+      "path": "tooling/evidence-supersession.mjs",
+      "status": "added"
+    },
+    {
       "path": "tooling/fixtures/portable-compliance/all-skill-options/plugin.json",
       "status": "added"
     },
@@ -5031,8 +5035,8 @@
       "evidenceIds": [
         "reevaluation-authority"
       ],
-      "expectedPathCount": 80,
-      "expectedPathsDigest": "c0bf5fead4ca823f0d28f18e80333ade4b838c5047d950bfc6562eaddcfaf58d"
+      "expectedPathCount": 81,
+      "expectedPathsDigest": "d7d9ffb363bd54b6cc52a7caf5c79018a98df01811c029fb7337ec014f3b8487"
     },
     {
       "excludePathPatterns": [],

--- a/tooling/catalog-v2-validation.mjs
+++ b/tooling/catalog-v2-validation.mjs
@@ -22,6 +22,7 @@ import {
     regularFiles,
     validateComponentCatalogs,
 } from "./component-catalog-validation.mjs";
+import { supersededEvidenceIds } from "./evidence-supersession.mjs";
 
 export const v2CatalogPaths = {
     sources: "catalog/v2/sources.json",
@@ -948,8 +949,21 @@ export function validateEvidenceAndCoverage(
         "ecosystem facts",
         catalogs.evidence.ecosystemFacts.map((fact) => fact.id),
     );
+    const supersededIds = supersededEvidenceIds(
+        catalogs.evidence.evidence,
+        catalogs.evidence.asOf,
+    );
     for (const evidence of catalogs.evidence.evidence) {
-        if (evidence.expiresOn < catalogs.evidence.asOf)
+        for (const supersededId of evidence.supersedes ?? []) {
+            if (!evidenceIds.has(supersededId))
+                errors.push(
+                    `${evidence.id}: unknown superseded evidence ${supersededId}`,
+                );
+        }
+        if (
+            evidence.expiresOn < catalogs.evidence.asOf &&
+            !supersededIds.has(evidence.id)
+        )
             errors.push(
                 `${evidence.id}: evidence expired before the catalog as-of date`,
             );

--- a/tooling/evidence-supersession.mjs
+++ b/tooling/evidence-supersession.mjs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// The evidence catalog is append-only: an observation is never edited or deleted, so renewing one means
+// appending a new observation whose `supersedes` names the observation it replaces. The replaced observation
+// stays in the catalog as history, which means its own `expiresOn` keeps moving into the past forever. Expiry
+// therefore has to be read through the supersession chain rather than record by record: once a live replacement
+// covers an observation, that observation's expiry stops gating anything, exactly as `assertionsForBinding` in
+// tooling/support-validation.mjs already demotes an observation that an active observation supersedes.
+
+function isLive(record, asOf) {
+    return record.verifiedOn <= asOf && asOf <= record.expiresOn;
+}
+
+// Ids of the evidence records that a live replacement covers, directly or through a chain of renewals, and whose
+// own expiry is consequently historical. Records without a replacement, and records whose whole replacement chain
+// has itself expired or is not yet in force, are absent so that they keep gating.
+export function supersededEvidenceIds(records, asOf) {
+    const recordsById = new Map(records.map((record) => [record.id, record]));
+    const replacementIdsById = new Map();
+    for (const record of records) {
+        for (const supersededId of record.supersedes ?? []) {
+            replacementIdsById.set(supersededId, [
+                ...(replacementIdsById.get(supersededId) ?? []),
+                record.id,
+            ]);
+        }
+    }
+    function coveredByLiveReplacement(id, visited) {
+        for (const replacementId of replacementIdsById.get(id) ?? []) {
+            if (visited.has(replacementId)) continue;
+            visited.add(replacementId);
+            const replacement = recordsById.get(replacementId);
+            if (!replacement) continue;
+            if (isLive(replacement, asOf)) return true;
+            if (coveredByLiveReplacement(replacementId, visited)) return true;
+        }
+        return false;
+    }
+    return new Set(
+        [...replacementIdsById.keys()].filter((id) =>
+            coveredByLiveReplacement(id, new Set([id])),
+        ),
+    );
+}

--- a/tooling/generate-catalog-v2.mjs
+++ b/tooling/generate-catalog-v2.mjs
@@ -13,7 +13,7 @@ import {
 } from "node:fs";
 import { join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { compareOrdinal } from "./catalog-ordering.mjs";
+import { compareOrdinal, sortedOrdinal } from "./catalog-ordering.mjs";
 import { readCatalog } from "./catalog-validation.mjs";
 import { artifactForbiddenPathPatterns } from "./harness-registry.mjs";
 import { generateComponentCatalogs } from "./generate-component-catalogs.mjs";
@@ -1754,6 +1754,9 @@ const evidence = normalizedEvidence.observations.map((observation) => {
         expiresOn: observation.validThrough,
         applicableVersion: observation.legacy.applicableVersion,
         confidence: observation.confidence,
+        ...(observation.supersedes.length > 0
+            ? { supersedes: sortedOrdinal(observation.supersedes) }
+            : {}),
         ...(source.immutableRevision
             ? { immutableRevision: source.immutableRevision }
             : {}),

--- a/tooling/specs/catalog-v2-validation.spec.mjs
+++ b/tooling/specs/catalog-v2-validation.spec.mjs
@@ -823,6 +823,104 @@ test("stale and future-dated evidence fail and unsupported local facts remain ex
     assert(errors.some((error) => error.includes("verified after")));
 });
 
+// Evidence is append-only, so renewing an observation appends a replacement that names it in `supersedes` while
+// the replaced observation stays in the catalog forever with an `expiresOn` that keeps receding into the past.
+// These cover the resulting expiry semantics: history stops gating for exactly as long as a live renewal covers it.
+function renewalOf(record, id, verifiedOn, expiresOn) {
+    return {
+        id,
+        officialUrl: record.officialUrl,
+        sourceKind: record.sourceKind,
+        verifiedOn,
+        expiresOn,
+        applicableVersion: record.applicableVersion,
+        confidence: record.confidence,
+        supersedes: [record.id],
+    };
+}
+
+test("a live renewal retires the expiry of the observation it supersedes", () => {
+    const catalogs = loadCatalogs();
+    const original = catalogs.evidence.evidence[0];
+    original.expiresOn = daysFromAsOf(catalogs, -1);
+    assert(
+        validateEvidenceAndCoverage(catalogs).includes(
+            `${original.id}: evidence expired before the catalog as-of date`,
+        ),
+    );
+    catalogs.evidence.evidence.push(
+        renewalOf(
+            original,
+            `${original.id}-renewal`,
+            daysFromAsOf(catalogs, -1),
+            daysFromAsOf(catalogs, 30),
+        ),
+    );
+    assert.deepEqual(validateEvidenceAndCoverage(catalogs), []);
+});
+
+test("expiry gates again once an entire renewal chain has lapsed", () => {
+    const catalogs = loadCatalogs();
+    const original = catalogs.evidence.evidence[0];
+    original.expiresOn = daysFromAsOf(catalogs, -20);
+    const lapsed = renewalOf(
+        original,
+        `${original.id}-renewal`,
+        daysFromAsOf(catalogs, -20),
+        daysFromAsOf(catalogs, -1),
+    );
+    catalogs.evidence.evidence.push(lapsed);
+    const errors = validateEvidenceAndCoverage(catalogs);
+    assert(
+        errors.includes(
+            `${original.id}: evidence expired before the catalog as-of date`,
+        ),
+    );
+    assert(
+        errors.includes(
+            `${lapsed.id}: evidence expired before the catalog as-of date`,
+        ),
+    );
+    catalogs.evidence.evidence.push(
+        renewalOf(
+            lapsed,
+            `${original.id}-renewal-2`,
+            daysFromAsOf(catalogs, -1),
+            daysFromAsOf(catalogs, 30),
+        ),
+    );
+    assert.deepEqual(validateEvidenceAndCoverage(catalogs), []);
+});
+
+test("evidence cannot supersede an observation the catalog does not carry", () => {
+    const catalogs = loadCatalogs();
+    const evidence = catalogs.evidence.evidence[0];
+    evidence.supersedes = ["missing-evidence"];
+    assert(
+        validateEvidenceAndCoverage(catalogs).includes(
+            `${evidence.id}: unknown superseded evidence missing-evidence`,
+        ),
+    );
+});
+
+test("the v2 evidence projection carries the normalized supersession relation", () => {
+    const normalized = readCatalog(
+        join(defaultRepositoryRoot, "catalog/evidence.json"),
+    );
+    const expected = Object.fromEntries(
+        normalized.observations
+            .filter((observation) => observation.supersedes.length > 0)
+            .map((observation) => [observation.id, [...observation.supersedes]]),
+    );
+    const projected = Object.fromEntries(
+        readCatalog(join(defaultRepositoryRoot, v2CatalogPaths.evidence))
+            .evidence.filter((evidence) => evidence.supersedes)
+            .map((evidence) => [evidence.id, evidence.supersedes]),
+    );
+    assert(Object.keys(expected).length > 0);
+    assert.deepEqual(projected, expected);
+});
+
 test("aggregate validation propagates its repository root to evidence checks", () => {
     const source = readFileSync(
         join(defaultRepositoryRoot, "tooling/catalog-v2-validation.mjs"),


### PR DESCRIPTION
# Summary

Evidence is append-only, so renewing an observation appends a replacement and leaves the replaced observation in the catalog forever with an `expiresOn` that keeps receding into the past. The catalog v2 gate read every projected record's expiry flat, so a renewed observation kept gating on its own dead date — the gap #269 left open. Expiry is now read through the supersession chain, which is the mechanism every future renewal needs, not a fix for two ids.

## Added

- `supersedes` on the records in `catalog/v2/evidence.json`, projecting the normalized supersession relation the gate needs (#253)

## Fixed

- A superseded observation no longer fails the catalog gate on its own expiry for as long as a live replacement covers it, directly or through a chain of renewals; with the as-of date advanced to 2026-09-20 the basic lane goes from two errors to green (#253)
- Once an entire renewal chain has lapsed, every record in it gates again, so renewal cannot be used to retire evidence permanently (#253)

---

### The gap this closes

`tooling/generate-catalog-v2.mjs` maps every observation into `catalog/v2/evidence.json`, superseded ones included, and `validateEvidenceAndCoverage` compared each record's `expiresOn` against the catalog as-of date with no supersession awareness. `reevaluation-authority-2026-09-06` and `workflows-68-2026-09-06` are valid through 2026-12-05, but the observations they supersede still failed on their own 2026-09-19 dates.

Reproduced end to end on a scratch clone with the as-of date advanced to 2026-09-20 in `catalog/evidence.json`, `catalog/support-policy.json`, `catalog/v2/ecosystem-contracts.json` and `catalog/ecosystem-versions.json`, regenerating the catalogs and running `node tooling/validate-catalogs.mjs --basic`:

```
before (ab1fe04)  Catalog validation failed with 2 error(s):
                  - reevaluation-authority: evidence expired before the catalog as-of date
                  - workflows-68: evidence expired before the catalog as-of date
after             Basic catalog validation passed
```

At the repository's real as-of date of 2026-09-06 the gate stays green, and the repository's own as-of date is unchanged by this pull request.

### Why supersession awareness rather than repointing the citations

`reevaluation-authority` is cited by name in roughly 50 places across `tooling/generate-catalog-v2.mjs` and `tooling/generate-repository-inventory.mjs`, so repointing generated `evidenceIds` at each renewal is per-renewal manual work that would have to be repeated for all 135 observations expiring in November. Exempting superseded evidence is the general rule, and it is the rule this repository already applies elsewhere: `assertionsForBinding` in `tooling/support-validation.mjs` demotes an observation that an active observation supersedes. The new `tooling/evidence-supersession.mjs` states that rule once, resolves it transitively so a renewal of a renewal still covers the original, and is importable by any other gate that later needs it.

### What still gates

Coverage is checked as-of, not forever: a superseded record is exempt only while a live replacement covers it. A replacement that is expired or not yet in force covers nothing, so a chain that has entirely lapsed fails again, naming every record in it. At an as-of date of 2026-12-06, after the renewals themselves expire, all four records in these two chains gate again.

### November cliff not touched

The 68 observations expiring 2026-11-18 and the 67 expiring 2026-11-23 are deliberately untouched; this pull request only makes the mechanism supersession-aware so that renewal pass is safe. One thing that pass will still need on top of this: `tooling/component-catalog-validation.mjs` separately rejects a *citation* of expired evidence, and seven ids cited by `catalog/v2/component-projections.json` expire in November, so those citations will have to be repointed at their renewals or that gate made supersession-aware too.

### Validation

All green: `validate-ai-setup.sh`, every generator, `git diff --exit-code` on the generated artifacts, `portable-compliance-validation --verify-lock`, `release-assurance-validation`, `validate-catalogs --basic`, `run-spec-suite --basic` (488 passed, 0 failed, 11 skipped) and `run-spec-suite --governed` (554 passed, 0 failed, 11 skipped). Support tiers are unchanged: `documented=24`, `statically-validated=21`, `support=0`.
