### PR TITLE
Make merged-branch deletion the standard final ship step

### DIFF
--- a/.ai/skills/ship-changes/SKILL.md
+++ b/.ai/skills/ship-changes/SKILL.md
@@ -3,7 +3,8 @@ name: ship-changes
 description: >
   Use when asked to commit, push, create a PR, ship, or land changes. Stop at
   the requested verb; separately authorize merge, publication, issue effects,
-  label mutations, and branch deletion. Preserve history and explicit staging.
+  and label mutations. Deleting the merged PR branch is the standard final
+  step. Preserve history and explicit staging.
 
 ---
 
@@ -21,7 +22,18 @@ The requested verb is the stopping point, not permission for the whole workflow:
 - **PR-only:** prepare/open the requested PR and report required checks; stop before merge.
 - **Ship/land:** clarify the exact intended endpoint and effects. These words alone do not authorize destructive or notification-bearing effects.
 
-Merge, issue comments or closure, label mutations (especially labels that trigger publication/releases), publication, and local or remote branch deletion each require separate explicit authorization for exact targets and effects. Apply the repository's current mutation protocol and stricter local/private gates; tool access and inverse escrow alone supply no authority. For destructive/bulk effects, prepare an exact dry-run, capture pre-state and deterministic inverse escrow in ignored `.ai-work/`, obtain approval, recheck preconditions, and record/read back outcomes through the approved repository-owned adapter. If a required adapter, safe inverse/compensation, or authorization is missing, stop. Preserve any stricter prohibition below.
+Merge, issue comments or closure, label mutations (especially labels that
+trigger publication/releases), and publication each require separate explicit
+authorization for exact targets and effects. Deleting the PR branch after a
+verified successful merge is the one standard cleanup step (step 10) and needs
+no separate authorization. Apply the repository's current mutation protocol and
+stricter local/private gates; tool access and inverse escrow alone supply no
+authority. For destructive/bulk effects, prepare an exact dry-run, capture
+pre-state and deterministic inverse escrow in ignored `.ai-work/`, obtain
+approval, recheck preconditions, and record/read back outcomes through the
+approved repository-owned adapter. If a required adapter, safe
+inverse/compensation, or authorization is missing, stop. Preserve any stricter
+prohibition below.
 
 Never rewrite history: no amend, rebase, squash merge, hard reset, force-push, or forced branch deletion. Use new commits, revert, cherry-pick, and merge instead. A request to ship does not override this prohibition.
 
@@ -260,15 +272,34 @@ separate public repo (check canonical `.cratis/PROJECT.md`; `.agents/PROJECT.md`
   comment or closure stays behind the owning tracker repository's exact effect
   policy.
 
-## Step 10 — Clean up the branch
+## Step 10 — Delete the merged branch
 
-Branch deletion is optional, not completion criteria. Only after a verified merge
-and separate explicit authorization for each exact local/remote ref may cleanup
-proceed through the repository’s mutation protocol. Capture pre-state and inverse
-escrow, recheck refs immediately before each action, and read back each outcome.
-Do not batch checkout, pull, and deletion into one unreviewed command. Use only
-`git branch -d`, never `-D`; stop if it refuses or any ref/precondition drifts.
-Leave branches intact and report pending cleanup when authorization is absent.
+After a verified successful merge, deleting the PR branch — locally and on the
+remote — is the standard final step of the ship flow. It requires no separate
+authorization, because a true merge commit keeps every branch commit reachable
+from `main`; nothing is lost.
+
+Verify the merge before deleting anything, then delete remote first, local
+second:
+
+```bash
+git fetch origin
+git merge-base --is-ancestor <branch-name> origin/main   # must exit 0
+git push origin --delete <branch-name>
+git branch -d <branch-name>
+```
+
+Rules:
+
+- Safe deletion only. `git branch -d` refuses to delete an unmerged branch —
+  if it refuses, that is a stop-and-report signal, never a reason to reach for
+  `-D`. Never force-delete the remote ref either.
+- Delete only after verification, and recheck the ref immediately before each
+  action; if any precondition drifts, stop and report.
+- Nothing is deleted at the earlier stopping points: commit-only, push-only, and
+  PR-only endpoints leave the branch in place.
+- If the remote branch was already removed (some hosts delete it on merge),
+  delete the local branch and note the remote was already gone.
 
 ## Full example sequence
 
@@ -287,11 +318,17 @@ git push -u origin <authorized-branch>
 # Only when PR creation was requested: use the reviewed template/body.
 gh pr create --base main --head <authorized-branch> --body-file <reviewed-body-path>
 # STOP before merge for PR-only. Report relevant required checks.
+
+# After a separately authorized merge: step 10 deletes the merged branch.
+git fetch origin
+git merge-base --is-ancestor <authorized-branch> origin/main
+git push origin --delete <authorized-branch>
+git branch -d <authorized-branch>
 ```
 
-A release-intent label, merge, issue comment/closure, or branch deletion is not an
-implied next command. First obtain separate explicit authorization for the exact
-effect and satisfy the authorization, current workflow, and mutation gates above.
+A release-intent label, merge, or issue effect is not an implied next command.
+Deleting the merged branch after a verified merge is the one standard step 10
+cleanup; every other effect waits for its own authorization.
 
 ## Common mistakes to avoid
 
@@ -302,4 +339,4 @@ effect and satisfy the authorization, current workflow, and mutation gates above
 - **Never push directly to `main`** — always go through the branch + PR flow.
 - **Never assume issue-effect authority** — prepare the exact post-merge disposition in step 9; an owning repository adapter and operation profile must authorize any later comment or closure.
 - **Never put `Closes #N` / `Fixes #N` in the PR body** — the release notes are the body verbatim.
-- **Never delete branches automatically** — leave local/remote refs intact unless their exact deletion is separately authorized after verified merge.
+- **Never force-delete a branch** — after a verified merge, delete the PR branch with safe deletion (`git branch -d`, `git push origin --delete`); if a deletion refuses, stop and report instead of reaching for `-D`.

--- a/catalog/components.json
+++ b/catalog/components.json
@@ -6092,12 +6092,12 @@
       "canonicalSources": [
         {
           "path": ".ai/skills/ship-changes",
-          "digest": "d707392ab648aec8d114e7941a85293bf302c2435d1d19fb7e270765abc6c2a0",
+          "digest": "def7578f965cc989967df312274324c591b7ca88c5ee98d7293f53e011a7dd0a",
           "ownership": "owner",
           "ownerComponentId": "cratis-engineering-ship-changes"
         }
       ],
-      "contentDigest": "4ef4b530bf18dd8ab2effdd195a318f3ab71fc4f5f1b7ed5487bc018dc6b3e12",
+      "contentDigest": "3de6c3d451c9abf8612cee6e62b71464ab84b9f401dd1a0bf1b9b59167043d45",
       "owner": "reusable Cratis engineering behavior",
       "audience": "cratis-engineering",
       "classification": {

--- a/catalog/ecosystem-versions.json
+++ b/catalog/ecosystem-versions.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "verifiedOn": "2026-09-08",
+  "verifiedOn": "2026-09-09",
   "policy": "official-sources-only",
   "ecosystems": [
     {

--- a/catalog/evidence.json
+++ b/catalog/evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "asOf": "2026-09-08",
+  "asOf": "2026-09-09",
   "defaultPolicy": "deny",
   "sources": [
     {
@@ -123,6 +123,13 @@
       "locator": "https://github.com/Cratis/AI/tree/f5f215fee9ba5ad95ea5b4d512d5730229dda49d/.ai/skills/ship-changes",
       "immutableRevision": "f5f215fee9ba5ad95ea5b4d512d5730229dda49d",
       "digest": "d707392ab648aec8d114e7941a85293bf302c2435d1d19fb7e270765abc6c2a0"
+    },
+    {
+      "id": "source-engineering-ship-changes-merged-branch-cleanup-c29984a",
+      "kind": "repository-snapshot",
+      "locator": "https://github.com/Cratis/AI/tree/c29984acd8d55ca61b1bc3e918ef11627db8b06d/.ai/skills/ship-changes",
+      "immutableRevision": "c29984acd8d55ca61b1bc3e918ef11627db8b06d",
+      "digest": "def7578f965cc989967df312274324c591b7ca88c5ee98d7293f53e011a7dd0a"
     },
     {
       "id": "source-chronicle-event-type-migrations-value-map-source-ed28ee6",
@@ -1617,6 +1624,46 @@
         "officialUrl": "https://github.com/Cratis/AI/tree/f5f215fee9ba5ad95ea5b4d512d5730229dda49d/.ai/skills/ship-changes",
         "sourceKind": "repository-snapshot",
         "applicableVersion": "f5f215fee9ba5ad95ea5b4d512d5730229dda49d"
+      }
+    },
+    {
+      "id": "engineering-ship-changes-merged-branch-cleanup-c29984a",
+      "sourceId": "source-engineering-ship-changes-merged-branch-cleanup-c29984a",
+      "evidenceClass": "local",
+      "subject": {
+        "kind": "target",
+        "id": "cratis-engineering-ship-changes",
+        "version": "c29984acd8d55ca61b1bc3e918ef11627db8b06d",
+        "digest": "def7578f965cc989967df312274324c591b7ca88c5ee98d7293f53e011a7dd0a"
+      },
+      "bindingIds": [],
+      "assertions": [
+        {
+          "assuranceId": "source-provenance",
+          "outcome": "pass",
+          "supporting": true,
+          "claimIds": []
+        }
+      ],
+      "scope": "Compared the exact bundled ship-changes paths and bytes in the local publication worktree with immutable commit c29984acd8d55ca61b1bc3e918ef11627db8b06d, and recomputed the catalog content digest. Source provenance only.",
+      "environment": {
+        "operatingSystem": "not-recorded",
+        "architecture": "not-recorded",
+        "isolation": "not-recorded"
+      },
+      "observedOn": "2026-09-09",
+      "validThrough": "2027-09-09",
+      "confidence": "high",
+      "limitations": [
+        "Local source inspection only; this is not hosted or consumer execution evidence.",
+        "The synchronized catalog snapshot advances for this source record; existing per-source verification dates and external facts are unchanged and were not reverified by this observation.",
+        "No installation, behavioral, release-readiness, or publication approval is granted."
+      ],
+      "supersedes": [],
+      "legacy": {
+        "officialUrl": "https://github.com/Cratis/AI/tree/c29984acd8d55ca61b1bc3e918ef11627db8b06d/.ai/skills/ship-changes",
+        "sourceKind": "repository-snapshot",
+        "applicableVersion": "c29984acd8d55ca61b1bc3e918ef11627db8b06d"
       }
     },
     {

--- a/catalog/generated/human-catalog/CATALOG.md
+++ b/catalog/generated/human-catalog/CATALOG.md
@@ -55,7 +55,7 @@ Modeled or planned components and projections are catalog metadata only; they ar
 
 ## Computed ecosystem support
 
-As of 2026-09-08, technical tiers are computed from active normalized evidence; expired and future evidence cannot satisfy gates. Marketplace listing is orthogonal.
+As of 2026-09-09, technical tiers are computed from active normalized evidence; expired and future evidence cannot satisfy gates. Marketplace listing is orthogonal.
 
 - unsupported: 0
 - documented: 24

--- a/catalog/generated/human-catalog/catalog.json
+++ b/catalog/generated/human-catalog/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractVersion": 1,
   "disclaimer": "Catalog inclusion, evaluation evidence, component modeling, planned projection, bundle generation, or publication does not grant runtime permission, emitted bytes, support, or approval.",
-  "inputDigest": "426272f4007a6f3ea2dcef0c4c292d2f8ea7bac098b7671cd450c15b9b2f4ae0",
+  "inputDigest": "5aa5288950d0963d33c00c87bdc5daab3eb36dd74eecf10fa5701fb7e0eb5078",
   "componentSummary": {
     "disclaimer": "Modeled or planned components and projections are catalog metadata only; they are not emitted, supported, installable, published, promoted, or runtime eligible.",
     "total": 193,

--- a/catalog/generated/human-catalog/manifest.json
+++ b/catalog/generated/human-catalog/manifest.json
@@ -1,17 +1,17 @@
 {
   "schemaVersion": 2,
   "contractVersion": 1,
-  "inputDigest": "426272f4007a6f3ea2dcef0c4c292d2f8ea7bac098b7671cd450c15b9b2f4ae0",
+  "inputDigest": "5aa5288950d0963d33c00c87bdc5daab3eb36dd74eecf10fa5701fb7e0eb5078",
   "files": [
     {
       "path": "CATALOG.md",
       "size": 198497,
-      "sha256": "f214578ec75505c217a3a46ecd045482fb64c09c2e663fd5ee36ba2fd42ef1ac"
+      "sha256": "d1d85571146dd3082fc06ef5276dc008176f4a3804ad5809c2a728f572405347"
     },
     {
       "path": "catalog.json",
       "size": 258899,
-      "sha256": "15ee430f066fa1977085e5ee0e0ce99a0d8581810ff734c9ae27898c3696f31e"
+      "sha256": "a798966f3b8beccbaf70684fdbe28f35a996544e7dae2d174462cf9c4e527edf"
     }
   ]
 }

--- a/catalog/support-policy.json
+++ b/catalog/support-policy.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "asOf": "2026-09-08",
+  "asOf": "2026-09-09",
   "defaultPolicy": "deny",
   "evidenceClasses": [
     "synthetic-fixture",

--- a/catalog/v2/components.json
+++ b/catalog/v2/components.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "generatedBy": "tooling/generate-component-catalogs.mjs",
-  "sourceDigest": "e1a534db8c663796410dc550db49a29dd59c4f1c80913d7d4901ebce7c3370c0",
+  "sourceDigest": "40e153ad987017258937d08e691d05ec6d4e3b2f55b86a57ab7b8c7ad8446790",
   "defaultPolicy": "deny",
   "canonicalSourceRoots": [
     ".ai/agents",
@@ -6094,12 +6094,12 @@
       "canonicalSources": [
         {
           "path": ".ai/skills/ship-changes",
-          "digest": "d707392ab648aec8d114e7941a85293bf302c2435d1d19fb7e270765abc6c2a0",
+          "digest": "def7578f965cc989967df312274324c591b7ca88c5ee98d7293f53e011a7dd0a",
           "ownership": "owner",
           "ownerComponentId": "cratis-engineering-ship-changes"
         }
       ],
-      "contentDigest": "4ef4b530bf18dd8ab2effdd195a318f3ab71fc4f5f1b7ed5487bc018dc6b3e12",
+      "contentDigest": "3de6c3d451c9abf8612cee6e62b71464ab84b9f401dd1a0bf1b9b59167043d45",
       "owner": "reusable Cratis engineering behavior",
       "audience": "cratis-engineering",
       "classification": {

--- a/catalog/v2/ecosystem-contracts.json
+++ b/catalog/v2/ecosystem-contracts.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "asOf": "2026-09-08",
+  "asOf": "2026-09-09",
   "defaultPolicy": "deny",
   "ecosystems": [
     {

--- a/catalog/v2/evidence.json
+++ b/catalog/v2/evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "asOf": "2026-09-08",
+  "asOf": "2026-09-09",
   "generatedBy": "tooling/generate-catalog-v2.mjs",
   "evidence": [
     {
@@ -542,6 +542,17 @@
       "applicableVersion": "56e0a3d3b257c61f211eae7300cc08669b90b41d",
       "confidence": "high",
       "immutableRevision": "56e0a3d3b257c61f211eae7300cc08669b90b41d"
+    },
+    {
+      "id": "engineering-ship-changes-merged-branch-cleanup-c29984a",
+      "officialUrl": "https://github.com/Cratis/AI/tree/c29984acd8d55ca61b1bc3e918ef11627db8b06d/.ai/skills/ship-changes",
+      "sourceKind": "repository-snapshot",
+      "verifiedOn": "2026-09-09",
+      "expiresOn": "2027-09-09",
+      "applicableVersion": "c29984acd8d55ca61b1bc3e918ef11627db8b06d",
+      "confidence": "high",
+      "immutableRevision": "c29984acd8d55ca61b1bc3e918ef11627db8b06d",
+      "digest": "def7578f965cc989967df312274324c591b7ca88c5ee98d7293f53e011a7dd0a"
     },
     {
       "id": "engineering-ship-changes-no-effect-source-6b5388d",

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "19de5240ee82e6dd2d87dd3e848512e49f737fcab8fc38ef5f17b5baa2830c3a",
+  "indexDigest": "73774af52f99a9d9a1767090ce3a46768212fbec71ed56bdfa0a8c3f5aa465c1",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "73774af52f99a9d9a1767090ce3a46768212fbec71ed56bdfa0a8c3f5aa465c1",
+  "indexDigest": "fbbb8c963f1c37d2fdb6bc1cb0060a1fb6d00e80233793c857c878f582cb26d6",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/catalog/v2/sources.json
+++ b/catalog/v2/sources.json
@@ -1122,13 +1122,13 @@
         ".ai/skills/ship-changes/SKILL.md",
         ".ai/skills/ship-changes/evals/evals.json"
       ],
-      "sourceRevision": "f5f215fee9ba5ad95ea5b4d512d5730229dda49d",
-      "contentDigest": "d707392ab648aec8d114e7941a85293bf302c2435d1d19fb7e270765abc6c2a0",
+      "sourceRevision": "c29984acd8d55ca61b1bc3e918ef11627db8b06d",
+      "contentDigest": "def7578f965cc989967df312274324c591b7ca88c5ee98d7293f53e011a7dd0a",
       "publicationApproval": false,
       "evidenceIds": [
         "repo-main-b795d53",
         "reevaluation-authority",
-        "engineering-ship-changes-scoped-operations-f5f215f"
+        "engineering-ship-changes-merged-branch-cleanup-c29984a"
       ]
     },
     {

--- a/catalog/v2/support.json
+++ b/catalog/v2/support.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "asOf": "2026-09-08",
+  "asOf": "2026-09-09",
   "generatedBy": "tooling/generate-support.mjs",
   "defaultPolicy": "deny",
   "publicationEligible": false,

--- a/tooling/component-catalog-validation.mjs
+++ b/tooling/component-catalog-validation.mjs
@@ -52,7 +52,7 @@ export const distributionPointerOutputs = new Set([
 ]);
 
 const expectedComponentAnchor =
-    "30323ccaa39916b638898cd53361a26363dc09580f420e6cd09f8a4b9b1ef152";
+    "f7c1e2acc314316148dc3fdc070aea11157683883405c5c88ddaf52f07f4c0f5";
 const expectedProjectionAnchor =
     "b896dcb363e9b52ae5a20985cd2706e730d7569ce93d0ee1755f5c59dadb24b9";
 const expectedProjectionHostAnchor =

--- a/tooling/generate-catalog-v2.mjs
+++ b/tooling/generate-catalog-v2.mjs
@@ -729,8 +729,8 @@ const sourceOverrides = new Map([
         "ship-changes",
         {
             sourcePath: ".ai/skills/ship-changes",
-            sourceRevision: "f5f215fee9ba5ad95ea5b4d512d5730229dda49d",
-            evidenceId: "engineering-ship-changes-scoped-operations-f5f215f",
+            sourceRevision: "c29984acd8d55ca61b1bc3e918ef11627db8b06d",
+            evidenceId: "engineering-ship-changes-merged-branch-cleanup-c29984a",
         },
     ],
     [


### PR DESCRIPTION
## Changed
- Ship-changes step 10 now deletes the merged PR branch as the standard final step: after a verified successful merge, the agent deletes the remote branch and the local branch with safe deletion only — no separate authorization, because a true merge commit keeps every branch commit reachable from `main`. Force deletion stays banned, earlier stopping points (commit-only, push-only, PR-only) delete nothing, and a refusing deletion is a stop-and-report signal.
- The skill's frontmatter and authorization section stop listing branch deletion as a separately authorized mutation, matching what the skill's own evals already expected.
- The source provenance chain (evidence snapshot, catalog as-of, component digests, reviewed semantic anchor) is rebound to the content commit and regenerated.
