### PR TITLE
Adopt the Cratis AI contract

### DIFF
--- a/.cratis/PROJECT.md
+++ b/.cratis/PROJECT.md
@@ -1,0 +1,60 @@
+# Cratis/AI — project context
+
+This repository is the source of the Cratis AI corpus: the skills, profiles,
+catalogs, distribution contracts, and marketplace plugins every other Cratis
+repository consumes. It is a corpus of markdown, JSON, and JavaScript — there
+is no build; correctness is enforced by validators and generated-file checks.
+
+## Layout
+
+| Path | Holds |
+| --- | --- |
+| `skills/` | canonical public skill sources (`<id>/SKILL.md` + references/assets) |
+| `engineering/` | maintainer-audience skill sources, plugin manifests, and `sources-staged/` (migrated general sources awaiting authoring) |
+| `.ai/` | the legacy local corpus this repository still authors and retires skill by skill; other repositories no longer carry a copy |
+| `profiles/` | one JSON file per profile under `profiles/public/` and `profiles/cratis-engineering/` |
+| `catalog/`, `catalog/v2/` | the capability catalog; `v2` files are **generated** by `tooling/generate-catalog-v2.mjs` |
+| `distribution/` | release contracts, the generated `profile-catalog.json`, and the subscription schema |
+| `tooling/` | validators, generators, and `tooling/specs/` (node:test) |
+| `evals/`, `pilots/`, `evidence/` | evaluation and evidence material |
+
+## Commands
+
+```bash
+node tooling/generate-profile-catalog.mjs        # after editing any profile file
+node tooling/generate-catalog-v2.mjs             # after editing catalog sources or evidence
+node tooling/generate-human-catalog.mjs          # regenerates catalog/generated/human-catalog
+node tooling/generate-repository-inventory.mjs   # after adding/removing corpus paths
+node tooling/validate-catalogs.mjs
+node tooling/profile-subscription-validation.mjs
+node --test tooling/specs/<name>.spec.mjs        # run the affected specs; CI runs them all
+```
+
+Generated files stay committed; CI runs the generators and fails on
+`git diff --exit-code`. Never hand-edit `distribution/profile-catalog.json`,
+`catalog/v2/*`, or `catalog/generated/*`.
+
+## Invariants
+
+- Every claim carries an evidence state (authored / generated / evaluated /
+  supported / unavailable); nothing is called supported without evidence.
+- Skills are passive markdown — no hooks, no executable code, no credentials.
+- The `cratis/engineering` subtree is the maintainer channel; compositions
+  never cross audiences. Subscriptions may deliberately mix channels
+  (documentation next to an engineering cell) and then leave `channel` unset.
+- New skill sources follow `Documentation/skill-authoring-contract.md`;
+  `engineering/sources-staged/` holds migrated source material only — it is
+  never projected or served.
+
+## AI-assisted development
+
+`.cratis/ai.json` records this repository's own profile selection
+(`cratis/documentation` + `cratis/engineering/typescript`). The marketplace
+plugins (`cratis@cratis` public, `cratis-engineering@cratis` maintainer) serve
+the skills from this repository's default branch — see the
+[harness guide](https://www.cratis.io/ai/harnesses/) for per-harness install.
+
+Contributors: propose general behavior changes **here** through the authoring
+contract; a consuming repository never edits shared corpus bytes locally.
+Repository-specific facts belong in the owning repository's
+`.cratis/PROJECT.md`, never in a skill.

--- a/.cratis/ai.json
+++ b/.cratis/ai.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.0.0",
+  "version": "1.0.0",
+  "profiles": [
+    "cratis/documentation",
+    "cratis/engineering/typescript"
+  ],
+  "harnesses": [
+    "claude",
+    "codex",
+    "copilot",
+    "cursor",
+    "pi"
+  ],
+  "updatePolicy": "reviewed-pull-request",
+  "projectContext": ".cratis/PROJECT.md"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,6 @@
-.ai/rules/general.md
+# Agents
+
+Read [`.cratis/PROJECT.md`](.cratis/PROJECT.md) before working in this
+repository — it is the canonical project context and the only one: do not
+merge it with any other context file. `.cratis/ai.json` records the Cratis
+profiles this repository subscribes to.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@.cratis/PROJECT.md

--- a/Documentation/adopting-cratis-ai-for-maintainers.md
+++ b/Documentation/adopting-cratis-ai-for-maintainers.md
@@ -9,29 +9,34 @@ review the intended adoption contract.
 
 ## Select shared engineering profiles
 
-Choose the narrowest product/repository profile:
+Choose the narrowest cell for the language(s) the repository actually writes,
+and carry `cratis/documentation` next to it so documentation-writing guidance
+arrives with everything else. A subscription deliberately mixes the public and
+engineering channels in that case and leaves `channel` unset.
 
-| Repository | Shared profile |
+| Repository | Shared profiles |
 | --- | --- |
-| Cratis/Fundamentals | `cratis/engineering` |
-| Cratis/Arc backend | `cratis/engineering` |
-| Arc React packages | `cratis/engineering` |
-| Cratis/Components | `cratis/engineering` |
-| Cratis/Chronicle kernel | `cratis/engineering` |
-| Chronicle client repository | `cratis/engineering` |
-| Cratis/cli | `cratis/engineering` |
-| Cratis/Lens | `cratis/engineering` |
-| Cratis/Screenplay | `cratis/engineering` |
-| Cratis/Stage | `cratis/engineering` |
-| Cratis/Specifications | `cratis/engineering` |
-| Documentation | `cratis/engineering` |
-| Cratis/AI | `cratis/engineering` |
-| Cratis/Workflows | `cratis/engineering` |
-| Private Studio repository | `cratis/engineering` plus local overlay |
-| Private Stagehand repository | `cratis/engineering` plus local overlay |
+| Cratis/Fundamentals | `cratis/engineering/csharp` + `cratis/documentation` |
+| Cratis/Arc backend | `cratis/engineering/csharp` + `cratis/documentation` |
+| Arc React packages | `cratis/engineering/react` + `cratis/documentation` |
+| Cratis/Components | `cratis/engineering/react` + `cratis/engineering/typescript` + `cratis/documentation` |
+| Cratis/Chronicle kernel | `cratis/engineering/csharp` + `cratis/engineering/react` + `cratis/application/csharp` + `cratis/application/react` + `cratis/documentation` |
+| Chronicle client repository | the client's language cell + `cratis/documentation` |
+| Cratis/cli | `cratis/engineering/csharp` + `cratis/documentation` |
+| Cratis/Lens | `cratis/engineering/react` + `cratis/engineering/typescript` + `cratis/documentation` |
+| Cratis/Screenplay | `cratis/engineering/csharp` + `cratis/documentation` |
+| Cratis/Stage | `cratis/engineering/csharp` + `cratis/documentation` |
+| Cratis/Specifications | `cratis/engineering/csharp` + `cratis/documentation` |
+| Documentation | `cratis/engineering/typescript` + `cratis/documentation` |
+| Cratis/AI | `cratis/engineering/typescript` + `cratis/documentation` |
+| Cratis/Workflows | `cratis/engineering/core` + `cratis/documentation` |
+| Private Studio repository | the cells above plus `cratis/application/csharp` and `cratis/application/react`, and a local overlay |
+| Private Stagehand repository | the cells above plus `cratis/application/react` and `cratis/application/csharp`, and a local overlay |
 
-Every engineering profile composes `cratis/engineering`. A generated profile
-artifact contains only approved public-safe skills and references. Browse the
+Every engineering cell composes `cratis/engineering/core`, so the
+decision-record, effect-boundary, and documentation-authoring procedures come
+along regardless. A generated profile artifact contains only approved
+public-safe skills and references. Browse the
 [package and capability catalog](../catalog/generated/human-catalog/CATALOG.md)
 to see each maintainer package, its included skills, and current availability.
 
@@ -45,15 +50,22 @@ to see each maintainer package, its included skills, and current availability.
 6. Run the repository's own build, specification, documentation, security, and
    release gates.
 
-Example Chronicle framework subscription:
+Example Chronicle repository subscription (mixed public and engineering
+channels — note the absent `channel`, which a mixed selection does not
+derive):
 
 ```json
 {
   "schemaVersion": "1.0.0",
-  "channel": "cratis-engineering",
   "version": "1.0.0",
-  "profiles": ["cratis/engineering"],
-  "harnesses": ["claude", "codex", "copilot", "pi"],
+  "profiles": [
+    "cratis/documentation",
+    "cratis/engineering/csharp",
+    "cratis/engineering/react",
+    "cratis/application/csharp",
+    "cratis/application/react"
+  ],
+  "harnesses": ["claude", "codex", "copilot", "cursor", "pi"],
   "updatePolicy": "reviewed-pull-request",
   "projectContext": ".cratis/PROJECT.md"
 }

--- a/Documentation/ai-distribution-and-subscriptions.md
+++ b/Documentation/ai-distribution-and-subscriptions.md
@@ -152,24 +152,30 @@ them, and this page never mixes them.
 ## Repository subscription
 
 A Cratis repository records intent in project-owned `.cratis/ai.json`. The file
-contains no shared rule text; it only selects a channel, exact release, profiles,
-and harnesses.
+contains no shared rule text; it only selects channels, an exact release,
+profiles, and harnesses. A selection from one channel may declare that
+channel; a selection that deliberately mixes the public and engineering
+channels — the standard Cratis-repository shape — leaves `channel` unset
+because it derives no single one.
 
-Chronicle framework example:
+Chronicle repository example (mixed public and engineering):
 
 ```json
 {
   "schemaVersion": "1.0.0",
-  "channel": "cratis-engineering",
   "version": "1.0.0",
-  "profiles": ["cratis/engineering"],
-  "harnesses": ["claude", "codex", "copilot", "pi"],
+  "profiles": [
+    "cratis/documentation",
+    "cratis/engineering/csharp",
+    "cratis/application/csharp"
+  ],
+  "harnesses": ["claude", "codex", "copilot", "cursor", "pi"],
   "updatePolicy": "reviewed-pull-request",
   "projectContext": ".cratis/PROJECT.md"
 }
 ```
 
-Full application example:
+Full public application example:
 
 ```json
 {

--- a/Documentation/concepts.md
+++ b/Documentation/concepts.md
@@ -9,7 +9,7 @@ is just a careful name for something you already know from plugin ecosystems.
 | A skill | **skill** | The same thing: a passive `SKILL.md` (plus references and assets) your assistant loads when a task matches. No hooks, no executable code. |
 | Your dependency manifest | **subscription** (`.cratis/ai.json`) | The committed, project-owned record of which profiles the repository expects, at which exact version, for which harnesses — the `package.json`-style pin the versioned flow updates by reviewed pull request. |
 | Your project README section | **project context** (`.cratis/PROJECT.md`) | Your project facts — what it is, environments, commands, conventions. The shared profiles never own these; your repository does. |
-| A release channel | **channel** | Derived, not declared: `cratis/engineering` is the maintainer channel, every other `cratis/*` id is the public channel. The two never mix in one subscription. |
+| A release channel | **channel** | Derived, not declared: `cratis/engineering` is the maintainer channel, every other `cratis/*` id is the public channel. A subscription may deliberately mix the two (documentation plus an engineering cell); a mixed selection derives no channel. |
 | The plugin marketplace | **marketplace** | The `Cratis/AI` repository itself, added as a marketplace source. Its manifests resolve the real `skills/` and `engineering/` directories on the default branch — there is no separate store. |
 
 One paragraph each, in the order you meet them:

--- a/Documentation/corpus-generations.md
+++ b/Documentation/corpus-generations.md
@@ -39,24 +39,37 @@ day — verify before acting on them.
 | `Cratis/StudioIssues` | none observed | No corpus in the local checkout — verify |
 | `cratis.github.io` | **unverified** | Not checked out locally |
 
-No repository carries a `.cratis/ai.json` subscription yet; the subscription
-controller has no live target until the versioned flow publishes (#255, #181).
+No repository carried a `.cratis/ai.json` subscription before the adoption; the
+subscription controller has no live versioned target until the versioned flow
+publishes (#255, #181), so the committed files record intended scope.
 
-## Migration order (#256)
+## Migration state after the 2026-09-10 fleet adoption (#256)
 
-1. **Repositories that build code** (`Chronicle.Kotlin`, `Chronicle.Elixir`,
-   `Chronicle.TypeScript`): upgrade to the two-profile corpus — copy the
-   current rule set, keep repository-local skills, each as one PR in that
-   repository referencing #256.
-2. **Repositories that only carry conventions** (`Ante`, `Dockerfiles`,
-   `Cratis/.github`, `cratis.github.io`): prefer the marketplace plugins over
-   any local tree — delete the propagated `.ai/` copy once nothing references
-   it, or move to a subscription when the versioned flow publishes.
-3. **`cratis.studio`**: private; keep the local overlay minimal and take the
-   public behavior from the marketplace.
-4. In this repository, legacy `.ai/skills` retirement continues skill by
-   skill: a canonical twin replaces the legacy source, the audit row moves,
-   the twin is deleted.
+The fleet adoption landed: **every active Cratis repository** now carries the
+subscription generation — a committed `.cratis/ai.json`, a canonical
+`.cratis/PROJECT.md`, and the minimal `AGENTS.md`/`CLAUDE.md`/`GEMINI.md`
+bootstraps — with **no local `.ai/` corpus tree** and **no generated tool
+adapters**. Shared behavior arrives through the marketplace plugins and, once
+the versioned flow publishes, the exact-version packages the subscription
+pins. The legacy propagation, broadcast, and reverse-sync workflows are
+removed from every repository and from `Cratis/Workflows`.
+
+What the retirement did with repository-unique corpus content:
+
+- **General content** (Arc.Kotlin's Kotlin/JVM language rules; the Studio and
+  Stagehand upstream-issue and issue-writing discipline) moved into this
+  repository under `engineering/sources-staged/` awaiting skill authoring.
+- **Repository-specific rules** became sections of the owning repository's
+  `.cratis/PROJECT.md`.
+- **Repository-local skills** moved to the owning repository's
+  `.agents/skills/` overlay, the documented project-owned location.
+- Everything else in the per-repository `.ai/` trees was a stale copy of this
+  repository's corpus or content already superseded here; nothing unique was
+  lost.
+
+In this repository, legacy `.ai/skills` retirement continues skill by
+skill: a canonical twin replaces the legacy source, the audit row moves,
+the twin is deleted.
 
 Update this page when a repository's generation changes — it is the record
 issue #256 asked for, and an unrecorded migration is an unfinished one.

--- a/Documentation/examples/ai-subscriptions/mixed-documentation-and-engineering.cratis-ai.json
+++ b/Documentation/examples/ai-subscriptions/mixed-documentation-and-engineering.cratis-ai.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": "1.0.0",
+  "version": "1.0.0",
+  "profiles": [
+    "cratis/documentation",
+    "cratis/engineering/csharp",
+    "cratis/application/csharp"
+  ],
+  "harnesses": [
+    "claude",
+    "codex",
+    "copilot",
+    "cursor",
+    "pi"
+  ],
+  "updatePolicy": "reviewed-pull-request",
+  "projectContext": ".cratis/PROJECT.md"
+}

--- a/Documentation/profile-reference.md
+++ b/Documentation/profile-reference.md
@@ -448,7 +448,11 @@ resolving it alone returns exactly itself and its one capability.
 
 All shared engineering packages are public-safe. Confidential facts remain in
 repository-local overlays. The whole `cratis/engineering` subtree derives the
-engineering channel; it never mixes with public profiles in one subscription.
+engineering channel. A subscription may combine public profiles with
+engineering cells — `cratis/documentation` plus `cratis/engineering/csharp` is
+the standard Cratis-repository selection — and such a mixed selection derives
+no single channel, so `channel` stays unset. A *resolution* still never crosses
+audiences: each channel of a subscription resolves separately.
 
 | Profile | Intended package | Carries |
 | --- | --- | --- |

--- a/Documentation/scenarios/team-repository.md
+++ b/Documentation/scenarios/team-repository.md
@@ -31,8 +31,12 @@ A `.cratis/ai.json` looks like this:
 Name the profile after the narrowest true description of the repository —
 `cratis/arc/csharp`, `cratis/chronicle`, `cratis/application` — every id and
 its composition is listed in the [profile reference](../profile-reference.md).
-`cratis/engineering` is the one maintainer-audience profile; it never mixes
-with the public ones in the same subscription.
+The `cratis/engineering` subtree is the maintainer-audience channel. A
+subscription may deliberately combine it with public profiles: Cratis's own
+repositories standardly carry `cratis/documentation` next to their
+`cratis/engineering/<language>` cell, and application repositories add their
+`cratis/application/<language>` cells. Such a mixed selection derives no
+single channel and omits `channel`; each channel resolves separately.
 
 ## What you get
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+@.cratis/PROJECT.md

--- a/catalog/component-projections.json
+++ b/catalog/component-projections.json
@@ -1,9868 +1,9843 @@
 {
-  "schemaVersion": 1,
-  "defaultPolicy": "deny",
-  "supportClaim": false,
-  "hosts": [
-    {
-      "id": "claude-code",
-      "contract": "claude-code",
-      "hostAdapterId": "claude-code-plugins-host-adapter",
-      "materialization": "repository-existing",
-      "staticOutputRoot": null,
-      "acceptsAnyPassiveProjection": true,
-      "allowedProjectedKinds": [
-        "command",
-        "hook",
-        "instruction",
-        "prompt",
-        "rule",
-        "skill",
-        "subagent"
-      ],
-      "allowedOutputPrefixes": [
-        ".claude"
-      ],
-      "sharedSymlinkOutputs": [
-        ".claude/agents",
-        ".claude/prompts",
-        ".claude/skills"
-      ],
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ]
-    },
-    {
-      "id": "codex",
-      "contract": "codex",
-      "hostAdapterId": "openai-plugins-host-adapter",
-      "materialization": "repository-existing",
-      "staticOutputRoot": null,
-      "acceptsAnyPassiveProjection": true,
-      "allowedProjectedKinds": [
-        "instruction",
-        "skill"
-      ],
-      "allowedOutputPrefixes": [
-        ".agents",
-        "AGENTS.md"
-      ],
-      "sharedSymlinkOutputs": [
-        ".agents/skills"
-      ],
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ]
-    },
-    {
-      "id": "devin-hosted",
-      "contract": "devin-hosted",
-      "hostAdapterId": "devin-hosted-host-adapter",
-      "materialization": "static-fixture",
-      "staticOutputRoot": "devin-hosted-instructions",
-      "acceptsAnyPassiveProjection": true,
-      "allowedProjectedKinds": [
-        "instruction"
-      ],
-      "allowedOutputPrefixes": [
-        "devin-hosted-instructions"
-      ],
-      "sharedSymlinkOutputs": [],
-      "evidenceIds": [
-        "devin-hosted-source-2"
-      ]
-    },
-    {
-      "id": "github-copilot",
-      "contract": "github-copilot",
-      "hostAdapterId": "github-copilot-plugins-host-adapter",
-      "materialization": "repository-existing",
-      "staticOutputRoot": null,
-      "acceptsAnyPassiveProjection": true,
-      "allowedProjectedKinds": [
-        "agent",
-        "instruction",
-        "prompt",
-        "rule",
-        "skill"
-      ],
-      "allowedOutputPrefixes": [
-        ".github/agents",
-        ".github/copilot-instructions.md",
-        ".github/instructions",
-        ".github/prompts",
-        ".github/skills"
-      ],
-      "sharedSymlinkOutputs": [
-        ".github/instructions",
-        ".github/prompts",
-        ".github/skills"
-      ],
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ]
-    },
-    {
-      "id": "jetbrains-ai-assistant",
-      "contract": "jetbrains-ai-assistant",
-      "hostAdapterId": "jetbrains-ai-assistant-host-adapter",
-      "materialization": "static-fixture",
-      "staticOutputRoot": "jetbrains-ai-assistant-rules",
-      "acceptsAnyPassiveProjection": true,
-      "allowedProjectedKinds": [
-        "rule"
-      ],
-      "allowedOutputPrefixes": [
-        "jetbrains-ai-assistant-rules"
-      ],
-      "sharedSymlinkOutputs": [],
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ]
-    },
-    {
-      "id": "pi",
-      "contract": "pi",
-      "hostAdapterId": "pi-packages-host-adapter",
-      "materialization": "repository-existing",
-      "staticOutputRoot": null,
-      "acceptsAnyPassiveProjection": true,
-      "allowedProjectedKinds": [
-        "agent",
-        "executable-host-extension",
-        "prompt"
-      ],
-      "allowedOutputPrefixes": [
-        ".pi/agents",
-        ".pi/extensions",
-        ".pi/prompts"
-      ],
-      "sharedSymlinkOutputs": [],
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ]
-    },
-    {
-      "id": "portable-agent-plugins-1-0",
-      "contract": "portable-agent-plugins-1-0",
-      "hostAdapterId": null,
-      "materialization": "none",
-      "staticOutputRoot": null,
-      "acceptsAnyPassiveProjection": false,
-      "allowedProjectedKinds": [
-        "skill",
-        "mcp"
-      ],
-      "allowedOutputPrefixes": [],
-      "sharedSymlinkOutputs": [],
-      "evidenceIds": [
-        "agent-plugins-source-1",
-        "agent-plugins-source-2"
-      ]
-    },
-    {
-      "id": "tabnine",
-      "contract": "tabnine",
-      "hostAdapterId": "tabnine-host-adapter",
-      "materialization": "static-fixture",
-      "staticOutputRoot": "tabnine-guidelines",
-      "acceptsAnyPassiveProjection": true,
-      "allowedProjectedKinds": [
-        "rule"
-      ],
-      "allowedOutputPrefixes": [
-        "tabnine-guidelines"
-      ],
-      "sharedSymlinkOutputs": [],
-      "evidenceIds": [
-        "tabnine-source-1"
-      ]
-    },
-    {
-      "id": "visual-studio-copilot",
-      "contract": "visual-studio-copilot",
-      "hostAdapterId": "visual-studio-copilot-host-adapter",
-      "materialization": "static-fixture",
-      "staticOutputRoot": "visual-studio-copilot-instructions",
-      "acceptsAnyPassiveProjection": true,
-      "allowedProjectedKinds": [
-        "instruction"
-      ],
-      "allowedOutputPrefixes": [
-        "visual-studio-copilot-instructions"
-      ],
-      "sharedSymlinkOutputs": [],
-      "evidenceIds": [
-        "visual-studio-copilot-source-2"
-      ]
-    }
-  ],
-  "projections": [
-    {
-      "id": "cratis-agent-backend-developer-to-claude-code-subagent",
-      "componentId": "cratis-agent-backend-developer",
-      "hostId": "claude-code",
-      "projectedKind": "subagent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/agents"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-backend-developer-to-github-copilot-agent",
-      "componentId": "cratis-agent-backend-developer",
-      "hostId": "github-copilot",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/agents/backend-developer.agent.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-backend-developer-to-pi-agent",
-      "componentId": "cratis-agent-backend-developer",
-      "hostId": "pi",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "generated",
-      "outputPaths": [
-        ".pi/agents/backend-developer.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-code-reviewer-to-claude-code-subagent",
-      "componentId": "cratis-agent-code-reviewer",
-      "hostId": "claude-code",
-      "projectedKind": "subagent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/agents"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-code-reviewer-to-github-copilot-agent",
-      "componentId": "cratis-agent-code-reviewer",
-      "hostId": "github-copilot",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/agents/code-reviewer.agent.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-code-reviewer-to-pi-agent",
-      "componentId": "cratis-agent-code-reviewer",
-      "hostId": "pi",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "generated",
-      "outputPaths": [
-        ".pi/agents/code-reviewer.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-coordinator-to-claude-code-subagent",
-      "componentId": "cratis-agent-coordinator",
-      "hostId": "claude-code",
-      "projectedKind": "subagent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/agents"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-coordinator-to-github-copilot-agent",
-      "componentId": "cratis-agent-coordinator",
-      "hostId": "github-copilot",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/agents/coordinator.agent.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-coordinator-to-pi-agent",
-      "componentId": "cratis-agent-coordinator",
-      "hostId": "pi",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "generated",
-      "outputPaths": [
-        ".pi/agents/coordinator.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-frontend-developer-to-claude-code-subagent",
-      "componentId": "cratis-agent-frontend-developer",
-      "hostId": "claude-code",
-      "projectedKind": "subagent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/agents"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-frontend-developer-to-github-copilot-agent",
-      "componentId": "cratis-agent-frontend-developer",
-      "hostId": "github-copilot",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/agents/frontend-developer.agent.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-frontend-developer-to-pi-agent",
-      "componentId": "cratis-agent-frontend-developer",
-      "hostId": "pi",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "generated",
-      "outputPaths": [
-        ".pi/agents/frontend-developer.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-orchestrator-to-claude-code-subagent",
-      "componentId": "cratis-agent-orchestrator",
-      "hostId": "claude-code",
-      "projectedKind": "subagent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/agents"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-orchestrator-to-github-copilot-agent",
-      "componentId": "cratis-agent-orchestrator",
-      "hostId": "github-copilot",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/agents/orchestrator.agent.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-orchestrator-to-pi-agent",
-      "componentId": "cratis-agent-orchestrator",
-      "hostId": "pi",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "generated",
-      "outputPaths": [
-        ".pi/agents/orchestrator.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-performance-reviewer-to-claude-code-subagent",
-      "componentId": "cratis-agent-performance-reviewer",
-      "hostId": "claude-code",
-      "projectedKind": "subagent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/agents"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-performance-reviewer-to-github-copilot-agent",
-      "componentId": "cratis-agent-performance-reviewer",
-      "hostId": "github-copilot",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/agents/performance-reviewer.agent.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-performance-reviewer-to-pi-agent",
-      "componentId": "cratis-agent-performance-reviewer",
-      "hostId": "pi",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "generated",
-      "outputPaths": [
-        ".pi/agents/performance-reviewer.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-planner-to-claude-code-subagent",
-      "componentId": "cratis-agent-planner",
-      "hostId": "claude-code",
-      "projectedKind": "subagent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/agents"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-planner-to-github-copilot-agent",
-      "componentId": "cratis-agent-planner",
-      "hostId": "github-copilot",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/agents/planner.agent.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-planner-to-pi-agent",
-      "componentId": "cratis-agent-planner",
-      "hostId": "pi",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "generated",
-      "outputPaths": [
-        ".pi/agents/planner.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-repository-investigation-reviewer-to-claude-code-subagent",
-      "componentId": "cratis-agent-repository-investigation-reviewer",
-      "hostId": "claude-code",
-      "projectedKind": "subagent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/agents"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-repository-investigation-reviewer-to-github-copilot-agent",
-      "componentId": "cratis-agent-repository-investigation-reviewer",
-      "hostId": "github-copilot",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "inert",
-      "adapterType": "path-reference",
-      "outputPaths": [
-        ".github/agents/repository-investigation-reviewer.agent.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-repository-investigation-reviewer-to-pi-agent",
-      "componentId": "cratis-agent-repository-investigation-reviewer",
-      "hostId": "pi",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "generated",
-      "outputPaths": [
-        ".pi/agents/repository-investigation-reviewer.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-repository-investigator-to-claude-code-subagent",
-      "componentId": "cratis-agent-repository-investigator",
-      "hostId": "claude-code",
-      "projectedKind": "subagent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/agents"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-repository-investigator-to-github-copilot-agent",
-      "componentId": "cratis-agent-repository-investigator",
-      "hostId": "github-copilot",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "inert",
-      "adapterType": "path-reference",
-      "outputPaths": [
-        ".github/agents/repository-investigator.agent.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-repository-investigator-to-pi-agent",
-      "componentId": "cratis-agent-repository-investigator",
-      "hostId": "pi",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "generated",
-      "outputPaths": [
-        ".pi/agents/repository-investigator.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-security-reviewer-to-claude-code-subagent",
-      "componentId": "cratis-agent-security-reviewer",
-      "hostId": "claude-code",
-      "projectedKind": "subagent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/agents"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-security-reviewer-to-github-copilot-agent",
-      "componentId": "cratis-agent-security-reviewer",
-      "hostId": "github-copilot",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/agents/security-reviewer.agent.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-security-reviewer-to-pi-agent",
-      "componentId": "cratis-agent-security-reviewer",
-      "hostId": "pi",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "generated",
-      "outputPaths": [
-        ".pi/agents/security-reviewer.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-slice-implementer-to-claude-code-subagent",
-      "componentId": "cratis-agent-slice-implementer",
-      "hostId": "claude-code",
-      "projectedKind": "subagent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/agents"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-slice-implementer-to-github-copilot-agent",
-      "componentId": "cratis-agent-slice-implementer",
-      "hostId": "github-copilot",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/agents/slice-implementer.agent.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-slice-implementer-to-pi-agent",
-      "componentId": "cratis-agent-slice-implementer",
-      "hostId": "pi",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "generated",
-      "outputPaths": [
-        ".pi/agents/slice-implementer.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-spec-writer-to-claude-code-subagent",
-      "componentId": "cratis-agent-spec-writer",
-      "hostId": "claude-code",
-      "projectedKind": "subagent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/agents"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-spec-writer-to-github-copilot-agent",
-      "componentId": "cratis-agent-spec-writer",
-      "hostId": "github-copilot",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/agents/spec-writer.agent.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-agent-spec-writer-to-pi-agent",
-      "componentId": "cratis-agent-spec-writer",
-      "hostId": "pi",
-      "projectedKind": "agent",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "generated",
-      "outputPaths": [
-        ".pi/agents/spec-writer.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-application-slice-diagnostics-to-claude-code-skill",
-      "componentId": "cratis-application-slice-diagnostics",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-application-slice-diagnostics-to-codex-skill",
-      "componentId": "cratis-application-slice-diagnostics",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-application-slice-diagnostics-to-github-copilot-skill",
-      "componentId": "cratis-application-slice-diagnostics",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-application-vertical-slice-to-claude-code-skill",
-      "componentId": "cratis-application-vertical-slice",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-application-vertical-slice-to-codex-skill",
-      "componentId": "cratis-application-vertical-slice",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-application-vertical-slice-to-github-copilot-skill",
-      "componentId": "cratis-application-vertical-slice",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-arc-react-feature-scaffolding-to-claude-code-skill",
-      "componentId": "cratis-arc-react-feature-scaffolding",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-arc-react-feature-scaffolding-to-codex-skill",
-      "componentId": "cratis-arc-react-feature-scaffolding",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-arc-react-feature-scaffolding-to-github-copilot-skill",
-      "componentId": "cratis-arc-react-feature-scaffolding",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-chronicle-event-metadata-to-claude-code-skill",
-      "componentId": "cratis-chronicle-event-metadata",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-chronicle-event-metadata-to-codex-skill",
-      "componentId": "cratis-chronicle-event-metadata",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-chronicle-event-metadata-to-github-copilot-skill",
-      "componentId": "cratis-chronicle-event-metadata",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-command-add-business-rule-to-claude-code-command",
-      "componentId": "cratis-command-add-business-rule",
-      "hostId": "claude-code",
-      "projectedKind": "command",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/commands/add-business-rule.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-command-add-concept-to-claude-code-command",
-      "componentId": "cratis-command-add-concept",
-      "hostId": "claude-code",
-      "projectedKind": "command",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/commands/add-concept.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-command-add-ef-migration-to-claude-code-command",
-      "componentId": "cratis-command-add-ef-migration",
-      "hostId": "claude-code",
-      "projectedKind": "command",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/commands/add-ef-migration.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-command-add-projection-to-claude-code-command",
-      "componentId": "cratis-command-add-projection",
-      "hostId": "claude-code",
-      "projectedKind": "command",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/commands/add-projection.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-command-add-reactor-to-claude-code-command",
-      "componentId": "cratis-command-add-reactor",
-      "hostId": "claude-code",
-      "projectedKind": "command",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/commands/add-reactor.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-command-add-reducer-to-claude-code-command",
-      "componentId": "cratis-command-add-reducer",
-      "hostId": "claude-code",
-      "projectedKind": "command",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/commands/add-reducer.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-command-audit-hooks-to-claude-code-command",
-      "componentId": "cratis-command-audit-hooks",
-      "hostId": "claude-code",
-      "projectedKind": "command",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/commands/audit-hooks.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-command-check-doc-drift-to-claude-code-command",
-      "componentId": "cratis-command-check-doc-drift",
-      "hostId": "claude-code",
-      "projectedKind": "command",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/commands/check-doc-drift.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-command-code-review-to-claude-code-command",
-      "componentId": "cratis-command-code-review",
-      "hostId": "claude-code",
-      "projectedKind": "command",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/commands/code-review.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-command-new-feature-to-claude-code-command",
-      "componentId": "cratis-command-new-feature",
-      "hostId": "claude-code",
-      "projectedKind": "command",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/commands/new-feature.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-command-new-vertical-slice-to-claude-code-command",
-      "componentId": "cratis-command-new-vertical-slice",
-      "hostId": "claude-code",
-      "projectedKind": "command",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/commands/new-vertical-slice.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-command-review-pr-to-claude-code-command",
-      "componentId": "cratis-command-review-pr",
-      "hostId": "claude-code",
-      "projectedKind": "command",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/commands/review-pr.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-command-review-skill-to-claude-code-command",
-      "componentId": "cratis-command-review-skill",
-      "hostId": "claude-code",
-      "projectedKind": "command",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/commands/review-skill.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-command-scaffold-feature-to-claude-code-command",
-      "componentId": "cratis-command-scaffold-feature",
-      "hostId": "claude-code",
-      "projectedKind": "command",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/commands/scaffold-feature.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-command-ship-changes-to-claude-code-command",
-      "componentId": "cratis-command-ship-changes",
-      "hostId": "claude-code",
-      "projectedKind": "command",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/commands/ship-changes.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-command-verify-ai-setup-to-claude-code-command",
-      "componentId": "cratis-command-verify-ai-setup",
-      "hostId": "claude-code",
-      "projectedKind": "command",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/commands/verify-ai-setup.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-command-write-documentation-to-claude-code-command",
-      "componentId": "cratis-command-write-documentation",
-      "hostId": "claude-code",
-      "projectedKind": "command",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/commands/write-documentation.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-command-write-specs-to-claude-code-command",
-      "componentId": "cratis-command-write-specs",
-      "hostId": "claude-code",
-      "projectedKind": "command",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/commands/write-specs.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-engineering-docs-visual-qa-to-claude-code-skill",
-      "componentId": "cratis-engineering-docs-visual-qa",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-engineering-docs-visual-qa-to-codex-skill",
-      "componentId": "cratis-engineering-docs-visual-qa",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-engineering-docs-visual-qa-to-github-copilot-skill",
-      "componentId": "cratis-engineering-docs-visual-qa",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-engineering-ship-changes-to-claude-code-skill",
-      "componentId": "cratis-engineering-ship-changes",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-engineering-ship-changes-to-codex-skill",
-      "componentId": "cratis-engineering-ship-changes",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-engineering-ship-changes-to-github-copilot-skill",
-      "componentId": "cratis-engineering-ship-changes",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-hooks-to-claude-code-hook",
-      "componentId": "cratis-hooks",
-      "hostId": "claude-code",
-      "projectedKind": "hook",
-      "artifactClass": "executable-plugin-package",
-      "assuranceProfileId": "executable-plugin-package-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/hooks"
-      ],
-      "approval": "blocked",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [
-        "effect-boundary",
-        "security-review",
-        "threat-model"
-      ],
-      "requiredCanaries": [
-        "effect-boundary",
-        "host-discovery",
-        "security-review",
-        "threat-model"
-      ]
-    },
-    {
-      "id": "cratis-instruction-general-to-claude-code-instruction",
-      "componentId": "cratis-instruction-general",
-      "hostId": "claude-code",
-      "projectedKind": "instruction",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/CLAUDE.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-instruction-general-to-codex-instruction",
-      "componentId": "cratis-instruction-general",
-      "hostId": "codex",
-      "projectedKind": "instruction",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        "AGENTS.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-instruction-general-to-devin-hosted-instruction",
-      "componentId": "cratis-instruction-general",
-      "hostId": "devin-hosted",
-      "projectedKind": "instruction",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "devin-hosted-instructions/AGENTS.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "devin-hosted-source-2"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-instruction-general-to-github-copilot-instruction",
-      "componentId": "cratis-instruction-general",
-      "hostId": "github-copilot",
-      "projectedKind": "instruction",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "inert",
-      "adapterType": "path-reference",
-      "outputPaths": [
-        ".github/copilot-instructions.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-instruction-general-to-github-copilot-shared-instruction",
-      "componentId": "cratis-instruction-general",
-      "hostId": "github-copilot",
-      "projectedKind": "instruction",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-instruction-general-to-visual-studio-copilot-instruction",
-      "componentId": "cratis-instruction-general",
-      "hostId": "visual-studio-copilot",
-      "projectedKind": "instruction",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "visual-studio-copilot-instructions/.github/copilot-instructions.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "visual-studio-copilot-source-2"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-business-rule-to-claude-code-skill",
-      "componentId": "cratis-legacy-add-business-rule",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-business-rule-to-codex-skill",
-      "componentId": "cratis-legacy-add-business-rule",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-business-rule-to-github-copilot-skill",
-      "componentId": "cratis-legacy-add-business-rule",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-concept-to-claude-code-skill",
-      "componentId": "cratis-legacy-add-concept",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-concept-to-codex-skill",
-      "componentId": "cratis-legacy-add-concept",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-concept-to-github-copilot-skill",
-      "componentId": "cratis-legacy-add-concept",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-cratis-docs-page-to-claude-code-skill",
-      "componentId": "cratis-legacy-add-cratis-docs-page",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-cratis-docs-page-to-codex-skill",
-      "componentId": "cratis-legacy-add-cratis-docs-page",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-cratis-docs-page-to-github-copilot-skill",
-      "componentId": "cratis-legacy-add-cratis-docs-page",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-ef-migration-to-claude-code-skill",
-      "componentId": "cratis-legacy-add-ef-migration",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-ef-migration-to-codex-skill",
-      "componentId": "cratis-legacy-add-ef-migration",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-ef-migration-to-github-copilot-skill",
-      "componentId": "cratis-legacy-add-ef-migration",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-projection-to-claude-code-skill",
-      "componentId": "cratis-legacy-add-projection",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-projection-to-codex-skill",
-      "componentId": "cratis-legacy-add-projection",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-projection-to-github-copilot-skill",
-      "componentId": "cratis-legacy-add-projection",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-reactor-to-claude-code-skill",
-      "componentId": "cratis-legacy-add-reactor",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-reactor-to-codex-skill",
-      "componentId": "cratis-legacy-add-reactor",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-reactor-to-github-copilot-skill",
-      "componentId": "cratis-legacy-add-reactor",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-reducer-to-claude-code-skill",
-      "componentId": "cratis-legacy-add-reducer",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-reducer-to-codex-skill",
-      "componentId": "cratis-legacy-add-reducer",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-reducer-to-github-copilot-skill",
-      "componentId": "cratis-legacy-add-reducer",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-traces-to-claude-code-skill",
-      "componentId": "cratis-legacy-add-traces",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-traces-to-codex-skill",
-      "componentId": "cratis-legacy-add-traces",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-add-traces-to-github-copilot-skill",
-      "componentId": "cratis-legacy-add-traces",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-auth-and-identity-to-claude-code-skill",
-      "componentId": "cratis-legacy-auth-and-identity",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-auth-and-identity-to-codex-skill",
-      "componentId": "cratis-legacy-auth-and-identity",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-auth-and-identity-to-github-copilot-skill",
-      "componentId": "cratis-legacy-auth-and-identity",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-call-command-from-code-to-claude-code-skill",
-      "componentId": "cratis-legacy-call-command-from-code",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-call-command-from-code-to-codex-skill",
-      "componentId": "cratis-legacy-call-command-from-code",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-call-command-from-code-to-github-copilot-skill",
-      "componentId": "cratis-legacy-call-command-from-code",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-cratis-command-to-claude-code-skill",
-      "componentId": "cratis-legacy-cratis-command",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-cratis-command-to-codex-skill",
-      "componentId": "cratis-legacy-cratis-command",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-cratis-command-to-github-copilot-skill",
-      "componentId": "cratis-legacy-cratis-command",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-cratis-csharp-standards-to-claude-code-skill",
-      "componentId": "cratis-legacy-cratis-csharp-standards",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-cratis-csharp-standards-to-codex-skill",
-      "componentId": "cratis-legacy-cratis-csharp-standards",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-cratis-csharp-standards-to-github-copilot-skill",
-      "componentId": "cratis-legacy-cratis-csharp-standards",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-cratis-react-page-to-claude-code-skill",
-      "componentId": "cratis-legacy-cratis-react-page",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-cratis-react-page-to-codex-skill",
-      "componentId": "cratis-legacy-cratis-react-page",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-cratis-react-page-to-github-copilot-skill",
-      "componentId": "cratis-legacy-cratis-react-page",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-cratis-readmodel-to-claude-code-skill",
-      "componentId": "cratis-legacy-cratis-readmodel",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-cratis-readmodel-to-codex-skill",
-      "componentId": "cratis-legacy-cratis-readmodel",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-cratis-readmodel-to-github-copilot-skill",
-      "componentId": "cratis-legacy-cratis-readmodel",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-cratis-specs-csharp-to-claude-code-skill",
-      "componentId": "cratis-legacy-cratis-specs-csharp",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-cratis-specs-csharp-to-codex-skill",
-      "componentId": "cratis-legacy-cratis-specs-csharp",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-cratis-specs-csharp-to-github-copilot-skill",
-      "componentId": "cratis-legacy-cratis-specs-csharp",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-cratis-specs-typescript-to-claude-code-skill",
-      "componentId": "cratis-legacy-cratis-specs-typescript",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-cratis-specs-typescript-to-codex-skill",
-      "componentId": "cratis-legacy-cratis-specs-typescript",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-cratis-specs-typescript-to-github-copilot-skill",
-      "componentId": "cratis-legacy-cratis-specs-typescript",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-create-event-model-to-claude-code-skill",
-      "componentId": "cratis-legacy-create-event-model",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-create-event-model-to-codex-skill",
-      "componentId": "cratis-legacy-create-event-model",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-create-event-model-to-github-copilot-skill",
-      "componentId": "cratis-legacy-create-event-model",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-discover-implementations-to-claude-code-skill",
-      "componentId": "cratis-legacy-discover-implementations",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-discover-implementations-to-codex-skill",
-      "componentId": "cratis-legacy-discover-implementations",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-discover-implementations-to-github-copilot-skill",
-      "componentId": "cratis-legacy-discover-implementations",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-edit-cratis-docs-to-claude-code-skill",
-      "componentId": "cratis-legacy-edit-cratis-docs",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-edit-cratis-docs-to-codex-skill",
-      "componentId": "cratis-legacy-edit-cratis-docs",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-edit-cratis-docs-to-github-copilot-skill",
-      "componentId": "cratis-legacy-edit-cratis-docs",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-event-modeling-to-claude-code-skill",
-      "componentId": "cratis-legacy-event-modeling",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-event-modeling-to-codex-skill",
-      "componentId": "cratis-legacy-event-modeling",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-event-modeling-to-github-copilot-skill",
-      "componentId": "cratis-legacy-event-modeling",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-event-type-migrations-to-claude-code-skill",
-      "componentId": "cratis-legacy-event-type-migrations",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-event-type-migrations-to-codex-skill",
-      "componentId": "cratis-legacy-event-type-migrations",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-event-type-migrations-to-github-copilot-skill",
-      "componentId": "cratis-legacy-event-type-migrations",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-inspect-running-chronicle-to-claude-code-skill",
-      "componentId": "cratis-legacy-inspect-running-chronicle",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-inspect-running-chronicle-to-codex-skill",
-      "componentId": "cratis-legacy-inspect-running-chronicle",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-inspect-running-chronicle-to-github-copilot-skill",
-      "componentId": "cratis-legacy-inspect-running-chronicle",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-multi-tenancy-to-claude-code-skill",
-      "componentId": "cratis-legacy-multi-tenancy",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-multi-tenancy-to-codex-skill",
-      "componentId": "cratis-legacy-multi-tenancy",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-multi-tenancy-to-github-copilot-skill",
-      "componentId": "cratis-legacy-multi-tenancy",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-observable-query-curl-to-claude-code-skill",
-      "componentId": "cratis-legacy-observable-query-curl",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-observable-query-curl-to-codex-skill",
-      "componentId": "cratis-legacy-observable-query-curl",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-observable-query-curl-to-github-copilot-skill",
-      "componentId": "cratis-legacy-observable-query-curl",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-query-paging-to-claude-code-skill",
-      "componentId": "cratis-legacy-query-paging",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-query-paging-to-codex-skill",
-      "componentId": "cratis-legacy-query-paging",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-query-paging-to-github-copilot-skill",
-      "componentId": "cratis-legacy-query-paging",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-review-code-to-claude-code-skill",
-      "componentId": "cratis-legacy-review-code",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-review-code-to-codex-skill",
-      "componentId": "cratis-legacy-review-code",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-review-code-to-github-copilot-skill",
-      "componentId": "cratis-legacy-review-code",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-review-performance-to-claude-code-skill",
-      "componentId": "cratis-legacy-review-performance",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-review-performance-to-codex-skill",
-      "componentId": "cratis-legacy-review-performance",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-review-performance-to-github-copilot-skill",
-      "componentId": "cratis-legacy-review-performance",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-review-security-to-claude-code-skill",
-      "componentId": "cratis-legacy-review-security",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-review-security-to-codex-skill",
-      "componentId": "cratis-legacy-review-security",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-review-security-to-github-copilot-skill",
-      "componentId": "cratis-legacy-review-security",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-stepper-command-dialog-to-claude-code-skill",
-      "componentId": "cratis-legacy-stepper-command-dialog",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-stepper-command-dialog-to-codex-skill",
-      "componentId": "cratis-legacy-stepper-command-dialog",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-stepper-command-dialog-to-github-copilot-skill",
-      "componentId": "cratis-legacy-stepper-command-dialog",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-toolbar-to-claude-code-skill",
-      "componentId": "cratis-legacy-toolbar",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-toolbar-to-codex-skill",
-      "componentId": "cratis-legacy-toolbar",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-toolbar-to-github-copilot-skill",
-      "componentId": "cratis-legacy-toolbar",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-write-documentation-to-claude-code-skill",
-      "componentId": "cratis-legacy-write-documentation",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-write-documentation-to-codex-skill",
-      "componentId": "cratis-legacy-write-documentation",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-write-documentation-to-github-copilot-skill",
-      "componentId": "cratis-legacy-write-documentation",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-write-specs-events-to-claude-code-skill",
-      "componentId": "cratis-legacy-write-specs-events",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-write-specs-events-to-codex-skill",
-      "componentId": "cratis-legacy-write-specs-events",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-write-specs-events-to-github-copilot-skill",
-      "componentId": "cratis-legacy-write-specs-events",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-write-specs-frontend-to-claude-code-skill",
-      "componentId": "cratis-legacy-write-specs-frontend",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-write-specs-frontend-to-codex-skill",
-      "componentId": "cratis-legacy-write-specs-frontend",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-write-specs-frontend-to-github-copilot-skill",
-      "componentId": "cratis-legacy-write-specs-frontend",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-write-specs-readmodels-to-claude-code-skill",
-      "componentId": "cratis-legacy-write-specs-readmodels",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-write-specs-readmodels-to-codex-skill",
-      "componentId": "cratis-legacy-write-specs-readmodels",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-write-specs-readmodels-to-github-copilot-skill",
-      "componentId": "cratis-legacy-write-specs-readmodels",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-write-specs-to-claude-code-skill",
-      "componentId": "cratis-legacy-write-specs",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-write-specs-to-codex-skill",
-      "componentId": "cratis-legacy-write-specs",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-legacy-write-specs-to-github-copilot-skill",
-      "componentId": "cratis-legacy-write-specs",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-pi-hooks-extension-to-pi-executable-host-extension",
-      "componentId": "cratis-pi-hooks-extension",
-      "hostId": "pi",
-      "projectedKind": "executable-host-extension",
-      "artifactClass": "executable-plugin-package",
-      "assuranceProfileId": "executable-plugin-package-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "canonical-in-place",
-      "outputPaths": [
-        ".pi/extensions/cratis-hooks/index.ts"
-      ],
-      "approval": "blocked",
-      "evidenceIds": [
-        "ai-126",
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [
-        "effect-boundary",
-        "security-review",
-        "threat-model"
-      ],
-      "requiredCanaries": [
-        "effect-boundary",
-        "host-discovery",
-        "security-review",
-        "threat-model"
-      ]
-    },
-    {
-      "id": "cratis-pi-subagent-extension-to-pi-executable-host-extension",
-      "componentId": "cratis-pi-subagent-extension",
-      "hostId": "pi",
-      "projectedKind": "executable-host-extension",
-      "artifactClass": "executable-plugin-package",
-      "assuranceProfileId": "executable-plugin-package-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "canonical-in-place",
-      "outputPaths": [
-        ".pi/extensions/subagent/agents.ts",
-        ".pi/extensions/subagent/index.ts"
-      ],
-      "approval": "blocked",
-      "evidenceIds": [
-        "ai-126",
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [
-        "effect-boundary",
-        "security-review",
-        "threat-model"
-      ],
-      "requiredCanaries": [
-        "effect-boundary",
-        "host-discovery",
-        "security-review",
-        "threat-model"
-      ]
-    },
-    {
-      "id": "cratis-prompt-add-business-rule-to-claude-code-prompt",
-      "componentId": "cratis-prompt-add-business-rule",
-      "hostId": "claude-code",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-add-business-rule-to-github-copilot-prompt",
-      "componentId": "cratis-prompt-add-business-rule",
-      "hostId": "github-copilot",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-add-business-rule-to-pi-prompt",
-      "componentId": "cratis-prompt-add-business-rule",
-      "hostId": "pi",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".pi/prompts/add-business-rule.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-add-concept-to-claude-code-prompt",
-      "componentId": "cratis-prompt-add-concept",
-      "hostId": "claude-code",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-add-concept-to-github-copilot-prompt",
-      "componentId": "cratis-prompt-add-concept",
-      "hostId": "github-copilot",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-add-concept-to-pi-prompt",
-      "componentId": "cratis-prompt-add-concept",
-      "hostId": "pi",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".pi/prompts/add-concept.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-add-ef-migration-to-claude-code-prompt",
-      "componentId": "cratis-prompt-add-ef-migration",
-      "hostId": "claude-code",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-add-ef-migration-to-github-copilot-prompt",
-      "componentId": "cratis-prompt-add-ef-migration",
-      "hostId": "github-copilot",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-add-ef-migration-to-pi-prompt",
-      "componentId": "cratis-prompt-add-ef-migration",
-      "hostId": "pi",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".pi/prompts/add-ef-migration.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-add-projection-to-claude-code-prompt",
-      "componentId": "cratis-prompt-add-projection",
-      "hostId": "claude-code",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-add-projection-to-github-copilot-prompt",
-      "componentId": "cratis-prompt-add-projection",
-      "hostId": "github-copilot",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-add-projection-to-pi-prompt",
-      "componentId": "cratis-prompt-add-projection",
-      "hostId": "pi",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".pi/prompts/add-projection.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-add-reactor-to-claude-code-prompt",
-      "componentId": "cratis-prompt-add-reactor",
-      "hostId": "claude-code",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-add-reactor-to-github-copilot-prompt",
-      "componentId": "cratis-prompt-add-reactor",
-      "hostId": "github-copilot",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-add-reactor-to-pi-prompt",
-      "componentId": "cratis-prompt-add-reactor",
-      "hostId": "pi",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".pi/prompts/add-reactor.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-add-reducer-to-claude-code-prompt",
-      "componentId": "cratis-prompt-add-reducer",
-      "hostId": "claude-code",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-add-reducer-to-github-copilot-prompt",
-      "componentId": "cratis-prompt-add-reducer",
-      "hostId": "github-copilot",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-add-reducer-to-pi-prompt",
-      "componentId": "cratis-prompt-add-reducer",
-      "hostId": "pi",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".pi/prompts/add-reducer.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-audit-hooks-to-claude-code-prompt",
-      "componentId": "cratis-prompt-audit-hooks",
-      "hostId": "claude-code",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-audit-hooks-to-github-copilot-prompt",
-      "componentId": "cratis-prompt-audit-hooks",
-      "hostId": "github-copilot",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-audit-hooks-to-pi-prompt",
-      "componentId": "cratis-prompt-audit-hooks",
-      "hostId": "pi",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".pi/prompts/audit-hooks.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-check-doc-drift-to-claude-code-prompt",
-      "componentId": "cratis-prompt-check-doc-drift",
-      "hostId": "claude-code",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-check-doc-drift-to-github-copilot-prompt",
-      "componentId": "cratis-prompt-check-doc-drift",
-      "hostId": "github-copilot",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-check-doc-drift-to-pi-prompt",
-      "componentId": "cratis-prompt-check-doc-drift",
-      "hostId": "pi",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".pi/prompts/check-doc-drift.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-code-review-to-claude-code-prompt",
-      "componentId": "cratis-prompt-code-review",
-      "hostId": "claude-code",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-code-review-to-github-copilot-prompt",
-      "componentId": "cratis-prompt-code-review",
-      "hostId": "github-copilot",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-code-review-to-pi-prompt",
-      "componentId": "cratis-prompt-code-review",
-      "hostId": "pi",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".pi/prompts/code-review.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-new-feature-to-claude-code-prompt",
-      "componentId": "cratis-prompt-new-feature",
-      "hostId": "claude-code",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-new-feature-to-github-copilot-prompt",
-      "componentId": "cratis-prompt-new-feature",
-      "hostId": "github-copilot",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-new-feature-to-pi-prompt",
-      "componentId": "cratis-prompt-new-feature",
-      "hostId": "pi",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".pi/prompts/new-feature.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-new-vertical-slice-to-claude-code-prompt",
-      "componentId": "cratis-prompt-new-vertical-slice",
-      "hostId": "claude-code",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-new-vertical-slice-to-github-copilot-prompt",
-      "componentId": "cratis-prompt-new-vertical-slice",
-      "hostId": "github-copilot",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-new-vertical-slice-to-pi-prompt",
-      "componentId": "cratis-prompt-new-vertical-slice",
-      "hostId": "pi",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".pi/prompts/new-vertical-slice.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-review-pr-to-claude-code-prompt",
-      "componentId": "cratis-prompt-review-pr",
-      "hostId": "claude-code",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-review-pr-to-github-copilot-prompt",
-      "componentId": "cratis-prompt-review-pr",
-      "hostId": "github-copilot",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-review-pr-to-pi-prompt",
-      "componentId": "cratis-prompt-review-pr",
-      "hostId": "pi",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".pi/prompts/review-pr.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-review-skill-to-claude-code-prompt",
-      "componentId": "cratis-prompt-review-skill",
-      "hostId": "claude-code",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-review-skill-to-github-copilot-prompt",
-      "componentId": "cratis-prompt-review-skill",
-      "hostId": "github-copilot",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-review-skill-to-pi-prompt",
-      "componentId": "cratis-prompt-review-skill",
-      "hostId": "pi",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".pi/prompts/review-skill.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-scaffold-feature-to-claude-code-prompt",
-      "componentId": "cratis-prompt-scaffold-feature",
-      "hostId": "claude-code",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-scaffold-feature-to-github-copilot-prompt",
-      "componentId": "cratis-prompt-scaffold-feature",
-      "hostId": "github-copilot",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-scaffold-feature-to-pi-prompt",
-      "componentId": "cratis-prompt-scaffold-feature",
-      "hostId": "pi",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".pi/prompts/scaffold-feature.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-ship-changes-to-claude-code-prompt",
-      "componentId": "cratis-prompt-ship-changes",
-      "hostId": "claude-code",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-ship-changes-to-github-copilot-prompt",
-      "componentId": "cratis-prompt-ship-changes",
-      "hostId": "github-copilot",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-ship-changes-to-pi-prompt",
-      "componentId": "cratis-prompt-ship-changes",
-      "hostId": "pi",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".pi/prompts/ship-changes.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-verify-ai-setup-to-claude-code-prompt",
-      "componentId": "cratis-prompt-verify-ai-setup",
-      "hostId": "claude-code",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-verify-ai-setup-to-github-copilot-prompt",
-      "componentId": "cratis-prompt-verify-ai-setup",
-      "hostId": "github-copilot",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-verify-ai-setup-to-pi-prompt",
-      "componentId": "cratis-prompt-verify-ai-setup",
-      "hostId": "pi",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".pi/prompts/verify-ai-setup.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-write-documentation-to-claude-code-prompt",
-      "componentId": "cratis-prompt-write-documentation",
-      "hostId": "claude-code",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-write-documentation-to-github-copilot-prompt",
-      "componentId": "cratis-prompt-write-documentation",
-      "hostId": "github-copilot",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-write-documentation-to-pi-prompt",
-      "componentId": "cratis-prompt-write-documentation",
-      "hostId": "pi",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".pi/prompts/write-documentation.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-write-specs-to-claude-code-prompt",
-      "componentId": "cratis-prompt-write-specs",
-      "hostId": "claude-code",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-write-specs-to-github-copilot-prompt",
-      "componentId": "cratis-prompt-write-specs",
-      "hostId": "github-copilot",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/prompts"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-prompt-write-specs-to-pi-prompt",
-      "componentId": "cratis-prompt-write-specs",
-      "hostId": "pi",
-      "projectedKind": "prompt",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".pi/prompts/write-specs.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-capability-is-not-authority-to-claude-code-rule",
-      "componentId": "cratis-rule-capability-is-not-authority",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/capability-is-not-authority.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-capability-is-not-authority-to-github-copilot-rule",
-      "componentId": "cratis-rule-capability-is-not-authority",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-code-quality-csharp-to-claude-code-rule",
-      "componentId": "cratis-rule-code-quality-csharp",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/code-quality.csharp.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-code-quality-csharp-to-github-copilot-rule",
-      "componentId": "cratis-rule-code-quality-csharp",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-code-quality-csharp-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-code-quality-csharp",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/code-quality.csharp.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-code-quality-csharp-to-tabnine-rule",
-      "componentId": "cratis-rule-code-quality-csharp",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/code-quality.csharp.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-code-quality-to-claude-code-rule",
-      "componentId": "cratis-rule-code-quality",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/code-quality.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-code-quality-to-github-copilot-rule",
-      "componentId": "cratis-rule-code-quality",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-code-quality-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-code-quality",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/code-quality.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-code-quality-to-tabnine-rule",
-      "componentId": "cratis-rule-code-quality",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/code-quality.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-code-quality-typescript-to-claude-code-rule",
-      "componentId": "cratis-rule-code-quality-typescript",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/code-quality.typescript.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-code-quality-typescript-to-github-copilot-rule",
-      "componentId": "cratis-rule-code-quality-typescript",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-code-quality-typescript-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-code-quality-typescript",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/code-quality.typescript.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-code-quality-typescript-to-tabnine-rule",
-      "componentId": "cratis-rule-code-quality-typescript",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/code-quality.typescript.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-components-to-claude-code-rule",
-      "componentId": "cratis-rule-components",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/components.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-components-to-github-copilot-rule",
-      "componentId": "cratis-rule-components",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-components-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-components",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/components.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-components-to-tabnine-rule",
-      "componentId": "cratis-rule-components",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/components.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-concepts-to-claude-code-rule",
-      "componentId": "cratis-rule-concepts",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/concepts.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-concepts-to-github-copilot-rule",
-      "componentId": "cratis-rule-concepts",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-concepts-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-concepts",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/concepts.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-concepts-to-tabnine-rule",
-      "componentId": "cratis-rule-concepts",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/concepts.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-csharp-to-claude-code-rule",
-      "componentId": "cratis-rule-csharp",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/csharp.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-csharp-to-github-copilot-rule",
-      "componentId": "cratis-rule-csharp",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-csharp-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-csharp",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/csharp.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-csharp-to-tabnine-rule",
-      "componentId": "cratis-rule-csharp",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/csharp.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-decision-records-to-claude-code-rule",
-      "componentId": "cratis-rule-decision-records",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/decision-records.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-decision-records-to-github-copilot-rule",
-      "componentId": "cratis-rule-decision-records",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-dialogs-to-claude-code-rule",
-      "componentId": "cratis-rule-dialogs",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/dialogs.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-dialogs-to-github-copilot-rule",
-      "componentId": "cratis-rule-dialogs",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-dialogs-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-dialogs",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/dialogs.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-dialogs-to-tabnine-rule",
-      "componentId": "cratis-rule-dialogs",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/dialogs.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-documentation-structure-and-formatting-to-claude-code-rule",
-      "componentId": "cratis-rule-documentation-structure-and-formatting",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/documentation-structure-and-formatting.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-documentation-structure-and-formatting-to-github-copilot-rule",
-      "componentId": "cratis-rule-documentation-structure-and-formatting",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-documentation-structure-and-formatting-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-documentation-structure-and-formatting",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/documentation-structure-and-formatting.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-documentation-structure-and-formatting-to-tabnine-rule",
-      "componentId": "cratis-rule-documentation-structure-and-formatting",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/documentation-structure-and-formatting.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-documentation-to-claude-code-rule",
-      "componentId": "cratis-rule-documentation",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/documentation.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-documentation-to-github-copilot-rule",
-      "componentId": "cratis-rule-documentation",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-documentation-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-documentation",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/documentation.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-documentation-to-tabnine-rule",
-      "componentId": "cratis-rule-documentation",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/documentation.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-editing-cratis-docs-to-claude-code-rule",
-      "componentId": "cratis-rule-editing-cratis-docs",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/editing-cratis-docs.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-editing-cratis-docs-to-github-copilot-rule",
-      "componentId": "cratis-rule-editing-cratis-docs",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-editing-cratis-docs-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-editing-cratis-docs",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/editing-cratis-docs.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-editing-cratis-docs-to-tabnine-rule",
-      "componentId": "cratis-rule-editing-cratis-docs",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/editing-cratis-docs.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-efcore-specs-to-claude-code-rule",
-      "componentId": "cratis-rule-efcore-specs",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/efcore.specs.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-efcore-specs-to-github-copilot-rule",
-      "componentId": "cratis-rule-efcore-specs",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-efcore-specs-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-efcore-specs",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/efcore.specs.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-efcore-specs-to-tabnine-rule",
-      "componentId": "cratis-rule-efcore-specs",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/efcore.specs.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-efcore-to-claude-code-rule",
-      "componentId": "cratis-rule-efcore",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/efcore.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-efcore-to-github-copilot-rule",
-      "componentId": "cratis-rule-efcore",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-efcore-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-efcore",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/efcore.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-efcore-to-tabnine-rule",
-      "componentId": "cratis-rule-efcore",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/efcore.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-engineering-recipe-skeleton-to-claude-code-rule",
-      "componentId": "cratis-rule-engineering-recipe-skeleton",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/engineering-recipe-skeleton.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-engineering-recipe-skeleton-to-github-copilot-rule",
-      "componentId": "cratis-rule-engineering-recipe-skeleton",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-exit-codes-and-wrappers-to-claude-code-rule",
-      "componentId": "cratis-rule-exit-codes-and-wrappers",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/exit-codes-and-wrappers.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-exit-codes-and-wrappers-to-github-copilot-rule",
-      "componentId": "cratis-rule-exit-codes-and-wrappers",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-framework-to-claude-code-rule",
-      "componentId": "cratis-rule-framework",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/framework.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-framework-to-github-copilot-rule",
-      "componentId": "cratis-rule-framework",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-framework-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-framework",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/framework.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-framework-to-tabnine-rule",
-      "componentId": "cratis-rule-framework",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/framework.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-frontend-quality-to-claude-code-rule",
-      "componentId": "cratis-rule-frontend-quality",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/frontend-quality.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-frontend-quality-to-github-copilot-rule",
-      "componentId": "cratis-rule-frontend-quality",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-frontend-quality-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-frontend-quality",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/frontend-quality.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-frontend-quality-to-tabnine-rule",
-      "componentId": "cratis-rule-frontend-quality",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/frontend-quality.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-frontend-testing-to-claude-code-rule",
-      "componentId": "cratis-rule-frontend-testing",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/frontend-testing.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-frontend-testing-to-github-copilot-rule",
-      "componentId": "cratis-rule-frontend-testing",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-frontend-testing-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-frontend-testing",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/frontend-testing.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-frontend-testing-to-tabnine-rule",
-      "componentId": "cratis-rule-frontend-testing",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/frontend-testing.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-git-commits-to-claude-code-rule",
-      "componentId": "cratis-rule-git-commits",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/git-commits.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-git-commits-to-github-copilot-rule",
-      "componentId": "cratis-rule-git-commits",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-git-commits-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-git-commits",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/git-commits.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-git-commits-to-tabnine-rule",
-      "componentId": "cratis-rule-git-commits",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/git-commits.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-github-actions-to-claude-code-rule",
-      "componentId": "cratis-rule-github-actions",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/github-actions.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-github-actions-to-github-copilot-rule",
-      "componentId": "cratis-rule-github-actions",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-glossary-to-claude-code-rule",
-      "componentId": "cratis-rule-glossary",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/glossary.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-glossary-to-github-copilot-rule",
-      "componentId": "cratis-rule-glossary",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-glossary-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-glossary",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/glossary.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-glossary-to-tabnine-rule",
-      "componentId": "cratis-rule-glossary",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/glossary.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-guards-and-fuses-to-claude-code-rule",
-      "componentId": "cratis-rule-guards-and-fuses",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/guards-and-fuses.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-guards-and-fuses-to-github-copilot-rule",
-      "componentId": "cratis-rule-guards-and-fuses",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-human-verdicts-to-claude-code-rule",
-      "componentId": "cratis-rule-human-verdicts",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/human-verdicts.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-human-verdicts-to-github-copilot-rule",
-      "componentId": "cratis-rule-human-verdicts",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-local-work-artifacts-to-claude-code-rule",
-      "componentId": "cratis-rule-local-work-artifacts",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/local-work-artifacts.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-local-work-artifacts-to-github-copilot-rule",
-      "componentId": "cratis-rule-local-work-artifacts",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-managing-ai-rules-to-claude-code-rule",
-      "componentId": "cratis-rule-managing-ai-rules",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/managing-ai-rules.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-managing-ai-rules-to-github-copilot-rule",
-      "componentId": "cratis-rule-managing-ai-rules",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-managing-ai-rules-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-managing-ai-rules",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/managing-ai-rules.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-managing-ai-rules-to-tabnine-rule",
-      "componentId": "cratis-rule-managing-ai-rules",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/managing-ai-rules.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-orleans-to-claude-code-rule",
-      "componentId": "cratis-rule-orleans",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/orleans.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-orleans-to-github-copilot-rule",
-      "componentId": "cratis-rule-orleans",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-orleans-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-orleans",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/orleans.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-orleans-to-tabnine-rule",
-      "componentId": "cratis-rule-orleans",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/orleans.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-pull-requests-to-claude-code-rule",
-      "componentId": "cratis-rule-pull-requests",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/pull-requests.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-pull-requests-to-github-copilot-rule",
-      "componentId": "cratis-rule-pull-requests",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-pull-requests-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-pull-requests",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/pull-requests.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-pull-requests-to-tabnine-rule",
-      "componentId": "cratis-rule-pull-requests",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/pull-requests.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-react-to-claude-code-rule",
-      "componentId": "cratis-rule-react",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/react.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-react-to-github-copilot-rule",
-      "componentId": "cratis-rule-react",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-react-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-react",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/react.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-react-to-tabnine-rule",
-      "componentId": "cratis-rule-react",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/react.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-reactors-to-claude-code-rule",
-      "componentId": "cratis-rule-reactors",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/reactors.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-reactors-to-github-copilot-rule",
-      "componentId": "cratis-rule-reactors",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-reactors-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-reactors",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/reactors.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-reactors-to-tabnine-rule",
-      "componentId": "cratis-rule-reactors",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/reactors.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-rtk-to-claude-code-rule",
-      "componentId": "cratis-rule-rtk",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/rtk.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-rtk-to-github-copilot-rule",
-      "componentId": "cratis-rule-rtk",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-rtk-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-rtk",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/rtk.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-rtk-to-tabnine-rule",
-      "componentId": "cratis-rule-rtk",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/rtk.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-specs-csharp-to-claude-code-rule",
-      "componentId": "cratis-rule-specs-csharp",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/specs.csharp.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-specs-csharp-to-github-copilot-rule",
-      "componentId": "cratis-rule-specs-csharp",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-specs-csharp-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-specs-csharp",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/specs.csharp.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-specs-csharp-to-tabnine-rule",
-      "componentId": "cratis-rule-specs-csharp",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/specs.csharp.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-specs-scenarios-csharp-to-claude-code-rule",
-      "componentId": "cratis-rule-specs-scenarios-csharp",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/specs.scenarios.csharp.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-specs-scenarios-csharp-to-github-copilot-rule",
-      "componentId": "cratis-rule-specs-scenarios-csharp",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-specs-scenarios-csharp-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-specs-scenarios-csharp",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/specs.scenarios.csharp.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-specs-scenarios-csharp-to-tabnine-rule",
-      "componentId": "cratis-rule-specs-scenarios-csharp",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/specs.scenarios.csharp.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-specs-to-claude-code-rule",
-      "componentId": "cratis-rule-specs",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/specs.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-specs-to-github-copilot-rule",
-      "componentId": "cratis-rule-specs",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-specs-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-specs",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/specs.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-specs-to-tabnine-rule",
-      "componentId": "cratis-rule-specs",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/specs.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-specs-typescript-to-claude-code-rule",
-      "componentId": "cratis-rule-specs-typescript",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/specs.typescript.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-specs-typescript-to-github-copilot-rule",
-      "componentId": "cratis-rule-specs-typescript",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-specs-typescript-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-specs-typescript",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/specs.typescript.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-specs-typescript-to-tabnine-rule",
-      "componentId": "cratis-rule-specs-typescript",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/specs.typescript.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-storybook-to-claude-code-rule",
-      "componentId": "cratis-rule-storybook",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/storybook.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-storybook-to-github-copilot-rule",
-      "componentId": "cratis-rule-storybook",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-storybook-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-storybook",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/storybook.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-storybook-to-tabnine-rule",
-      "componentId": "cratis-rule-storybook",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/storybook.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-terminal-commands-to-claude-code-rule",
-      "componentId": "cratis-rule-terminal-commands",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/terminal-commands.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-terminal-commands-to-github-copilot-rule",
-      "componentId": "cratis-rule-terminal-commands",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-terminal-commands-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-terminal-commands",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/terminal-commands.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-terminal-commands-to-tabnine-rule",
-      "componentId": "cratis-rule-terminal-commands",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/terminal-commands.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-typescript-to-claude-code-rule",
-      "componentId": "cratis-rule-typescript",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/typescript.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-typescript-to-github-copilot-rule",
-      "componentId": "cratis-rule-typescript",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-typescript-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-typescript",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/typescript.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-typescript-to-tabnine-rule",
-      "componentId": "cratis-rule-typescript",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/typescript.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-verification-discipline-to-claude-code-rule",
-      "componentId": "cratis-rule-verification-discipline",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/verification-discipline.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-verification-discipline-to-github-copilot-rule",
-      "componentId": "cratis-rule-verification-discipline",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-vertical-slices-to-claude-code-rule",
-      "componentId": "cratis-rule-vertical-slices",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/vertical-slices.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-vertical-slices-to-github-copilot-rule",
-      "componentId": "cratis-rule-vertical-slices",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-vertical-slices-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-vertical-slices",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/vertical-slices.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-vertical-slices-to-tabnine-rule",
-      "componentId": "cratis-rule-vertical-slices",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/vertical-slices.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-web-fetching-to-claude-code-rule",
-      "componentId": "cratis-rule-web-fetching",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/web-fetching.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-web-fetching-to-github-copilot-rule",
-      "componentId": "cratis-rule-web-fetching",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-web-fetching-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-web-fetching",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/web-fetching.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-web-fetching-to-tabnine-rule",
-      "componentId": "cratis-rule-web-fetching",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/web-fetching.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-work-records-and-comments-to-claude-code-rule",
-      "componentId": "cratis-rule-work-records-and-comments",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/work-records-and-comments.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-work-records-and-comments-to-github-copilot-rule",
-      "componentId": "cratis-rule-work-records-and-comments",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-writing-correct-examples-to-claude-code-rule",
-      "componentId": "cratis-rule-writing-correct-examples",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/writing-correct-examples.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-writing-correct-examples-to-github-copilot-rule",
-      "componentId": "cratis-rule-writing-correct-examples",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-writing-correct-examples-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-writing-correct-examples",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/writing-correct-examples.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-writing-correct-examples-to-tabnine-rule",
-      "componentId": "cratis-rule-writing-correct-examples",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/writing-correct-examples.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-writing-cratis-docs-to-claude-code-rule",
-      "componentId": "cratis-rule-writing-cratis-docs",
-      "hostId": "claude-code",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/rules/writing-cratis-docs.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-writing-cratis-docs-to-github-copilot-rule",
-      "componentId": "cratis-rule-writing-cratis-docs",
-      "hostId": "github-copilot",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/instructions"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-rule-writing-cratis-docs-to-jetbrains-ai-assistant-rule",
-      "componentId": "cratis-rule-writing-cratis-docs",
-      "hostId": "jetbrains-ai-assistant",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "jetbrains-ai-assistant-rules/.aiassistant/rules/writing-cratis-docs.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "jetbrains-ai-assistant-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "cratis-rule-writing-cratis-docs-to-tabnine-rule",
-      "componentId": "cratis-rule-writing-cratis-docs",
-      "hostId": "tabnine",
-      "projectedKind": "rule",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "generated-static",
-      "hostActivation": "none",
-      "adapterType": "generated",
-      "outputPaths": [
-        "tabnine-guidelines/.tabnine/guidelines/writing-cratis-docs.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "tabnine-source-1"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest",
-        "static-inventory"
-      ]
-    },
-    {
-      "id": "skill-creator-to-claude-code-skill",
-      "componentId": "skill-creator",
-      "hostId": "claude-code",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".claude/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "skill-creator-to-codex-skill",
-      "componentId": "skill-creator",
-      "hostId": "codex",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".agents/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "skill-creator-to-github-copilot-skill",
-      "componentId": "skill-creator",
-      "hostId": "github-copilot",
-      "projectedKind": "skill",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        ".github/skills"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    }
-  ]
+    "schemaVersion": 1,
+    "defaultPolicy": "deny",
+    "supportClaim": false,
+    "hosts": [
+        {
+            "id": "claude-code",
+            "contract": "claude-code",
+            "hostAdapterId": "claude-code-plugins-host-adapter",
+            "materialization": "repository-existing",
+            "staticOutputRoot": null,
+            "acceptsAnyPassiveProjection": true,
+            "allowedProjectedKinds": [
+                "command",
+                "hook",
+                "instruction",
+                "prompt",
+                "rule",
+                "skill",
+                "subagent"
+            ],
+            "allowedOutputPrefixes": [
+                ".claude"
+            ],
+            "sharedSymlinkOutputs": [
+                ".claude/agents",
+                ".claude/prompts",
+                ".claude/skills"
+            ],
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ]
+        },
+        {
+            "id": "codex",
+            "contract": "codex",
+            "hostAdapterId": "openai-plugins-host-adapter",
+            "materialization": "repository-existing",
+            "staticOutputRoot": null,
+            "acceptsAnyPassiveProjection": true,
+            "allowedProjectedKinds": [
+                "instruction",
+                "skill"
+            ],
+            "allowedOutputPrefixes": [
+                ".agents"
+            ],
+            "sharedSymlinkOutputs": [
+                ".agents/skills"
+            ],
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ]
+        },
+        {
+            "id": "devin-hosted",
+            "contract": "devin-hosted",
+            "hostAdapterId": "devin-hosted-host-adapter",
+            "materialization": "static-fixture",
+            "staticOutputRoot": "devin-hosted-instructions",
+            "acceptsAnyPassiveProjection": true,
+            "allowedProjectedKinds": [
+                "instruction"
+            ],
+            "allowedOutputPrefixes": [
+                "devin-hosted-instructions"
+            ],
+            "sharedSymlinkOutputs": [],
+            "evidenceIds": [
+                "devin-hosted-source-2"
+            ]
+        },
+        {
+            "id": "github-copilot",
+            "contract": "github-copilot",
+            "hostAdapterId": "github-copilot-plugins-host-adapter",
+            "materialization": "repository-existing",
+            "staticOutputRoot": null,
+            "acceptsAnyPassiveProjection": true,
+            "allowedProjectedKinds": [
+                "agent",
+                "instruction",
+                "prompt",
+                "rule",
+                "skill"
+            ],
+            "allowedOutputPrefixes": [
+                ".github/agents",
+                ".github/copilot-instructions.md",
+                ".github/instructions",
+                ".github/prompts",
+                ".github/skills"
+            ],
+            "sharedSymlinkOutputs": [
+                ".github/instructions",
+                ".github/prompts",
+                ".github/skills"
+            ],
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ]
+        },
+        {
+            "id": "jetbrains-ai-assistant",
+            "contract": "jetbrains-ai-assistant",
+            "hostAdapterId": "jetbrains-ai-assistant-host-adapter",
+            "materialization": "static-fixture",
+            "staticOutputRoot": "jetbrains-ai-assistant-rules",
+            "acceptsAnyPassiveProjection": true,
+            "allowedProjectedKinds": [
+                "rule"
+            ],
+            "allowedOutputPrefixes": [
+                "jetbrains-ai-assistant-rules"
+            ],
+            "sharedSymlinkOutputs": [],
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ]
+        },
+        {
+            "id": "pi",
+            "contract": "pi",
+            "hostAdapterId": "pi-packages-host-adapter",
+            "materialization": "repository-existing",
+            "staticOutputRoot": null,
+            "acceptsAnyPassiveProjection": true,
+            "allowedProjectedKinds": [
+                "agent",
+                "executable-host-extension",
+                "prompt"
+            ],
+            "allowedOutputPrefixes": [
+                ".pi/agents",
+                ".pi/extensions",
+                ".pi/prompts"
+            ],
+            "sharedSymlinkOutputs": [],
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ]
+        },
+        {
+            "id": "portable-agent-plugins-1-0",
+            "contract": "portable-agent-plugins-1-0",
+            "hostAdapterId": null,
+            "materialization": "none",
+            "staticOutputRoot": null,
+            "acceptsAnyPassiveProjection": false,
+            "allowedProjectedKinds": [
+                "skill",
+                "mcp"
+            ],
+            "allowedOutputPrefixes": [],
+            "sharedSymlinkOutputs": [],
+            "evidenceIds": [
+                "agent-plugins-source-1",
+                "agent-plugins-source-2"
+            ]
+        },
+        {
+            "id": "tabnine",
+            "contract": "tabnine",
+            "hostAdapterId": "tabnine-host-adapter",
+            "materialization": "static-fixture",
+            "staticOutputRoot": "tabnine-guidelines",
+            "acceptsAnyPassiveProjection": true,
+            "allowedProjectedKinds": [
+                "rule"
+            ],
+            "allowedOutputPrefixes": [
+                "tabnine-guidelines"
+            ],
+            "sharedSymlinkOutputs": [],
+            "evidenceIds": [
+                "tabnine-source-1"
+            ]
+        },
+        {
+            "id": "visual-studio-copilot",
+            "contract": "visual-studio-copilot",
+            "hostAdapterId": "visual-studio-copilot-host-adapter",
+            "materialization": "static-fixture",
+            "staticOutputRoot": "visual-studio-copilot-instructions",
+            "acceptsAnyPassiveProjection": true,
+            "allowedProjectedKinds": [
+                "instruction"
+            ],
+            "allowedOutputPrefixes": [
+                "visual-studio-copilot-instructions"
+            ],
+            "sharedSymlinkOutputs": [],
+            "evidenceIds": [
+                "visual-studio-copilot-source-2"
+            ]
+        }
+    ],
+    "projections": [
+        {
+            "id": "cratis-agent-backend-developer-to-claude-code-subagent",
+            "componentId": "cratis-agent-backend-developer",
+            "hostId": "claude-code",
+            "projectedKind": "subagent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/agents"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-backend-developer-to-github-copilot-agent",
+            "componentId": "cratis-agent-backend-developer",
+            "hostId": "github-copilot",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/agents/backend-developer.agent.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-backend-developer-to-pi-agent",
+            "componentId": "cratis-agent-backend-developer",
+            "hostId": "pi",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "generated",
+            "outputPaths": [
+                ".pi/agents/backend-developer.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-code-reviewer-to-claude-code-subagent",
+            "componentId": "cratis-agent-code-reviewer",
+            "hostId": "claude-code",
+            "projectedKind": "subagent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/agents"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-code-reviewer-to-github-copilot-agent",
+            "componentId": "cratis-agent-code-reviewer",
+            "hostId": "github-copilot",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/agents/code-reviewer.agent.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-code-reviewer-to-pi-agent",
+            "componentId": "cratis-agent-code-reviewer",
+            "hostId": "pi",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "generated",
+            "outputPaths": [
+                ".pi/agents/code-reviewer.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-coordinator-to-claude-code-subagent",
+            "componentId": "cratis-agent-coordinator",
+            "hostId": "claude-code",
+            "projectedKind": "subagent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/agents"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-coordinator-to-github-copilot-agent",
+            "componentId": "cratis-agent-coordinator",
+            "hostId": "github-copilot",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/agents/coordinator.agent.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-coordinator-to-pi-agent",
+            "componentId": "cratis-agent-coordinator",
+            "hostId": "pi",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "generated",
+            "outputPaths": [
+                ".pi/agents/coordinator.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-frontend-developer-to-claude-code-subagent",
+            "componentId": "cratis-agent-frontend-developer",
+            "hostId": "claude-code",
+            "projectedKind": "subagent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/agents"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-frontend-developer-to-github-copilot-agent",
+            "componentId": "cratis-agent-frontend-developer",
+            "hostId": "github-copilot",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/agents/frontend-developer.agent.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-frontend-developer-to-pi-agent",
+            "componentId": "cratis-agent-frontend-developer",
+            "hostId": "pi",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "generated",
+            "outputPaths": [
+                ".pi/agents/frontend-developer.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-orchestrator-to-claude-code-subagent",
+            "componentId": "cratis-agent-orchestrator",
+            "hostId": "claude-code",
+            "projectedKind": "subagent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/agents"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-orchestrator-to-github-copilot-agent",
+            "componentId": "cratis-agent-orchestrator",
+            "hostId": "github-copilot",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/agents/orchestrator.agent.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-orchestrator-to-pi-agent",
+            "componentId": "cratis-agent-orchestrator",
+            "hostId": "pi",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "generated",
+            "outputPaths": [
+                ".pi/agents/orchestrator.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-performance-reviewer-to-claude-code-subagent",
+            "componentId": "cratis-agent-performance-reviewer",
+            "hostId": "claude-code",
+            "projectedKind": "subagent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/agents"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-performance-reviewer-to-github-copilot-agent",
+            "componentId": "cratis-agent-performance-reviewer",
+            "hostId": "github-copilot",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/agents/performance-reviewer.agent.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-performance-reviewer-to-pi-agent",
+            "componentId": "cratis-agent-performance-reviewer",
+            "hostId": "pi",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "generated",
+            "outputPaths": [
+                ".pi/agents/performance-reviewer.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-planner-to-claude-code-subagent",
+            "componentId": "cratis-agent-planner",
+            "hostId": "claude-code",
+            "projectedKind": "subagent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/agents"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-planner-to-github-copilot-agent",
+            "componentId": "cratis-agent-planner",
+            "hostId": "github-copilot",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/agents/planner.agent.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-planner-to-pi-agent",
+            "componentId": "cratis-agent-planner",
+            "hostId": "pi",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "generated",
+            "outputPaths": [
+                ".pi/agents/planner.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-repository-investigation-reviewer-to-claude-code-subagent",
+            "componentId": "cratis-agent-repository-investigation-reviewer",
+            "hostId": "claude-code",
+            "projectedKind": "subagent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/agents"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-repository-investigation-reviewer-to-github-copilot-agent",
+            "componentId": "cratis-agent-repository-investigation-reviewer",
+            "hostId": "github-copilot",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "inert",
+            "adapterType": "path-reference",
+            "outputPaths": [
+                ".github/agents/repository-investigation-reviewer.agent.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-repository-investigation-reviewer-to-pi-agent",
+            "componentId": "cratis-agent-repository-investigation-reviewer",
+            "hostId": "pi",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "generated",
+            "outputPaths": [
+                ".pi/agents/repository-investigation-reviewer.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-repository-investigator-to-claude-code-subagent",
+            "componentId": "cratis-agent-repository-investigator",
+            "hostId": "claude-code",
+            "projectedKind": "subagent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/agents"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-repository-investigator-to-github-copilot-agent",
+            "componentId": "cratis-agent-repository-investigator",
+            "hostId": "github-copilot",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "inert",
+            "adapterType": "path-reference",
+            "outputPaths": [
+                ".github/agents/repository-investigator.agent.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-repository-investigator-to-pi-agent",
+            "componentId": "cratis-agent-repository-investigator",
+            "hostId": "pi",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "generated",
+            "outputPaths": [
+                ".pi/agents/repository-investigator.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-security-reviewer-to-claude-code-subagent",
+            "componentId": "cratis-agent-security-reviewer",
+            "hostId": "claude-code",
+            "projectedKind": "subagent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/agents"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-security-reviewer-to-github-copilot-agent",
+            "componentId": "cratis-agent-security-reviewer",
+            "hostId": "github-copilot",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/agents/security-reviewer.agent.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-security-reviewer-to-pi-agent",
+            "componentId": "cratis-agent-security-reviewer",
+            "hostId": "pi",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "generated",
+            "outputPaths": [
+                ".pi/agents/security-reviewer.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-slice-implementer-to-claude-code-subagent",
+            "componentId": "cratis-agent-slice-implementer",
+            "hostId": "claude-code",
+            "projectedKind": "subagent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/agents"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-slice-implementer-to-github-copilot-agent",
+            "componentId": "cratis-agent-slice-implementer",
+            "hostId": "github-copilot",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/agents/slice-implementer.agent.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-slice-implementer-to-pi-agent",
+            "componentId": "cratis-agent-slice-implementer",
+            "hostId": "pi",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "generated",
+            "outputPaths": [
+                ".pi/agents/slice-implementer.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-spec-writer-to-claude-code-subagent",
+            "componentId": "cratis-agent-spec-writer",
+            "hostId": "claude-code",
+            "projectedKind": "subagent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/agents"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-spec-writer-to-github-copilot-agent",
+            "componentId": "cratis-agent-spec-writer",
+            "hostId": "github-copilot",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/agents/spec-writer.agent.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-agent-spec-writer-to-pi-agent",
+            "componentId": "cratis-agent-spec-writer",
+            "hostId": "pi",
+            "projectedKind": "agent",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "generated",
+            "outputPaths": [
+                ".pi/agents/spec-writer.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-application-slice-diagnostics-to-claude-code-skill",
+            "componentId": "cratis-application-slice-diagnostics",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-application-slice-diagnostics-to-codex-skill",
+            "componentId": "cratis-application-slice-diagnostics",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-application-slice-diagnostics-to-github-copilot-skill",
+            "componentId": "cratis-application-slice-diagnostics",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-application-vertical-slice-to-claude-code-skill",
+            "componentId": "cratis-application-vertical-slice",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-application-vertical-slice-to-codex-skill",
+            "componentId": "cratis-application-vertical-slice",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-application-vertical-slice-to-github-copilot-skill",
+            "componentId": "cratis-application-vertical-slice",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-arc-react-feature-scaffolding-to-claude-code-skill",
+            "componentId": "cratis-arc-react-feature-scaffolding",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-arc-react-feature-scaffolding-to-codex-skill",
+            "componentId": "cratis-arc-react-feature-scaffolding",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-arc-react-feature-scaffolding-to-github-copilot-skill",
+            "componentId": "cratis-arc-react-feature-scaffolding",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-chronicle-event-metadata-to-claude-code-skill",
+            "componentId": "cratis-chronicle-event-metadata",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-chronicle-event-metadata-to-codex-skill",
+            "componentId": "cratis-chronicle-event-metadata",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-chronicle-event-metadata-to-github-copilot-skill",
+            "componentId": "cratis-chronicle-event-metadata",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-command-add-business-rule-to-claude-code-command",
+            "componentId": "cratis-command-add-business-rule",
+            "hostId": "claude-code",
+            "projectedKind": "command",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/commands/add-business-rule.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-command-add-concept-to-claude-code-command",
+            "componentId": "cratis-command-add-concept",
+            "hostId": "claude-code",
+            "projectedKind": "command",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/commands/add-concept.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-command-add-ef-migration-to-claude-code-command",
+            "componentId": "cratis-command-add-ef-migration",
+            "hostId": "claude-code",
+            "projectedKind": "command",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/commands/add-ef-migration.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-command-add-projection-to-claude-code-command",
+            "componentId": "cratis-command-add-projection",
+            "hostId": "claude-code",
+            "projectedKind": "command",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/commands/add-projection.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-command-add-reactor-to-claude-code-command",
+            "componentId": "cratis-command-add-reactor",
+            "hostId": "claude-code",
+            "projectedKind": "command",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/commands/add-reactor.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-command-add-reducer-to-claude-code-command",
+            "componentId": "cratis-command-add-reducer",
+            "hostId": "claude-code",
+            "projectedKind": "command",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/commands/add-reducer.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-command-audit-hooks-to-claude-code-command",
+            "componentId": "cratis-command-audit-hooks",
+            "hostId": "claude-code",
+            "projectedKind": "command",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/commands/audit-hooks.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-command-check-doc-drift-to-claude-code-command",
+            "componentId": "cratis-command-check-doc-drift",
+            "hostId": "claude-code",
+            "projectedKind": "command",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/commands/check-doc-drift.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-command-code-review-to-claude-code-command",
+            "componentId": "cratis-command-code-review",
+            "hostId": "claude-code",
+            "projectedKind": "command",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/commands/code-review.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-command-new-feature-to-claude-code-command",
+            "componentId": "cratis-command-new-feature",
+            "hostId": "claude-code",
+            "projectedKind": "command",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/commands/new-feature.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-command-new-vertical-slice-to-claude-code-command",
+            "componentId": "cratis-command-new-vertical-slice",
+            "hostId": "claude-code",
+            "projectedKind": "command",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/commands/new-vertical-slice.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-command-review-pr-to-claude-code-command",
+            "componentId": "cratis-command-review-pr",
+            "hostId": "claude-code",
+            "projectedKind": "command",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/commands/review-pr.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-command-review-skill-to-claude-code-command",
+            "componentId": "cratis-command-review-skill",
+            "hostId": "claude-code",
+            "projectedKind": "command",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/commands/review-skill.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-command-scaffold-feature-to-claude-code-command",
+            "componentId": "cratis-command-scaffold-feature",
+            "hostId": "claude-code",
+            "projectedKind": "command",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/commands/scaffold-feature.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-command-ship-changes-to-claude-code-command",
+            "componentId": "cratis-command-ship-changes",
+            "hostId": "claude-code",
+            "projectedKind": "command",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/commands/ship-changes.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-command-verify-ai-setup-to-claude-code-command",
+            "componentId": "cratis-command-verify-ai-setup",
+            "hostId": "claude-code",
+            "projectedKind": "command",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/commands/verify-ai-setup.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-command-write-documentation-to-claude-code-command",
+            "componentId": "cratis-command-write-documentation",
+            "hostId": "claude-code",
+            "projectedKind": "command",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/commands/write-documentation.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-command-write-specs-to-claude-code-command",
+            "componentId": "cratis-command-write-specs",
+            "hostId": "claude-code",
+            "projectedKind": "command",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/commands/write-specs.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-engineering-docs-visual-qa-to-claude-code-skill",
+            "componentId": "cratis-engineering-docs-visual-qa",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-engineering-docs-visual-qa-to-codex-skill",
+            "componentId": "cratis-engineering-docs-visual-qa",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-engineering-docs-visual-qa-to-github-copilot-skill",
+            "componentId": "cratis-engineering-docs-visual-qa",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-engineering-ship-changes-to-claude-code-skill",
+            "componentId": "cratis-engineering-ship-changes",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-engineering-ship-changes-to-codex-skill",
+            "componentId": "cratis-engineering-ship-changes",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-engineering-ship-changes-to-github-copilot-skill",
+            "componentId": "cratis-engineering-ship-changes",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-hooks-to-claude-code-hook",
+            "componentId": "cratis-hooks",
+            "hostId": "claude-code",
+            "projectedKind": "hook",
+            "artifactClass": "executable-plugin-package",
+            "assuranceProfileId": "executable-plugin-package-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/hooks"
+            ],
+            "approval": "blocked",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [
+                "effect-boundary",
+                "security-review",
+                "threat-model"
+            ],
+            "requiredCanaries": [
+                "effect-boundary",
+                "host-discovery",
+                "security-review",
+                "threat-model"
+            ]
+        },
+        {
+            "id": "cratis-instruction-general-to-claude-code-instruction",
+            "componentId": "cratis-instruction-general",
+            "hostId": "claude-code",
+            "projectedKind": "instruction",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/CLAUDE.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-instruction-general-to-devin-hosted-instruction",
+            "componentId": "cratis-instruction-general",
+            "hostId": "devin-hosted",
+            "projectedKind": "instruction",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "devin-hosted-instructions/AGENTS.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "devin-hosted-source-2"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-instruction-general-to-github-copilot-instruction",
+            "componentId": "cratis-instruction-general",
+            "hostId": "github-copilot",
+            "projectedKind": "instruction",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "inert",
+            "adapterType": "path-reference",
+            "outputPaths": [
+                ".github/copilot-instructions.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-instruction-general-to-github-copilot-shared-instruction",
+            "componentId": "cratis-instruction-general",
+            "hostId": "github-copilot",
+            "projectedKind": "instruction",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-instruction-general-to-visual-studio-copilot-instruction",
+            "componentId": "cratis-instruction-general",
+            "hostId": "visual-studio-copilot",
+            "projectedKind": "instruction",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "visual-studio-copilot-instructions/.github/copilot-instructions.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "visual-studio-copilot-source-2"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-business-rule-to-claude-code-skill",
+            "componentId": "cratis-legacy-add-business-rule",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-business-rule-to-codex-skill",
+            "componentId": "cratis-legacy-add-business-rule",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-business-rule-to-github-copilot-skill",
+            "componentId": "cratis-legacy-add-business-rule",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-concept-to-claude-code-skill",
+            "componentId": "cratis-legacy-add-concept",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-concept-to-codex-skill",
+            "componentId": "cratis-legacy-add-concept",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-concept-to-github-copilot-skill",
+            "componentId": "cratis-legacy-add-concept",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-cratis-docs-page-to-claude-code-skill",
+            "componentId": "cratis-legacy-add-cratis-docs-page",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-cratis-docs-page-to-codex-skill",
+            "componentId": "cratis-legacy-add-cratis-docs-page",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-cratis-docs-page-to-github-copilot-skill",
+            "componentId": "cratis-legacy-add-cratis-docs-page",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-ef-migration-to-claude-code-skill",
+            "componentId": "cratis-legacy-add-ef-migration",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-ef-migration-to-codex-skill",
+            "componentId": "cratis-legacy-add-ef-migration",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-ef-migration-to-github-copilot-skill",
+            "componentId": "cratis-legacy-add-ef-migration",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-projection-to-claude-code-skill",
+            "componentId": "cratis-legacy-add-projection",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-projection-to-codex-skill",
+            "componentId": "cratis-legacy-add-projection",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-projection-to-github-copilot-skill",
+            "componentId": "cratis-legacy-add-projection",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-reactor-to-claude-code-skill",
+            "componentId": "cratis-legacy-add-reactor",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-reactor-to-codex-skill",
+            "componentId": "cratis-legacy-add-reactor",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-reactor-to-github-copilot-skill",
+            "componentId": "cratis-legacy-add-reactor",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-reducer-to-claude-code-skill",
+            "componentId": "cratis-legacy-add-reducer",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-reducer-to-codex-skill",
+            "componentId": "cratis-legacy-add-reducer",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-reducer-to-github-copilot-skill",
+            "componentId": "cratis-legacy-add-reducer",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-traces-to-claude-code-skill",
+            "componentId": "cratis-legacy-add-traces",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-traces-to-codex-skill",
+            "componentId": "cratis-legacy-add-traces",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-add-traces-to-github-copilot-skill",
+            "componentId": "cratis-legacy-add-traces",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-auth-and-identity-to-claude-code-skill",
+            "componentId": "cratis-legacy-auth-and-identity",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-auth-and-identity-to-codex-skill",
+            "componentId": "cratis-legacy-auth-and-identity",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-auth-and-identity-to-github-copilot-skill",
+            "componentId": "cratis-legacy-auth-and-identity",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-call-command-from-code-to-claude-code-skill",
+            "componentId": "cratis-legacy-call-command-from-code",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-call-command-from-code-to-codex-skill",
+            "componentId": "cratis-legacy-call-command-from-code",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-call-command-from-code-to-github-copilot-skill",
+            "componentId": "cratis-legacy-call-command-from-code",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-cratis-command-to-claude-code-skill",
+            "componentId": "cratis-legacy-cratis-command",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-cratis-command-to-codex-skill",
+            "componentId": "cratis-legacy-cratis-command",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-cratis-command-to-github-copilot-skill",
+            "componentId": "cratis-legacy-cratis-command",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-cratis-csharp-standards-to-claude-code-skill",
+            "componentId": "cratis-legacy-cratis-csharp-standards",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-cratis-csharp-standards-to-codex-skill",
+            "componentId": "cratis-legacy-cratis-csharp-standards",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-cratis-csharp-standards-to-github-copilot-skill",
+            "componentId": "cratis-legacy-cratis-csharp-standards",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-cratis-react-page-to-claude-code-skill",
+            "componentId": "cratis-legacy-cratis-react-page",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-cratis-react-page-to-codex-skill",
+            "componentId": "cratis-legacy-cratis-react-page",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-cratis-react-page-to-github-copilot-skill",
+            "componentId": "cratis-legacy-cratis-react-page",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-cratis-readmodel-to-claude-code-skill",
+            "componentId": "cratis-legacy-cratis-readmodel",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-cratis-readmodel-to-codex-skill",
+            "componentId": "cratis-legacy-cratis-readmodel",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-cratis-readmodel-to-github-copilot-skill",
+            "componentId": "cratis-legacy-cratis-readmodel",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-cratis-specs-csharp-to-claude-code-skill",
+            "componentId": "cratis-legacy-cratis-specs-csharp",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-cratis-specs-csharp-to-codex-skill",
+            "componentId": "cratis-legacy-cratis-specs-csharp",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-cratis-specs-csharp-to-github-copilot-skill",
+            "componentId": "cratis-legacy-cratis-specs-csharp",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-cratis-specs-typescript-to-claude-code-skill",
+            "componentId": "cratis-legacy-cratis-specs-typescript",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-cratis-specs-typescript-to-codex-skill",
+            "componentId": "cratis-legacy-cratis-specs-typescript",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-cratis-specs-typescript-to-github-copilot-skill",
+            "componentId": "cratis-legacy-cratis-specs-typescript",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-create-event-model-to-claude-code-skill",
+            "componentId": "cratis-legacy-create-event-model",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-create-event-model-to-codex-skill",
+            "componentId": "cratis-legacy-create-event-model",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-create-event-model-to-github-copilot-skill",
+            "componentId": "cratis-legacy-create-event-model",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-discover-implementations-to-claude-code-skill",
+            "componentId": "cratis-legacy-discover-implementations",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-discover-implementations-to-codex-skill",
+            "componentId": "cratis-legacy-discover-implementations",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-discover-implementations-to-github-copilot-skill",
+            "componentId": "cratis-legacy-discover-implementations",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-edit-cratis-docs-to-claude-code-skill",
+            "componentId": "cratis-legacy-edit-cratis-docs",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-edit-cratis-docs-to-codex-skill",
+            "componentId": "cratis-legacy-edit-cratis-docs",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-edit-cratis-docs-to-github-copilot-skill",
+            "componentId": "cratis-legacy-edit-cratis-docs",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-event-modeling-to-claude-code-skill",
+            "componentId": "cratis-legacy-event-modeling",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-event-modeling-to-codex-skill",
+            "componentId": "cratis-legacy-event-modeling",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-event-modeling-to-github-copilot-skill",
+            "componentId": "cratis-legacy-event-modeling",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-event-type-migrations-to-claude-code-skill",
+            "componentId": "cratis-legacy-event-type-migrations",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-event-type-migrations-to-codex-skill",
+            "componentId": "cratis-legacy-event-type-migrations",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-event-type-migrations-to-github-copilot-skill",
+            "componentId": "cratis-legacy-event-type-migrations",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-inspect-running-chronicle-to-claude-code-skill",
+            "componentId": "cratis-legacy-inspect-running-chronicle",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-inspect-running-chronicle-to-codex-skill",
+            "componentId": "cratis-legacy-inspect-running-chronicle",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-inspect-running-chronicle-to-github-copilot-skill",
+            "componentId": "cratis-legacy-inspect-running-chronicle",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-multi-tenancy-to-claude-code-skill",
+            "componentId": "cratis-legacy-multi-tenancy",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-multi-tenancy-to-codex-skill",
+            "componentId": "cratis-legacy-multi-tenancy",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-multi-tenancy-to-github-copilot-skill",
+            "componentId": "cratis-legacy-multi-tenancy",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-observable-query-curl-to-claude-code-skill",
+            "componentId": "cratis-legacy-observable-query-curl",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-observable-query-curl-to-codex-skill",
+            "componentId": "cratis-legacy-observable-query-curl",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-observable-query-curl-to-github-copilot-skill",
+            "componentId": "cratis-legacy-observable-query-curl",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-query-paging-to-claude-code-skill",
+            "componentId": "cratis-legacy-query-paging",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-query-paging-to-codex-skill",
+            "componentId": "cratis-legacy-query-paging",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-query-paging-to-github-copilot-skill",
+            "componentId": "cratis-legacy-query-paging",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-review-code-to-claude-code-skill",
+            "componentId": "cratis-legacy-review-code",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-review-code-to-codex-skill",
+            "componentId": "cratis-legacy-review-code",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-review-code-to-github-copilot-skill",
+            "componentId": "cratis-legacy-review-code",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-review-performance-to-claude-code-skill",
+            "componentId": "cratis-legacy-review-performance",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-review-performance-to-codex-skill",
+            "componentId": "cratis-legacy-review-performance",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-review-performance-to-github-copilot-skill",
+            "componentId": "cratis-legacy-review-performance",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-review-security-to-claude-code-skill",
+            "componentId": "cratis-legacy-review-security",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-review-security-to-codex-skill",
+            "componentId": "cratis-legacy-review-security",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-review-security-to-github-copilot-skill",
+            "componentId": "cratis-legacy-review-security",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-stepper-command-dialog-to-claude-code-skill",
+            "componentId": "cratis-legacy-stepper-command-dialog",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-stepper-command-dialog-to-codex-skill",
+            "componentId": "cratis-legacy-stepper-command-dialog",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-stepper-command-dialog-to-github-copilot-skill",
+            "componentId": "cratis-legacy-stepper-command-dialog",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-toolbar-to-claude-code-skill",
+            "componentId": "cratis-legacy-toolbar",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-toolbar-to-codex-skill",
+            "componentId": "cratis-legacy-toolbar",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-toolbar-to-github-copilot-skill",
+            "componentId": "cratis-legacy-toolbar",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-write-documentation-to-claude-code-skill",
+            "componentId": "cratis-legacy-write-documentation",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-write-documentation-to-codex-skill",
+            "componentId": "cratis-legacy-write-documentation",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-write-documentation-to-github-copilot-skill",
+            "componentId": "cratis-legacy-write-documentation",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-write-specs-events-to-claude-code-skill",
+            "componentId": "cratis-legacy-write-specs-events",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-write-specs-events-to-codex-skill",
+            "componentId": "cratis-legacy-write-specs-events",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-write-specs-events-to-github-copilot-skill",
+            "componentId": "cratis-legacy-write-specs-events",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-write-specs-frontend-to-claude-code-skill",
+            "componentId": "cratis-legacy-write-specs-frontend",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-write-specs-frontend-to-codex-skill",
+            "componentId": "cratis-legacy-write-specs-frontend",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-write-specs-frontend-to-github-copilot-skill",
+            "componentId": "cratis-legacy-write-specs-frontend",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-write-specs-readmodels-to-claude-code-skill",
+            "componentId": "cratis-legacy-write-specs-readmodels",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-write-specs-readmodels-to-codex-skill",
+            "componentId": "cratis-legacy-write-specs-readmodels",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-write-specs-readmodels-to-github-copilot-skill",
+            "componentId": "cratis-legacy-write-specs-readmodels",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-write-specs-to-claude-code-skill",
+            "componentId": "cratis-legacy-write-specs",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-write-specs-to-codex-skill",
+            "componentId": "cratis-legacy-write-specs",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-legacy-write-specs-to-github-copilot-skill",
+            "componentId": "cratis-legacy-write-specs",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-pi-hooks-extension-to-pi-executable-host-extension",
+            "componentId": "cratis-pi-hooks-extension",
+            "hostId": "pi",
+            "projectedKind": "executable-host-extension",
+            "artifactClass": "executable-plugin-package",
+            "assuranceProfileId": "executable-plugin-package-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "canonical-in-place",
+            "outputPaths": [
+                ".pi/extensions/cratis-hooks/index.ts"
+            ],
+            "approval": "blocked",
+            "evidenceIds": [
+                "ai-126",
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [
+                "effect-boundary",
+                "security-review",
+                "threat-model"
+            ],
+            "requiredCanaries": [
+                "effect-boundary",
+                "host-discovery",
+                "security-review",
+                "threat-model"
+            ]
+        },
+        {
+            "id": "cratis-pi-subagent-extension-to-pi-executable-host-extension",
+            "componentId": "cratis-pi-subagent-extension",
+            "hostId": "pi",
+            "projectedKind": "executable-host-extension",
+            "artifactClass": "executable-plugin-package",
+            "assuranceProfileId": "executable-plugin-package-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "canonical-in-place",
+            "outputPaths": [
+                ".pi/extensions/subagent/agents.ts",
+                ".pi/extensions/subagent/index.ts"
+            ],
+            "approval": "blocked",
+            "evidenceIds": [
+                "ai-126",
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [
+                "effect-boundary",
+                "security-review",
+                "threat-model"
+            ],
+            "requiredCanaries": [
+                "effect-boundary",
+                "host-discovery",
+                "security-review",
+                "threat-model"
+            ]
+        },
+        {
+            "id": "cratis-prompt-add-business-rule-to-claude-code-prompt",
+            "componentId": "cratis-prompt-add-business-rule",
+            "hostId": "claude-code",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-add-business-rule-to-github-copilot-prompt",
+            "componentId": "cratis-prompt-add-business-rule",
+            "hostId": "github-copilot",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-add-business-rule-to-pi-prompt",
+            "componentId": "cratis-prompt-add-business-rule",
+            "hostId": "pi",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".pi/prompts/add-business-rule.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-add-concept-to-claude-code-prompt",
+            "componentId": "cratis-prompt-add-concept",
+            "hostId": "claude-code",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-add-concept-to-github-copilot-prompt",
+            "componentId": "cratis-prompt-add-concept",
+            "hostId": "github-copilot",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-add-concept-to-pi-prompt",
+            "componentId": "cratis-prompt-add-concept",
+            "hostId": "pi",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".pi/prompts/add-concept.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-add-ef-migration-to-claude-code-prompt",
+            "componentId": "cratis-prompt-add-ef-migration",
+            "hostId": "claude-code",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-add-ef-migration-to-github-copilot-prompt",
+            "componentId": "cratis-prompt-add-ef-migration",
+            "hostId": "github-copilot",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-add-ef-migration-to-pi-prompt",
+            "componentId": "cratis-prompt-add-ef-migration",
+            "hostId": "pi",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".pi/prompts/add-ef-migration.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-add-projection-to-claude-code-prompt",
+            "componentId": "cratis-prompt-add-projection",
+            "hostId": "claude-code",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-add-projection-to-github-copilot-prompt",
+            "componentId": "cratis-prompt-add-projection",
+            "hostId": "github-copilot",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-add-projection-to-pi-prompt",
+            "componentId": "cratis-prompt-add-projection",
+            "hostId": "pi",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".pi/prompts/add-projection.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-add-reactor-to-claude-code-prompt",
+            "componentId": "cratis-prompt-add-reactor",
+            "hostId": "claude-code",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-add-reactor-to-github-copilot-prompt",
+            "componentId": "cratis-prompt-add-reactor",
+            "hostId": "github-copilot",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-add-reactor-to-pi-prompt",
+            "componentId": "cratis-prompt-add-reactor",
+            "hostId": "pi",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".pi/prompts/add-reactor.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-add-reducer-to-claude-code-prompt",
+            "componentId": "cratis-prompt-add-reducer",
+            "hostId": "claude-code",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-add-reducer-to-github-copilot-prompt",
+            "componentId": "cratis-prompt-add-reducer",
+            "hostId": "github-copilot",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-add-reducer-to-pi-prompt",
+            "componentId": "cratis-prompt-add-reducer",
+            "hostId": "pi",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".pi/prompts/add-reducer.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-audit-hooks-to-claude-code-prompt",
+            "componentId": "cratis-prompt-audit-hooks",
+            "hostId": "claude-code",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-audit-hooks-to-github-copilot-prompt",
+            "componentId": "cratis-prompt-audit-hooks",
+            "hostId": "github-copilot",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-audit-hooks-to-pi-prompt",
+            "componentId": "cratis-prompt-audit-hooks",
+            "hostId": "pi",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".pi/prompts/audit-hooks.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-check-doc-drift-to-claude-code-prompt",
+            "componentId": "cratis-prompt-check-doc-drift",
+            "hostId": "claude-code",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-check-doc-drift-to-github-copilot-prompt",
+            "componentId": "cratis-prompt-check-doc-drift",
+            "hostId": "github-copilot",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-check-doc-drift-to-pi-prompt",
+            "componentId": "cratis-prompt-check-doc-drift",
+            "hostId": "pi",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".pi/prompts/check-doc-drift.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-code-review-to-claude-code-prompt",
+            "componentId": "cratis-prompt-code-review",
+            "hostId": "claude-code",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-code-review-to-github-copilot-prompt",
+            "componentId": "cratis-prompt-code-review",
+            "hostId": "github-copilot",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-code-review-to-pi-prompt",
+            "componentId": "cratis-prompt-code-review",
+            "hostId": "pi",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".pi/prompts/code-review.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-new-feature-to-claude-code-prompt",
+            "componentId": "cratis-prompt-new-feature",
+            "hostId": "claude-code",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-new-feature-to-github-copilot-prompt",
+            "componentId": "cratis-prompt-new-feature",
+            "hostId": "github-copilot",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-new-feature-to-pi-prompt",
+            "componentId": "cratis-prompt-new-feature",
+            "hostId": "pi",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".pi/prompts/new-feature.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-new-vertical-slice-to-claude-code-prompt",
+            "componentId": "cratis-prompt-new-vertical-slice",
+            "hostId": "claude-code",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-new-vertical-slice-to-github-copilot-prompt",
+            "componentId": "cratis-prompt-new-vertical-slice",
+            "hostId": "github-copilot",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-new-vertical-slice-to-pi-prompt",
+            "componentId": "cratis-prompt-new-vertical-slice",
+            "hostId": "pi",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".pi/prompts/new-vertical-slice.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-review-pr-to-claude-code-prompt",
+            "componentId": "cratis-prompt-review-pr",
+            "hostId": "claude-code",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-review-pr-to-github-copilot-prompt",
+            "componentId": "cratis-prompt-review-pr",
+            "hostId": "github-copilot",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-review-pr-to-pi-prompt",
+            "componentId": "cratis-prompt-review-pr",
+            "hostId": "pi",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".pi/prompts/review-pr.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-review-skill-to-claude-code-prompt",
+            "componentId": "cratis-prompt-review-skill",
+            "hostId": "claude-code",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-review-skill-to-github-copilot-prompt",
+            "componentId": "cratis-prompt-review-skill",
+            "hostId": "github-copilot",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-review-skill-to-pi-prompt",
+            "componentId": "cratis-prompt-review-skill",
+            "hostId": "pi",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".pi/prompts/review-skill.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-scaffold-feature-to-claude-code-prompt",
+            "componentId": "cratis-prompt-scaffold-feature",
+            "hostId": "claude-code",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-scaffold-feature-to-github-copilot-prompt",
+            "componentId": "cratis-prompt-scaffold-feature",
+            "hostId": "github-copilot",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-scaffold-feature-to-pi-prompt",
+            "componentId": "cratis-prompt-scaffold-feature",
+            "hostId": "pi",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".pi/prompts/scaffold-feature.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-ship-changes-to-claude-code-prompt",
+            "componentId": "cratis-prompt-ship-changes",
+            "hostId": "claude-code",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-ship-changes-to-github-copilot-prompt",
+            "componentId": "cratis-prompt-ship-changes",
+            "hostId": "github-copilot",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-ship-changes-to-pi-prompt",
+            "componentId": "cratis-prompt-ship-changes",
+            "hostId": "pi",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".pi/prompts/ship-changes.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-verify-ai-setup-to-claude-code-prompt",
+            "componentId": "cratis-prompt-verify-ai-setup",
+            "hostId": "claude-code",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-verify-ai-setup-to-github-copilot-prompt",
+            "componentId": "cratis-prompt-verify-ai-setup",
+            "hostId": "github-copilot",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-verify-ai-setup-to-pi-prompt",
+            "componentId": "cratis-prompt-verify-ai-setup",
+            "hostId": "pi",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".pi/prompts/verify-ai-setup.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-write-documentation-to-claude-code-prompt",
+            "componentId": "cratis-prompt-write-documentation",
+            "hostId": "claude-code",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-write-documentation-to-github-copilot-prompt",
+            "componentId": "cratis-prompt-write-documentation",
+            "hostId": "github-copilot",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-write-documentation-to-pi-prompt",
+            "componentId": "cratis-prompt-write-documentation",
+            "hostId": "pi",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".pi/prompts/write-documentation.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-write-specs-to-claude-code-prompt",
+            "componentId": "cratis-prompt-write-specs",
+            "hostId": "claude-code",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-write-specs-to-github-copilot-prompt",
+            "componentId": "cratis-prompt-write-specs",
+            "hostId": "github-copilot",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/prompts"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-prompt-write-specs-to-pi-prompt",
+            "componentId": "cratis-prompt-write-specs",
+            "hostId": "pi",
+            "projectedKind": "prompt",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".pi/prompts/write-specs.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-capability-is-not-authority-to-claude-code-rule",
+            "componentId": "cratis-rule-capability-is-not-authority",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/capability-is-not-authority.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-capability-is-not-authority-to-github-copilot-rule",
+            "componentId": "cratis-rule-capability-is-not-authority",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-code-quality-csharp-to-claude-code-rule",
+            "componentId": "cratis-rule-code-quality-csharp",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/code-quality.csharp.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-code-quality-csharp-to-github-copilot-rule",
+            "componentId": "cratis-rule-code-quality-csharp",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-code-quality-csharp-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-code-quality-csharp",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/code-quality.csharp.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-code-quality-csharp-to-tabnine-rule",
+            "componentId": "cratis-rule-code-quality-csharp",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/code-quality.csharp.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-code-quality-to-claude-code-rule",
+            "componentId": "cratis-rule-code-quality",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/code-quality.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-code-quality-to-github-copilot-rule",
+            "componentId": "cratis-rule-code-quality",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-code-quality-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-code-quality",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/code-quality.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-code-quality-to-tabnine-rule",
+            "componentId": "cratis-rule-code-quality",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/code-quality.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-code-quality-typescript-to-claude-code-rule",
+            "componentId": "cratis-rule-code-quality-typescript",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/code-quality.typescript.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-code-quality-typescript-to-github-copilot-rule",
+            "componentId": "cratis-rule-code-quality-typescript",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-code-quality-typescript-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-code-quality-typescript",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/code-quality.typescript.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-code-quality-typescript-to-tabnine-rule",
+            "componentId": "cratis-rule-code-quality-typescript",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/code-quality.typescript.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-components-to-claude-code-rule",
+            "componentId": "cratis-rule-components",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/components.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-components-to-github-copilot-rule",
+            "componentId": "cratis-rule-components",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-components-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-components",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/components.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-components-to-tabnine-rule",
+            "componentId": "cratis-rule-components",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/components.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-concepts-to-claude-code-rule",
+            "componentId": "cratis-rule-concepts",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/concepts.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-concepts-to-github-copilot-rule",
+            "componentId": "cratis-rule-concepts",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-concepts-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-concepts",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/concepts.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-concepts-to-tabnine-rule",
+            "componentId": "cratis-rule-concepts",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/concepts.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-csharp-to-claude-code-rule",
+            "componentId": "cratis-rule-csharp",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/csharp.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-csharp-to-github-copilot-rule",
+            "componentId": "cratis-rule-csharp",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-csharp-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-csharp",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/csharp.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-csharp-to-tabnine-rule",
+            "componentId": "cratis-rule-csharp",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/csharp.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-decision-records-to-claude-code-rule",
+            "componentId": "cratis-rule-decision-records",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/decision-records.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-decision-records-to-github-copilot-rule",
+            "componentId": "cratis-rule-decision-records",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-dialogs-to-claude-code-rule",
+            "componentId": "cratis-rule-dialogs",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/dialogs.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-dialogs-to-github-copilot-rule",
+            "componentId": "cratis-rule-dialogs",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-dialogs-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-dialogs",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/dialogs.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-dialogs-to-tabnine-rule",
+            "componentId": "cratis-rule-dialogs",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/dialogs.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-documentation-structure-and-formatting-to-claude-code-rule",
+            "componentId": "cratis-rule-documentation-structure-and-formatting",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/documentation-structure-and-formatting.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-documentation-structure-and-formatting-to-github-copilot-rule",
+            "componentId": "cratis-rule-documentation-structure-and-formatting",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-documentation-structure-and-formatting-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-documentation-structure-and-formatting",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/documentation-structure-and-formatting.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-documentation-structure-and-formatting-to-tabnine-rule",
+            "componentId": "cratis-rule-documentation-structure-and-formatting",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/documentation-structure-and-formatting.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-documentation-to-claude-code-rule",
+            "componentId": "cratis-rule-documentation",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/documentation.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-documentation-to-github-copilot-rule",
+            "componentId": "cratis-rule-documentation",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-documentation-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-documentation",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/documentation.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-documentation-to-tabnine-rule",
+            "componentId": "cratis-rule-documentation",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/documentation.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-editing-cratis-docs-to-claude-code-rule",
+            "componentId": "cratis-rule-editing-cratis-docs",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/editing-cratis-docs.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-editing-cratis-docs-to-github-copilot-rule",
+            "componentId": "cratis-rule-editing-cratis-docs",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-editing-cratis-docs-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-editing-cratis-docs",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/editing-cratis-docs.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-editing-cratis-docs-to-tabnine-rule",
+            "componentId": "cratis-rule-editing-cratis-docs",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/editing-cratis-docs.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-efcore-specs-to-claude-code-rule",
+            "componentId": "cratis-rule-efcore-specs",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/efcore.specs.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-efcore-specs-to-github-copilot-rule",
+            "componentId": "cratis-rule-efcore-specs",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-efcore-specs-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-efcore-specs",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/efcore.specs.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-efcore-specs-to-tabnine-rule",
+            "componentId": "cratis-rule-efcore-specs",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/efcore.specs.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-efcore-to-claude-code-rule",
+            "componentId": "cratis-rule-efcore",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/efcore.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-efcore-to-github-copilot-rule",
+            "componentId": "cratis-rule-efcore",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-efcore-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-efcore",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/efcore.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-efcore-to-tabnine-rule",
+            "componentId": "cratis-rule-efcore",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/efcore.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-engineering-recipe-skeleton-to-claude-code-rule",
+            "componentId": "cratis-rule-engineering-recipe-skeleton",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/engineering-recipe-skeleton.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-engineering-recipe-skeleton-to-github-copilot-rule",
+            "componentId": "cratis-rule-engineering-recipe-skeleton",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-exit-codes-and-wrappers-to-claude-code-rule",
+            "componentId": "cratis-rule-exit-codes-and-wrappers",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/exit-codes-and-wrappers.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-exit-codes-and-wrappers-to-github-copilot-rule",
+            "componentId": "cratis-rule-exit-codes-and-wrappers",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-framework-to-claude-code-rule",
+            "componentId": "cratis-rule-framework",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/framework.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-framework-to-github-copilot-rule",
+            "componentId": "cratis-rule-framework",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-framework-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-framework",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/framework.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-framework-to-tabnine-rule",
+            "componentId": "cratis-rule-framework",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/framework.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-frontend-quality-to-claude-code-rule",
+            "componentId": "cratis-rule-frontend-quality",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/frontend-quality.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-frontend-quality-to-github-copilot-rule",
+            "componentId": "cratis-rule-frontend-quality",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-frontend-quality-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-frontend-quality",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/frontend-quality.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-frontend-quality-to-tabnine-rule",
+            "componentId": "cratis-rule-frontend-quality",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/frontend-quality.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-frontend-testing-to-claude-code-rule",
+            "componentId": "cratis-rule-frontend-testing",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/frontend-testing.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-frontend-testing-to-github-copilot-rule",
+            "componentId": "cratis-rule-frontend-testing",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-frontend-testing-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-frontend-testing",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/frontend-testing.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-frontend-testing-to-tabnine-rule",
+            "componentId": "cratis-rule-frontend-testing",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/frontend-testing.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-git-commits-to-claude-code-rule",
+            "componentId": "cratis-rule-git-commits",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/git-commits.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-git-commits-to-github-copilot-rule",
+            "componentId": "cratis-rule-git-commits",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-git-commits-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-git-commits",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/git-commits.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-git-commits-to-tabnine-rule",
+            "componentId": "cratis-rule-git-commits",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/git-commits.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-github-actions-to-claude-code-rule",
+            "componentId": "cratis-rule-github-actions",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/github-actions.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-github-actions-to-github-copilot-rule",
+            "componentId": "cratis-rule-github-actions",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-glossary-to-claude-code-rule",
+            "componentId": "cratis-rule-glossary",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/glossary.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-glossary-to-github-copilot-rule",
+            "componentId": "cratis-rule-glossary",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-glossary-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-glossary",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/glossary.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-glossary-to-tabnine-rule",
+            "componentId": "cratis-rule-glossary",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/glossary.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-guards-and-fuses-to-claude-code-rule",
+            "componentId": "cratis-rule-guards-and-fuses",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/guards-and-fuses.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-guards-and-fuses-to-github-copilot-rule",
+            "componentId": "cratis-rule-guards-and-fuses",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-human-verdicts-to-claude-code-rule",
+            "componentId": "cratis-rule-human-verdicts",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/human-verdicts.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-human-verdicts-to-github-copilot-rule",
+            "componentId": "cratis-rule-human-verdicts",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-local-work-artifacts-to-claude-code-rule",
+            "componentId": "cratis-rule-local-work-artifacts",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/local-work-artifacts.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-local-work-artifacts-to-github-copilot-rule",
+            "componentId": "cratis-rule-local-work-artifacts",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-managing-ai-rules-to-claude-code-rule",
+            "componentId": "cratis-rule-managing-ai-rules",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/managing-ai-rules.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-managing-ai-rules-to-github-copilot-rule",
+            "componentId": "cratis-rule-managing-ai-rules",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-managing-ai-rules-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-managing-ai-rules",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/managing-ai-rules.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-managing-ai-rules-to-tabnine-rule",
+            "componentId": "cratis-rule-managing-ai-rules",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/managing-ai-rules.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-orleans-to-claude-code-rule",
+            "componentId": "cratis-rule-orleans",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/orleans.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-orleans-to-github-copilot-rule",
+            "componentId": "cratis-rule-orleans",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-orleans-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-orleans",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/orleans.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-orleans-to-tabnine-rule",
+            "componentId": "cratis-rule-orleans",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/orleans.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-pull-requests-to-claude-code-rule",
+            "componentId": "cratis-rule-pull-requests",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/pull-requests.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-pull-requests-to-github-copilot-rule",
+            "componentId": "cratis-rule-pull-requests",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-pull-requests-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-pull-requests",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/pull-requests.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-pull-requests-to-tabnine-rule",
+            "componentId": "cratis-rule-pull-requests",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/pull-requests.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-react-to-claude-code-rule",
+            "componentId": "cratis-rule-react",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/react.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-react-to-github-copilot-rule",
+            "componentId": "cratis-rule-react",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-react-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-react",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/react.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-react-to-tabnine-rule",
+            "componentId": "cratis-rule-react",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/react.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-reactors-to-claude-code-rule",
+            "componentId": "cratis-rule-reactors",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/reactors.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-reactors-to-github-copilot-rule",
+            "componentId": "cratis-rule-reactors",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-reactors-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-reactors",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/reactors.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-reactors-to-tabnine-rule",
+            "componentId": "cratis-rule-reactors",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/reactors.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-rtk-to-claude-code-rule",
+            "componentId": "cratis-rule-rtk",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/rtk.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-rtk-to-github-copilot-rule",
+            "componentId": "cratis-rule-rtk",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-rtk-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-rtk",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/rtk.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-rtk-to-tabnine-rule",
+            "componentId": "cratis-rule-rtk",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/rtk.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-specs-csharp-to-claude-code-rule",
+            "componentId": "cratis-rule-specs-csharp",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/specs.csharp.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-specs-csharp-to-github-copilot-rule",
+            "componentId": "cratis-rule-specs-csharp",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-specs-csharp-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-specs-csharp",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/specs.csharp.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-specs-csharp-to-tabnine-rule",
+            "componentId": "cratis-rule-specs-csharp",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/specs.csharp.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-specs-scenarios-csharp-to-claude-code-rule",
+            "componentId": "cratis-rule-specs-scenarios-csharp",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/specs.scenarios.csharp.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-specs-scenarios-csharp-to-github-copilot-rule",
+            "componentId": "cratis-rule-specs-scenarios-csharp",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-specs-scenarios-csharp-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-specs-scenarios-csharp",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/specs.scenarios.csharp.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-specs-scenarios-csharp-to-tabnine-rule",
+            "componentId": "cratis-rule-specs-scenarios-csharp",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/specs.scenarios.csharp.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-specs-to-claude-code-rule",
+            "componentId": "cratis-rule-specs",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/specs.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-specs-to-github-copilot-rule",
+            "componentId": "cratis-rule-specs",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-specs-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-specs",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/specs.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-specs-to-tabnine-rule",
+            "componentId": "cratis-rule-specs",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/specs.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-specs-typescript-to-claude-code-rule",
+            "componentId": "cratis-rule-specs-typescript",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/specs.typescript.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-specs-typescript-to-github-copilot-rule",
+            "componentId": "cratis-rule-specs-typescript",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-specs-typescript-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-specs-typescript",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/specs.typescript.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-specs-typescript-to-tabnine-rule",
+            "componentId": "cratis-rule-specs-typescript",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/specs.typescript.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-storybook-to-claude-code-rule",
+            "componentId": "cratis-rule-storybook",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/storybook.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-storybook-to-github-copilot-rule",
+            "componentId": "cratis-rule-storybook",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-storybook-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-storybook",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/storybook.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-storybook-to-tabnine-rule",
+            "componentId": "cratis-rule-storybook",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/storybook.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-terminal-commands-to-claude-code-rule",
+            "componentId": "cratis-rule-terminal-commands",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/terminal-commands.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-terminal-commands-to-github-copilot-rule",
+            "componentId": "cratis-rule-terminal-commands",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-terminal-commands-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-terminal-commands",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/terminal-commands.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-terminal-commands-to-tabnine-rule",
+            "componentId": "cratis-rule-terminal-commands",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/terminal-commands.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-typescript-to-claude-code-rule",
+            "componentId": "cratis-rule-typescript",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/typescript.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-typescript-to-github-copilot-rule",
+            "componentId": "cratis-rule-typescript",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-typescript-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-typescript",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/typescript.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-typescript-to-tabnine-rule",
+            "componentId": "cratis-rule-typescript",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/typescript.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-verification-discipline-to-claude-code-rule",
+            "componentId": "cratis-rule-verification-discipline",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/verification-discipline.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-verification-discipline-to-github-copilot-rule",
+            "componentId": "cratis-rule-verification-discipline",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-vertical-slices-to-claude-code-rule",
+            "componentId": "cratis-rule-vertical-slices",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/vertical-slices.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-vertical-slices-to-github-copilot-rule",
+            "componentId": "cratis-rule-vertical-slices",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-vertical-slices-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-vertical-slices",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/vertical-slices.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-vertical-slices-to-tabnine-rule",
+            "componentId": "cratis-rule-vertical-slices",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/vertical-slices.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-web-fetching-to-claude-code-rule",
+            "componentId": "cratis-rule-web-fetching",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/web-fetching.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-web-fetching-to-github-copilot-rule",
+            "componentId": "cratis-rule-web-fetching",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-web-fetching-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-web-fetching",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/web-fetching.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-web-fetching-to-tabnine-rule",
+            "componentId": "cratis-rule-web-fetching",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/web-fetching.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-work-records-and-comments-to-claude-code-rule",
+            "componentId": "cratis-rule-work-records-and-comments",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/work-records-and-comments.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-work-records-and-comments-to-github-copilot-rule",
+            "componentId": "cratis-rule-work-records-and-comments",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-writing-correct-examples-to-claude-code-rule",
+            "componentId": "cratis-rule-writing-correct-examples",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/writing-correct-examples.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-writing-correct-examples-to-github-copilot-rule",
+            "componentId": "cratis-rule-writing-correct-examples",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-writing-correct-examples-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-writing-correct-examples",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/writing-correct-examples.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-writing-correct-examples-to-tabnine-rule",
+            "componentId": "cratis-rule-writing-correct-examples",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/writing-correct-examples.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-writing-cratis-docs-to-claude-code-rule",
+            "componentId": "cratis-rule-writing-cratis-docs",
+            "hostId": "claude-code",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/rules/writing-cratis-docs.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-writing-cratis-docs-to-github-copilot-rule",
+            "componentId": "cratis-rule-writing-cratis-docs",
+            "hostId": "github-copilot",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/instructions"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "cratis-rule-writing-cratis-docs-to-jetbrains-ai-assistant-rule",
+            "componentId": "cratis-rule-writing-cratis-docs",
+            "hostId": "jetbrains-ai-assistant",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "jetbrains-ai-assistant-rules/.aiassistant/rules/writing-cratis-docs.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "jetbrains-ai-assistant-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "cratis-rule-writing-cratis-docs-to-tabnine-rule",
+            "componentId": "cratis-rule-writing-cratis-docs",
+            "hostId": "tabnine",
+            "projectedKind": "rule",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "generated-static",
+            "hostActivation": "none",
+            "adapterType": "generated",
+            "outputPaths": [
+                "tabnine-guidelines/.tabnine/guidelines/writing-cratis-docs.md"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "tabnine-source-1"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest",
+                "static-inventory"
+            ]
+        },
+        {
+            "id": "skill-creator-to-claude-code-skill",
+            "componentId": "skill-creator",
+            "hostId": "claude-code",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".claude/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "skill-creator-to-codex-skill",
+            "componentId": "skill-creator",
+            "hostId": "codex",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".agents/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        },
+        {
+            "id": "skill-creator-to-github-copilot-skill",
+            "componentId": "skill-creator",
+            "hostId": "github-copilot",
+            "projectedKind": "skill",
+            "artifactClass": "provider-compatibility",
+            "assuranceProfileId": "provider-compatibility-v1",
+            "packageIdentity": null,
+            "state": "existing",
+            "hostActivation": "active",
+            "adapterType": "symlink",
+            "outputPaths": [
+                ".github/skills"
+            ],
+            "approval": "modeled",
+            "evidenceIds": [
+                "repo-main-b795d53"
+            ],
+            "securityRequirements": [],
+            "requiredCanaries": [
+                "projection-shape",
+                "source-digest"
+            ]
+        }
+    ]
 }

--- a/catalog/evidence.json
+++ b/catalog/evidence.json
@@ -34,6 +34,11 @@
             "locator": "https://github.com/Cratis/AI/issues/126"
         },
         {
+            "id": "source-ai-256",
+            "kind": "repository-authority",
+            "locator": "https://github.com/Cratis/AI/issues/256"
+        },
+        {
             "id": "source-ai-127",
             "kind": "repository-authority",
             "locator": "https://github.com/Cratis/AI/issues/127"
@@ -8450,6 +8455,43 @@
                 "officialUrl": "https://cli.github.com/manual/gh_skill_install",
                 "sourceKind": "official-documentation",
                 "applicableVersion": "current-documentation-2026-08-20"
+            }
+        },
+        {
+            "id": "ai-256",
+            "sourceId": "source-ai-256",
+            "evidenceClass": "hosted",
+            "subject": {
+                "kind": "repository",
+                "id": "cratis-ai",
+                "version": "issue-state-2026-09-10"
+            },
+            "bindingIds": [],
+            "assertions": [
+                {
+                    "assuranceId": "authority",
+                    "outcome": "pass",
+                    "supporting": true,
+                    "claimIds": []
+                }
+            ],
+            "scope": "Authority for the #256 corpus retirement: general content migrated from consuming repositories into this repository, repository-specific content kept in the owning repository.",
+            "environment": {
+                "operatingSystem": "not-recorded",
+                "architecture": "not-recorded",
+                "isolation": "not-recorded"
+            },
+            "observedOn": "2026-09-10",
+            "validThrough": "2026-12-09",
+            "confidence": "high",
+            "limitations": [
+                "This observation is limited to its exact recorded subject, version, digest, scope, and environment and grants no unrecorded assurance."
+            ],
+            "supersedes": [],
+            "legacy": {
+                "officialUrl": "https://github.com/Cratis/AI/issues/256",
+                "sourceKind": "repository-authority",
+                "applicableVersion": "issue-state-2026-09-10"
             }
         }
     ],

--- a/catalog/generated/human-catalog/CATALOG.md
+++ b/catalog/generated/human-catalog/CATALOG.md
@@ -19,9 +19,9 @@ Modeled or planned components and projections are catalog metadata only; they ar
 - Passive: 190
 - Executable: 3
 - Legacy-retained: 35
-- Existing adapter records: 329
+- Existing adapter records: 328
 - Generated static fixture projections: 70
-- Active host projections: 326
+- Active host projections: 325
 - Inert path references: 3
 - Planned projections: 0
 - Non-existing blocked projections: 0

--- a/catalog/generated/human-catalog/catalog.json
+++ b/catalog/generated/human-catalog/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractVersion": 1,
   "disclaimer": "Catalog inclusion, evaluation evidence, component modeling, planned projection, bundle generation, or publication does not grant runtime permission, emitted bytes, support, or approval.",
-  "inputDigest": "19722304a0e9dcaba71d9ffb73e40afecb0f0a47690cbbfb0b73932eedb1fe9c",
+  "inputDigest": "8b13d323e1bfa90a0af97bba0aa644ce92d877513d6c778a44ee78868979ff13",
   "componentSummary": {
     "disclaimer": "Modeled or planned components and projections are catalog metadata only; they are not emitted, supported, installable, published, promoted, or runtime eligible.",
     "total": 193,
@@ -34,20 +34,20 @@
       "legacy-retained": 35
     },
     "projections": {
-      "total": 399,
+      "total": 398,
       "byState": {
         "planned": 0,
         "blocked": 0,
-        "existing": 329,
+        "existing": 328,
         "generated-static": 70
       },
       "byActivation": {
-        "active": 326,
+        "active": 325,
         "inert": 3,
         "none": 70
       },
       "byApproval": {
-        "modeled": 396,
+        "modeled": 395,
         "approved": 0,
         "blocked": 3
       }

--- a/catalog/generated/human-catalog/manifest.json
+++ b/catalog/generated/human-catalog/manifest.json
@@ -1,17 +1,17 @@
 {
   "schemaVersion": 2,
   "contractVersion": 1,
-  "inputDigest": "19722304a0e9dcaba71d9ffb73e40afecb0f0a47690cbbfb0b73932eedb1fe9c",
+  "inputDigest": "8b13d323e1bfa90a0af97bba0aa644ce92d877513d6c778a44ee78868979ff13",
   "files": [
     {
       "path": "CATALOG.md",
       "size": 188571,
-      "sha256": "d473655d19ffcfff107761ad65b270fe9d661f833a4e3ed544270aaad5b62343"
+      "sha256": "37494291ef57d7f47d6ea4d74a29c48b41f373c9759f77f36c702f8e4893b675"
     },
     {
       "path": "catalog.json",
       "size": 246278,
-      "sha256": "95717a7a77f910d28d38d231019548830474a55e0f5cf9ece28538a50c0658b4"
+      "sha256": "11d6074b1730f0c243b89e9b41558399c9815e1f54a3f7ca3787828c97d8e72d"
     }
   ]
 }

--- a/catalog/v2/component-projections.json
+++ b/catalog/v2/component-projections.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "generatedBy": "tooling/generate-component-catalogs.mjs",
-  "sourceDigest": "e0073498e534bb6b5aaedd686b67aa4819d5ec227e7954ba3d8a7bb4d733b1b1",
+  "sourceDigest": "65ece4839195c242ddab2929eb35b385169cf5e7e951bed742e7b85285264816",
   "defaultPolicy": "deny",
   "supportClaim": false,
   "hosts": [
@@ -45,8 +45,7 @@
         "skill"
       ],
       "allowedOutputPrefixes": [
-        ".agents",
-        "AGENTS.md"
+        ".agents"
       ],
       "sharedSymlinkOutputs": [
         ".agents/skills"
@@ -1970,30 +1969,6 @@
       "adapterType": "symlink",
       "outputPaths": [
         ".claude/CLAUDE.md"
-      ],
-      "approval": "modeled",
-      "evidenceIds": [
-        "repo-main-b795d53"
-      ],
-      "securityRequirements": [],
-      "requiredCanaries": [
-        "projection-shape",
-        "source-digest"
-      ]
-    },
-    {
-      "id": "cratis-instruction-general-to-codex-instruction",
-      "componentId": "cratis-instruction-general",
-      "hostId": "codex",
-      "projectedKind": "instruction",
-      "artifactClass": "provider-compatibility",
-      "assuranceProfileId": "provider-compatibility-v1",
-      "packageIdentity": null,
-      "state": "existing",
-      "hostActivation": "active",
-      "adapterType": "symlink",
-      "outputPaths": [
-        "AGENTS.md"
       ],
       "approval": "modeled",
       "evidenceIds": [

--- a/catalog/v2/evidence.json
+++ b/catalog/v2/evidence.json
@@ -67,6 +67,15 @@
       "confidence": "high"
     },
     {
+      "id": "ai-256",
+      "officialUrl": "https://github.com/Cratis/AI/issues/256",
+      "sourceKind": "repository-authority",
+      "verifiedOn": "2026-09-10",
+      "expiresOn": "2026-12-09",
+      "applicableVersion": "issue-state-2026-09-10",
+      "confidence": "high"
+    },
+    {
       "id": "aider-source-1",
       "officialUrl": "https://aider.chat/docs/usage/conventions.html",
       "sourceKind": "official-documentation",

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "3aeb9a407068961a43842bf75a33741eea2c3168d2602ba471d15ac0135dbfba",
+  "indexDigest": "8ffc768b22b335c1728215e4f99e8dbde9a909192b8dcdc9ea929a28a9e78fb8",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],
@@ -343,6 +343,14 @@
       "status": "added"
     },
     {
+      "path": ".cratis/PROJECT.md",
+      "status": "added"
+    },
+    {
+      "path": ".cratis/ai.json",
+      "status": "added"
+    },
+    {
       "path": ".cursor-plugin/marketplace.json",
       "status": "added"
     },
@@ -485,6 +493,14 @@
     {
       "path": ".pi/agents/spec-writer.md",
       "status": "type-changed"
+    },
+    {
+      "path": "AGENTS.md",
+      "status": "type-changed"
+    },
+    {
+      "path": "CLAUDE.md",
+      "status": "added"
     },
     {
       "path": "Documentation/.markdownlint.json",
@@ -639,6 +655,10 @@
       "status": "added"
     },
     {
+      "path": "Documentation/examples/ai-subscriptions/mixed-documentation-and-engineering.cratis-ai.json",
+      "status": "added"
+    },
+    {
       "path": "Documentation/examples/ai-subscriptions/pi-settings.json",
       "status": "added"
     },
@@ -789,6 +809,10 @@
     {
       "path": "Documentation/verify-markdown.sh",
       "status": "modified"
+    },
+    {
+      "path": "GEMINI.md",
+      "status": "added"
     },
     {
       "path": "README.md",
@@ -1404,6 +1428,34 @@
     },
     {
       "path": "engineering/skills/cratis-engineering-effect-boundaries/references/failure-archetypes.md",
+      "status": "added"
+    },
+    {
+      "path": "engineering/sources-staged/README.md",
+      "status": "added"
+    },
+    {
+      "path": "engineering/sources-staged/arc-kotlin/rules/gradle.md",
+      "status": "added"
+    },
+    {
+      "path": "engineering/sources-staged/arc-kotlin/rules/java.md",
+      "status": "added"
+    },
+    {
+      "path": "engineering/sources-staged/arc-kotlin/rules/kotlin-java-interop.md",
+      "status": "added"
+    },
+    {
+      "path": "engineering/sources-staged/arc-kotlin/rules/kotlin.md",
+      "status": "added"
+    },
+    {
+      "path": "engineering/sources-staged/studio-issues/upstream-issues.md",
+      "status": "added"
+    },
+    {
+      "path": "engineering/sources-staged/studio-issues/writing-on-issues.md",
       "status": "added"
     },
     {
@@ -4283,20 +4335,7 @@
       "status": "added"
     }
   ],
-  "admittedUntracked": [
-    ".cratis/PROJECT.md",
-    ".cratis/ai.json",
-    "CLAUDE.md",
-    "Documentation/examples/ai-subscriptions/mixed-documentation-and-engineering.cratis-ai.json",
-    "GEMINI.md",
-    "engineering/sources-staged/README.md",
-    "engineering/sources-staged/arc-kotlin/rules/gradle.md",
-    "engineering/sources-staged/arc-kotlin/rules/java.md",
-    "engineering/sources-staged/arc-kotlin/rules/kotlin-java-interop.md",
-    "engineering/sources-staged/arc-kotlin/rules/kotlin.md",
-    "engineering/sources-staged/studio-issues/upstream-issues.md",
-    "engineering/sources-staged/studio-issues/writing-on-issues.md"
-  ],
+  "admittedUntracked": [],
   "excludedRuntimePrefixes": [
     ".pi/delegate/",
     ".pi/fusion/",

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -4283,7 +4283,20 @@
       "status": "added"
     }
   ],
-  "admittedUntracked": [],
+  "admittedUntracked": [
+    ".cratis/PROJECT.md",
+    ".cratis/ai.json",
+    "CLAUDE.md",
+    "Documentation/examples/ai-subscriptions/mixed-documentation-and-engineering.cratis-ai.json",
+    "GEMINI.md",
+    "engineering/sources-staged/README.md",
+    "engineering/sources-staged/arc-kotlin/rules/gradle.md",
+    "engineering/sources-staged/arc-kotlin/rules/java.md",
+    "engineering/sources-staged/arc-kotlin/rules/kotlin-java-interop.md",
+    "engineering/sources-staged/arc-kotlin/rules/kotlin.md",
+    "engineering/sources-staged/studio-issues/upstream-issues.md",
+    "engineering/sources-staged/studio-issues/writing-on-issues.md"
+  ],
   "excludedRuntimePrefixes": [
     ".pi/delegate/",
     ".pi/fusion/",
@@ -4317,28 +4330,78 @@
     },
     {
       "excludePathPatterns": [],
-      "id": "root-instruction-adapter",
+      "id": "root-context-bootstrap",
       "sourcePathPatterns": [
-        "AGENTS.md"
+        "AGENTS.md",
+        "CLAUDE.md",
+        "GEMINI.md"
       ],
-      "artifactType": "adapter",
+      "artifactType": "instruction",
       "currentOwner": "reusable Cratis engineering behavior",
-      "targetOwner": "obsolete, with deletion deferred until replacement evidence exists",
+      "targetOwner": "reusable Cratis engineering behavior",
       "runtimeEligibility": "forbidden",
-      "generatedStatus": "derived",
-      "adapterStatus": "symlink-adapter",
+      "generatedStatus": "source",
+      "adapterStatus": "none",
       "dependencies": [
-        ".ai/rules/general.md"
+        ".cratis/PROJECT.md"
       ],
-      "risk": "high",
-      "migrationState": "retire-after-evidence",
+      "risk": "low",
+      "migrationState": "retain",
       "evidenceIds": [
         "workflows-68",
-        "reevaluation-authority"
+        "ai-256"
       ],
-      "generator": "legacy-manual-adapter-model",
+      "expectedPathCount": 3,
+      "expectedPathsDigest": "8e63b75fb33c848a8eaeb1b09a5545950d9238076e9808da3937c64363bc0526"
+    },
+    {
+      "excludePathPatterns": [],
+      "id": "project-context",
+      "sourcePathPatterns": [
+        ".cratis/PROJECT.md"
+      ],
+      "artifactType": "instruction",
+      "currentOwner": "reusable Cratis engineering behavior",
+      "targetOwner": "reusable Cratis engineering behavior",
+      "runtimeEligibility": "forbidden",
+      "generatedStatus": "source",
+      "adapterStatus": "none",
+      "dependencies": [
+        "Documentation/project-context-bootstrap.md"
+      ],
+      "risk": "low",
+      "migrationState": "retain",
+      "evidenceIds": [
+        "workflows-68",
+        "ai-256"
+      ],
       "expectedPathCount": 1,
-      "expectedPathsDigest": "954ec5dad7eaf581ad4bfa090369b244ac0120b43722ef2efff5ba89fc52046f"
+      "expectedPathsDigest": "ac70b2f194b9e985b8de0184b5efc020f93826cb72063ab6bd94c7fb3db4e0b4"
+    },
+    {
+      "excludePathPatterns": [],
+      "id": "project-context-subscription",
+      "sourcePathPatterns": [
+        ".cratis/ai.json"
+      ],
+      "artifactType": "repository-metadata",
+      "currentOwner": "reusable Cratis engineering behavior",
+      "targetOwner": "reusable Cratis engineering behavior",
+      "runtimeEligibility": "forbidden",
+      "generatedStatus": "source",
+      "adapterStatus": "none",
+      "dependencies": [
+        "distribution/profile-subscription.schema.json",
+        "Documentation/project-context-bootstrap.md"
+      ],
+      "risk": "low",
+      "migrationState": "retain",
+      "evidenceIds": [
+        "workflows-68",
+        "ai-256"
+      ],
+      "expectedPathCount": 1,
+      "expectedPathsDigest": "1d26db70fb6a634cc529e79dff2139f8b819f6e2453b156679e7b6bd762bc23f"
     },
     {
       "excludePathPatterns": [],
@@ -4766,6 +4829,29 @@
       ],
       "expectedPathCount": 20,
       "expectedPathsDigest": "87680b04a4896de3879dd376482c17e950c709d3841b91ab5e2364c2b0d8d6fc"
+    },
+    {
+      "excludePathPatterns": [],
+      "id": "engineering-staged-migrated-sources",
+      "sourcePathPatterns": [
+        "engineering/sources-staged/**"
+      ],
+      "artifactType": "documentation",
+      "currentOwner": "reusable Cratis engineering behavior",
+      "targetOwner": "reusable Cratis engineering behavior",
+      "runtimeEligibility": "forbidden",
+      "generatedStatus": "source",
+      "adapterStatus": "none",
+      "dependencies": [
+        "Documentation/corpus-generations.md"
+      ],
+      "risk": "medium",
+      "migrationState": "classify-in-place",
+      "evidenceIds": [
+        "ai-256"
+      ],
+      "expectedPathCount": 7,
+      "expectedPathsDigest": "f4459741651d988637badc47c5862ca10b7f11678f142f571e4ee4c7d4dff821"
     },
     {
       "excludePathPatterns": [],
@@ -5210,8 +5296,8 @@
         "workflows-68",
         "reevaluation-authority"
       ],
-      "expectedPathCount": 29,
-      "expectedPathsDigest": "4297439841da17615086d138751286f28a43ad67ced1270512e383e720938618"
+      "expectedPathCount": 30,
+      "expectedPathsDigest": "b52e3885a337d88d6114c05b9c81a2898f48a17a79093e308730696e54372543"
     },
     {
       "excludePathPatterns": [],

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "8ffc768b22b335c1728215e4f99e8dbde9a909192b8dcdc9ea929a28a9e78fb8",
+  "indexDigest": "a3f8564b26d83e08ad7f3d33627cf8aba5ab09807b55e0012bf648759f0ab8cf",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/distribution/profile-subscription.schema.json
+++ b/distribution/profile-subscription.schema.json
@@ -4,7 +4,7 @@
   "title": "Cratis AI profile subscription",
   "type": "object",
   "additionalProperties": false,
-  "description": "A project-owned Cratis AI subscription. Every profile id lives in the cratis namespace: the cratis/engineering subtree (umbrella, core, and language cells) derives the cratis-engineering channel and everything else derives the public channel, so channel is optional and never hand-declared twice.",
+  "description": "A project-owned Cratis AI subscription. Every profile id lives in the cratis namespace: the cratis/engineering subtree (umbrella, core, and language cells) derives the cratis-engineering channel and everything else derives the public channel. A selection from one channel may declare that channel; a selection that deliberately mixes the two (for example cratis/documentation plus an engineering cell) is valid and leaves channel unset, because it no longer derives exactly one.",
   "required": [
     "schemaVersion",
     "version",
@@ -41,6 +41,30 @@
           }
         }
       }
+    },
+    {
+      "title": "Mixed public and Cratis engineering channels",
+      "description": "A repository may combine public profiles (documentation, application cells, clients) with maintainer engineering cells in one subscription. Each channel is resolved separately; the subscription derives no single channel, so channel must stay unset.",
+      "properties": {
+        "channel": false,
+        "profiles": {
+          "minItems": 2,
+          "allOf": [
+            {
+              "contains": {
+                "type": "string",
+                "pattern": "^cratis/engineering(?:/[a-z0-9]+(?:-[a-z0-9]+)*){0,2}$"
+              }
+            },
+            {
+              "contains": {
+                "type": "string",
+                "pattern": "^(?!cratis/engineering(?:/|$))cratis(?:/[a-z0-9]+(?:-[a-z0-9]+)*){0,3}$"
+              }
+            }
+          ]
+        }
+      }
     }
   ],
   "properties": {
@@ -48,7 +72,7 @@
       "const": "1.0.0"
     },
     "channel": {
-      "description": "Optional; derived from the profile namespace. Must agree with the derived channel when present.",
+      "description": "Optional; derived from the profile namespace. Must agree with the derived channel when the selection is single-channel, and must be absent when the selection mixes the public and engineering channels.",
       "enum": ["public", "cratis-engineering"]
     },
     "version": {

--- a/engineering/sources-staged/README.md
+++ b/engineering/sources-staged/README.md
@@ -1,0 +1,36 @@
+# Staged sources
+
+> **Status:** Source material, not skills. Nothing in this directory is
+> packaged, projected, or served to any harness.
+
+General AI-corpus content migrated out of consuming repositories during the
+#256 corpus retirement (see
+[`Documentation/corpus-generations.md`](../../Documentation/corpus-generations.md))
+that had no authored home here yet. It is preserved verbatim so the retirement
+loses nothing; turning any of it into a capability happens only through the
+[skill-authoring contract](../../Documentation/skill-authoring-contract.md),
+reviewed against its owning repository.
+
+## Provenance
+
+| Path | Migrated from | Intended eventual home |
+| --- | --- | --- |
+| `arc-kotlin/rules/kotlin.md` | `Cratis/Arc.Kotlin` `.ai/rules/kotlin.md` | the `cratis/language/kotlin` cell content gap |
+| `arc-kotlin/rules/kotlin-java-interop.md` | `Cratis/Arc.Kotlin` `.ai/rules/kotlin-java-interop.md` | the `cratis/language/kotlin` cell content gap |
+| `arc-kotlin/rules/java.md` | `Cratis/Arc.Kotlin` `.ai/rules/java.md` | JVM-consumer guidance under `cratis/language/kotlin` |
+| `arc-kotlin/rules/gradle.md` | `Cratis/Arc.Kotlin` `.ai/rules/gradle.md` | JVM build guidance under `cratis/language/kotlin` |
+| `studio-issues/upstream-issues.md` | `Cratis/Studio` and `Cratis/Stagehand` `.ai/rules/upstream-issues.md` (identical) | a `cratis/engineering` upstream-discipline procedure |
+| `studio-issues/writing-on-issues.md` | `Cratis/Studio` and `Cratis/Stagehand` `.ai/rules/writing-on-issues.md` (identical) | a `cratis/engineering` issue-communication procedure |
+
+Repository-specific rules and skills that were unique to a consuming
+repository were **not** moved here: they stayed in their owning repository,
+either as sections of its `.cratis/PROJECT.md` or as repository-local skills
+under `.agents/skills/`.
+
+## Rules
+
+- Never edit these files into shape here; authoring happens against the
+  contract, from the owning repository as authority.
+- Never project this directory from a profile; it contributes no capability.
+- Delete a row (and this table's row with it) once its authored replacement
+  lands, so this directory trends toward empty.

--- a/engineering/sources-staged/arc-kotlin/rules/gradle.md
+++ b/engineering/sources-staged/arc-kotlin/rules/gradle.md
@@ -1,0 +1,179 @@
+# Gradle Build, Modules, and Baselines
+
+This rule governs the Gradle workspace: how the multi-module build is wired, where convention
+configuration lives, how a module is added, how the checked-in `.api` binary-compatibility baselines
+are maintained, which modules publish and how, and the exact gate commands. Module boundaries and
+dependency direction are stated authoritatively in [AGENTS.md](../../AGENTS.md); this file is the
+build-level depth behind that contract. When the two disagree, `AGENTS.md` wins.
+
+## Running Gradle here
+
+- Always use the wrapper: `./gradlew`. It is pinned to Gradle 8.14.4 with a `distributionSha256Sum` in
+  `gradle/wrapper/gradle-wrapper.properties`, and CI validates it with
+  `gradle/actions/wrapper-validation`.
+- A **JDK 17 toolchain must be resolvable** before any Gradle invocation. If `java` is not on `PATH`,
+  export `JAVA_HOME` to a local JDK 17 installation and prepend `$JAVA_HOME/bin` to `PATH` for the
+  command. Never commit a machine-specific JDK path into any file in this repository.
+- Pass `--no-configuration-cache` wherever CI does — see the gate table below. Those tasks
+  (`typeScriptBuild`, `typeScriptRuntimeTest`, `verifyContractTestProxyDeterminism`,
+  `chronicleRealKernelTest`, publishing) are run that way in `.github/workflows/`, so reproduce the
+  gate exactly rather than inventing a shorter command.
+
+## Module map
+
+`settings.gradle.kts` includes exactly these projects under the root `arc-kotlin-workspace`.
+
+| Project path | Published coordinates | Notes |
+| --- | --- | --- |
+| `:Source` | `io.cratis:arc` | Host-agnostic runtime; no Spring, no Chronicle |
+| `:CodeGeneration:KSP` | `io.cratis:arc-ksp` | KSP processor; depends on `:Source` |
+| `:GradlePlugin` | `io.cratis:arc-gradle-plugin` | `io.cratis.arc` plugin; depends on `:Source` |
+| `:Integrations:SpringBoot` | `io.cratis:arc-spring-boot-starter` | Web/websocket/security are `compileOnly` |
+| `:Integrations:SpringDataJpa` | `io.cratis:arc-spring-data-jpa` | |
+| `:Integrations:SpringDataMongo` | `io.cratis:arc-spring-data-mongodb` | |
+| `:Integrations:OpenApi` | `io.cratis:arc-openapi-spring-boot-starter` | |
+| `:Integrations:Observability` | `io.cratis:arc-observability-spring-boot-starter` | OpenTelemetry is `compileOnly` |
+| `:Integrations:Chronicle` | `io.cratis:arc-chronicle-spring-boot-starter` | Optional; depends on the released Chronicle client |
+| `:Testing` | `io.cratis:arc-testing` | `api(project(":Source"))` |
+| `:ContractTests` | none — unpublished | Fixtures, cross-language contracts, TypeScript gates |
+| `:Samples:{Kotlin,Java}:{SpringBoot,ChronicleSpringBoot}` | none — unpublished | `group = io.cratis.samples`, `version = 1.0.0` |
+
+Optionality is expressed with `compileOnly` / `compileOnlyApi` in the integration build files. When
+you add a dependency to an integration, decide deliberately between `api`, `implementation`, and
+`compileOnly`; a `compileOnly` dependency that a consumer must always supply is how this repository
+keeps starters optional.
+
+## Where configuration lives
+
+Cross-cutting configuration is centralized in the root `build.gradle.kts` and applied reactively.
+Do not repeat it in a module build file.
+
+```kotlin
+subprojects {
+    pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+        extensions.configure<KotlinJvmProjectExtension> { jvmToolchain(17) }
+        tasks.withType<KotlinJvmCompile>().configureEach {
+            compilerOptions {
+                jvmTarget.set(JvmTarget.JVM_17)
+                allWarningsAsErrors.set(true)
+            }
+        }
+    }
+
+    pluginManager.withPlugin("java") {
+        extensions.configure<JavaPluginExtension> {
+            toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+        }
+        tasks.withType<JavaCompile>().configureEach {
+            options.release.set(17)
+            options.compilerArgs.addAll(listOf("-Xlint:all", "-Werror"))
+        }
+        dependencies.add("testImplementation", "org.junit.jupiter:junit-jupiter:5.11.4")
+        dependencies.add("testRuntimeOnly", "org.junit.platform:junit-platform-launcher")
+        tasks.withType<Test>().configureEach { useJUnitPlatform() }
+    }
+}
+```
+
+Centralized at the root: JVM toolchain 17, `jvmTarget`/`--release 17`, `allWarningsAsErrors`,
+`-Xlint:all -Werror`, JUnit Jupiter 5.11.4 plus the platform launcher, `useJUnitPlatform()`,
+`group = "io.cratis"`, the `version` property fallback, dependency-update rejection of non-stable
+candidates, the `apiCheck mustRunAfter apiDump` ordering, and `apiValidation.ignoredProjects`.
+
+Owned per module: the plugin set, dependencies and their configuration scopes, `mavenPublishing`
+coordinates and POM, KSP arguments, and any module-specific verification task.
+
+## Adding a module
+
+1. Add `include("<Path>")` to `settings.gradle.kts` in the existing grouping order.
+2. Create `<Path>/build.gradle.kts` starting with the standard Cratis MIT header, then the plugin
+   block. Apply `kotlin("jvm")` and `` `java-library` ``; add `kotlin("plugin.spring")` only for a
+   Spring integration. Do not re-declare toolchains, warning levels, or JUnit — the root supplies
+   them.
+3. Declare dependencies with the narrowest scope that works, using `project(":...")` for internal
+   modules. Respect the dependency direction in `AGENTS.md`.
+4. If the module is published, add the `com.vanniktech.maven.publish` plugin, a `mavenPublishing`
+   block with `publishToMavenCentral()`, `signAllPublications()`,
+   `coordinates("io.cratis", "<artifact>", version.toString())`, and the same POM shape as the
+   sibling modules (name, description, MIT license, `cratis` developer, SCM URLs).
+5. If the module is published, it needs a checked-in `.api` baseline — generate it once with
+   `./gradlew :<Path>:apiDump` and commit `<Path>/api/<Name>.api`. Add
+   `tasks.named("apiCheck") { mustRunAfter(tasks.named("apiDump")) }` as the sibling modules do.
+6. If the module must **not** be validated, extend `apiValidation { ignoredProjects }` in the root
+   build, or disable `apiCheck`/`apiDump` on it the way the samples do.
+7. Add the module path to the `paths:` filter in `.github/workflows/publish.yml` when it publishes,
+   and to the publish job's task list.
+
+## Binary-compatibility baselines
+
+`org.jetbrains.kotlinx.binary-compatibility-validator` 0.18.1 is applied at the root. Ten baselines
+are checked in: `Source/api/Source.api`, `CodeGeneration/KSP/api/KSP.api`,
+`GradlePlugin/api/GradlePlugin.api`, `Testing/api/Testing.api`, and one per integration. Root
+configuration excludes `ContractTests` and the sample projects from validation.
+
+The baseline is a reviewed record of the public ABI, not build noise:
+
+1. `./gradlew apiCheck` fails. **Read the diff it prints.** It names the exact removed, added, or
+   changed members.
+2. Decide whether that change is intended. A removed or re-signed public member is a breaking change
+   for Java and Kotlin consumers and needs a deliberate decision, not a regenerated file.
+3. If it is intended, run `./gradlew apiDump` (or `:<Module>:apiDump`) and commit the updated `.api`
+   file **in the same change** as the source change that caused it, so review sees both together.
+4. If it is not intended, fix the source. A leaked `public` type, a widened return type, or an
+   accidentally exposed internal is the bug — the baseline caught it.
+
+Never run `apiDump` to make a red gate go green without first understanding the diff. `KSP.api`
+contains only `ArcSymbolProcessorProvider`; keep everything else in that module `internal`.
+
+## Publishing and versions
+
+- Version comes from the `version` Gradle property, defaulting to `0.0.0-SNAPSHOT`
+  (`providers.gradleProperty("version").getOrElse("0.0.0-SNAPSHOT")`). Release builds pass
+  `-Pversion="$RELEASE_VERSION"`.
+- `.github/workflows/publish.yml` verifies with `./gradlew clean build --no-configuration-cache`,
+  runs the Chronicle real-kernel workflow, then publishes each module with
+  `:<Module>:publishAndReleaseToMavenCentral`. Publication is signed and goes to the Central Portal.
+- Gradle Plugin Portal publication is deliberately absent; the `io.cratis.arc` plugin marker is
+  uploaded by the `:GradlePlugin` Maven Central task. Do not add `com.gradle.plugin-publish`
+  unless asked.
+- Release intent is label-driven. `.github/workflows/verify-semver-label.yml` enforces exactly one
+  release-intent label on a pull request, and `publish.yml` fails a merge that publishes nothing
+  unless the pull request carried `no-release`.
+- Recognized Gradle properties in this repository: `version`, `useMavenLocal` (adds `mavenLocal()` in
+  `settings.gradle.kts`), `chronicleVersion` (`:Integrations:Chronicle`), and `chronicleKernelImage`
+  (`:ContractTests:chronicleRealKernelTest`, which requires an immutable `@sha256:` digest).
+
+## Quality gates
+
+| Gate | Command | What it proves |
+| --- | --- | --- |
+| Workspace | `./gradlew clean build --no-configuration-cache -x :ContractTests:typeScriptRuntimeTest` | Every module compiles with zero warnings, all JVM tests pass, `apiCheck` passes, sample proxy generation succeeds |
+| Baselines | `./gradlew apiCheck` | No unreviewed public ABI drift in the ten baselined modules |
+| Proxy determinism and strict TypeScript | `./gradlew :GradlePlugin:verifyContractTestProxyDeterminism :ContractTests:typeScriptBuild --no-configuration-cache` | A second generation changes no bytes, and the generated proxies compile strictly against the pinned `@cratis` packages |
+| TypeScript runtime | `./gradlew :ContractTests:typeScriptRuntimeTest --no-configuration-cache` | The published clients drive the real Kotlin Spring Boot sample; exact TAP totals with zero failures |
+| Documentation | `./Documentation/verify-markdown.sh` | Markdown lint, snippet validation, toc targets, and link checking over `Documentation/**` |
+| Chronicle kernel (opt-in) | `./gradlew :ContractTests:chronicleRealKernelTest --no-configuration-cache` | Kotlin and Java Chronicle samples against a digest-pinned kernel in Docker |
+
+`:ContractTests:check` depends on `typeScriptRuntimeTest`, which is why the workspace gate excludes
+it with `-x` and CI runs it as a separate, time-boxed step. Run the excluded gate too before calling
+work done.
+
+## Standing prohibitions
+
+- **Do not change dependency manifests, the Gradle wrapper, or `gradle.properties` unless explicitly
+  asked.** That includes bumping a library version pinned as a `val` in a module build file, editing
+  `gradle/wrapper/gradle-wrapper.properties`, and touching `ContractTests/TypeScript/package.json` or
+  `package-lock.json`. This is a repository convention with real consequences: pinned versions are
+  what make the contract gates reproducible.
+- There is no Gradle version catalog in this repository — `gradle/` contains only the wrapper, and
+  versions are declared as local `val` properties in each module build file. Do not introduce a
+  catalog as a side effect of another change.
+- Do not add a placeholder module, an empty publication, or a disabled task to make a gate pass.
+- Do not weaken `allWarningsAsErrors`, `-Werror`, or a toolchain version in a module build file to
+  work around a warning. Fix the warning.
+- Do not make `:Source` depend on Spring Boot or Chronicle, and do not make `:GradlePlugin` depend on
+  Spring Boot. Those directions are contract, not preference.
+
+See [testing.md](./testing.md) for what runs inside those gates, [ksp.md](./ksp.md) for the
+generation step the build depends on, and [typescript-proxies.md](./typescript-proxies.md) for the
+proxy gates in detail.

--- a/engineering/sources-staged/arc-kotlin/rules/java.md
+++ b/engineering/sources-staged/arc-kotlin/rules/java.md
@@ -1,0 +1,212 @@
+# Java Sources, Fixtures, Tests, and Samples
+
+This file governs the Java that exists in Arc.Kotlin: which modules contain it, why each piece is
+there, the compiler contract it is built under (`--release 17`, `-Xlint:all`, `-Werror`), the file
+and license conventions, Java test style, and the standing rule that every Java fixture, test, and
+sample consumes the **public** Arc surface only. Java is never the implementation language for
+framework behavior — Kotlin implements, Java proves the result is usable. How a Kotlin declaration
+becomes the JVM signature Java sees is [kotlin-java-interop.md](./kotlin-java-interop.md); Kotlin
+style itself is [kotlin.md](./kotlin.md); test layout and naming across languages is
+[testing.md](./testing.md).
+
+## Where Java lives, and why
+
+| Location | Count | Why it exists |
+| --- | --- | --- |
+| `Integrations/SpringBoot/src/main/java/**` | `ArcProperties`, `ArcTenancyProperties`, `IdentityCookieSecurePolicy`, `TenantResolverStrategy` | Spring Boot `@ConfigurationProperties` beans with JavaBean getters and setters, plus the enums they bind |
+| `Integrations/Observability/src/main/java/**` | `ArcObservabilityProperties`, `ArcObservationNames`, `ArcObservationTags` | A `@ConfigurationProperties` bean plus stable Micrometer name and tag constant holders |
+| `Source/src/test/java/**` | 8 files | Java conformance for the core public surface — adapters, tenancy, authentication, metadata, read-model resolvers |
+| `Integrations/*/src/test/java/**` | Spring Boot, Chronicle, Observability, OpenApi, SpringDataJpa, SpringDataMongo | Java conformance for each starter's public surface, plus Java fixture artifacts a Spring context can load |
+| `Testing/src/test/java/JavaScenarioConformanceTest.java` | 1 file | Proves the published `arc-testing` scenarios work from ordinary Java |
+| `ContractTests/src/testFixtures/java/**` | 30 files | Java records and classes that KSP must process — commands, read models, concepts, map/temporal/optional shapes |
+| `ContractTests/src/test/java/**` | 3 files | Java consumer contracts over generated artifacts |
+| `ContractTests/src/negativeFixtures/java/**` | 30 files | Java sources that must **fail** KSP with a specific diagnostic |
+| `Samples/Java/SpringBoot/**`, `Samples/Java/ChronicleSpringBoot/**` | 2 applications | Runnable proof that a Java Spring Boot application can use Arc end to end |
+
+**There is no `Source/src/main/java`.** `Source/src/main` contains `kotlin/` and `resources/` only.
+If you are about to add framework behavior in Java, you are in the wrong language — put it in
+Kotlin and, if Java needs a friendlier shape, add an adapter under
+`Source/src/main/kotlin/io/cratis/arc/java/`.
+
+## The compiler contract
+
+The root `build.gradle.kts` applies this to **every** module with the `java` plugin — there is no
+per-module opt-out:
+
+```kotlin
+extensions.configure<JavaPluginExtension> {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(17)
+    options.compilerArgs.addAll(listOf("-Xlint:all", "-Werror"))
+}
+```
+
+This is a **framework contract**:
+
+- `options.release.set(17)` compiles against the JDK 17 API surface, so a JDK 21 toolchain cannot
+  accidentally let a newer method into the sources. Do not replace it with `sourceCompatibility` /
+  `targetCompatibility`; `--release` is also what keeps `-Xlint:options` quiet.
+- `-Xlint:all -Werror` means **every javac warning is a build failure**.
+- The same root block adds `org.junit.jupiter:junit-jupiter:5.11.4` to `testImplementation`, adds
+  `junit-platform-launcher` to `testRuntimeOnly`, and applies `useJUnitPlatform()` to every `Test`
+  task. Do not re-declare those for the standard `test` source set; an extra source set such as
+  `ContractTests`'s `chronicleRealKernelTest` does have to wire its own configurations.
+
+## What `-Xlint:all -Werror` forbids in practice
+
+`-Xlint:all` on JDK 17 enables every category javac supports. The ones that actually bite when
+writing Arc consumer code:
+
+- **`rawtypes`** — `ConceptAs` instead of `ConceptAs<UUID>`, `List` instead of `List<TaskView>`.
+  Always parameterize. A Kotlin `Class<*>` arrives as `Class<?>`, which is fine; a bare `Class` is
+  not.
+- **`unchecked`** — an unchecked cast or an unchecked call to a raw-typed member. If a Kotlin API
+  hands you `Object` (a `CommandResult<?>` response, a `QueryResult<?>` payload), test with
+  `instanceof` and use pattern binding rather than casting blind.
+- **`deprecation`** and **`removal`** — using anything Kotlin marked `@Deprecated` or a JDK API
+  marked for removal. Migrate; there is no suppression budget for this.
+- **`serial`** — a `Serializable` type without `serialVersionUID`. Nothing in this repository
+  implements `Serializable`; if you introduce one you own the field.
+- **`cast`**, **`fallthrough`**, **`finally`**, **`overloads`**, **`overrides`**, **`static`**,
+  **`try`**, **`varargs`**, **`empty`**, **`divzero`** — ordinary correctness warnings. Fix the
+  code; none of them has a legitimate suppression in a framework repository.
+- **`missing-explicit-ctor`** applies only to exported packages of a named module; this build
+  produces no `module-info.java`, so it does not fire here.
+
+Rules:
+
+- **Never add `-Xlint:-<category>`, `-nowarn`, or drop `-Werror` to get a green build.** That
+  applies to a module build file as much as to the root.
+- `@SuppressWarnings` is a last resort and must be narrowly scoped to the single member that needs
+  it, with the specific category named. The whole repository uses it four times:
+  `@SuppressWarnings("unchecked")` on one JPA test helper, `@SuppressWarnings("unused")` on three
+  Chronicle test fixtures (an IDE-only category, not a javac one), and
+  `@SuppressWarnings("rawtypes")` in one negative fixture whose whole purpose is to model bad
+  consumer code.
+- A warning in a *sample* is as fatal as one in `Source`. Samples are in `./gradlew build`.
+
+## License header and file shape
+
+Every `.java` file starts with exactly these two lines, then a blank line, then `package`:
+
+```java
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package io.cratis.arc.samples.javaspringboot;
+```
+
+- One public type per file, named after the file. Nested records and helper types local to a test
+  may live inside the test class (`GeneratedArtifactModuleJavaContractTest`,
+  `CommandKeyProviderJavaContractTest` both do this).
+- Imports are explicit and alphabetical; no star imports. Static imports go in a separate block
+  after a blank line, following the ordinary imports.
+- Four-space indent, LF, final newline, no trailing whitespace — `.editorconfig` governs, and no
+  formatter or Checkstyle runs in this build.
+- Javadoc `/** … */` on every public type and member in `src/main/java`. `ArcProperties` documents
+  each getter and setter with `/** Gets … */` / `/** Sets … */`; follow that. Test methods do not
+  need Javadoc; a class-level `/** … */` naming the contract under test is the house habit.
+- American English in comments and messages.
+
+## Java language level and idioms in use
+
+Target the JDK 17 language, and use only what the repository already uses:
+
+- **`record`** is the default for a command, a read model, an event, a concept, or a value carrier:
+  `record CreateTask(String title)`, `record JavaOrderId(UUID value) implements ConceptAs<UUID>`.
+- **`final class`** with a private constructor for constant holders (`ArcObservationNames`), and
+  `final class` for anything not designed for extension.
+- **`enum`** for closed choices (`TenantResolverStrategy`, `IdentityCookieSecurePolicy`).
+- **Switch expressions** where they replace a chain of returns
+  (`Integrations/SpringBoot/src/main/java/io/cratis/arc/springboot/ArcProperties.java`).
+- **`var`** for locals whose type the initializer already states.
+- **`List.of` / `Map.of` / `Set.of`** for immutable literals — never `Arrays.asList` or a mutable
+  collection you then forget to wrap.
+- Not used anywhere here, and needing a reason before you are the first: `sealed`/`permits`, text
+  blocks, `module-info.java`, `Serializable`, and lambdas that capture mutable arrays.
+- Mutable JavaBean getters and setters appear **only** in Spring `@ConfigurationProperties` types,
+  where the binder requires them. Validate in the setter and throw `IllegalArgumentException` with
+  a message naming the property, as `ArcProperties` does.
+
+## Java test style
+
+[testing.md](./testing.md) owns test layout and class naming. What is Java-specific:
+
+- Most test classes are **package-private and `final`** — `final class JavaCoreAdaptersTest { … }`,
+  `final class TenancyJavaConformanceTest { … }`. A few are package-private without `final`, and the
+  two `Samples/Java` test classes are `public class …Tests`. Prefer package-private `final` for a
+  new class; match the module you are in rather than converting existing ones.
+- Test methods are package-private `void`, named in `lowerCamelCase` as a behavior sentence:
+  `resolversAndBlockingProviderBridgesAreJavaFriendly`,
+  `blockingAndAsyncCommandAdaptersRunThroughThePrimaryPipeline`,
+  `cancellingOpenCancelsTheJavaCompletionStage`. Kotlin's backticked sentence names have no Java
+  equivalent; do not import the snake_case variant that appears once in `ContractTests`.
+- Assertions are `org.junit.jupiter.api.Assertions.*` **static imports**, one per assertion used —
+  `assertEquals`, `assertTrue`, `assertThrows`. No AssertJ, no Hamcrest.
+- Await a `CompletionStage` in a test with `.toCompletableFuture().join()`. Prove cancellation and
+  ordering with a bounded `CountDownLatch.await(n, TimeUnit.SECONDS)` or
+  `ExecutorService.awaitTermination`. There is no `Thread.sleep` anywhere in this repository's Java;
+  do not add one.
+- Own every executor you create and close it, with try-with-resources:
+
+  ```java
+  try (JavaAsyncScope scope = JavaAsyncScope.owningExecutorService(executor)) {
+      // ... use scope.commands(pipeline) / scope.queries(pipeline)
+  }
+  ```
+
+  `JavaAsyncScope.usingExecutor(executor)` when the caller owns the executor,
+  `owningExecutorService(executor)` when the scope should shut it down. Blocking test scenarios use
+  the same shape: `try (BlockingCommandScenario<T> scenario = new BlockingCommandScenario<>(configured))`.
+- Test method names carrying "Java" (`…IsJavaFriendly`, `…FromJava`, `…JavaConformance…`) are how a
+  reviewer finds the dual-language coverage. Keep the marker.
+
+## Public API only — no module internals
+
+This is a **framework contract**, enforced by the fact that `internal` Kotlin members are absent
+from every `.api` baseline and unusable from a separate compilation unit.
+
+- Java fixtures, tests, and samples consume the published surface: `io.cratis.arc.*` from `Source`,
+  `io.cratis.arc.springboot.*` from the starter, `io.cratis.arc.testing.*` from `Testing`. Samples
+  depend on `project(":Integrations:SpringBoot")` or `project(":Integrations:Chronicle")` and are
+  wired with a plain `@SpringBootApplication`.
+- **If a Java sample or fixture cannot express something without reaching past the public API, the
+  public API is the defect.** Fix the Kotlin surface — usually by adding a `Blocking*`/`Async*`
+  adapter under `io.cratis.arc.java` — instead of widening a visibility or duplicating framework
+  logic in the fixture.
+- Do not re-implement pipeline behavior in a sample. `Samples/Java/SpringBoot` registers a validator
+  through the public seam and nothing else:
+
+  ```java
+  @Bean
+  public CommandValidator<CreateTask> createTaskValidator() {
+      return new BlockingCommandValidatorAdapter<>(new CreateTaskValidator());
+  }
+  ```
+
+- Never call a Kotlin `suspend` function from Java by passing a hand-built `Continuation`, and never
+  reference a `@JvmSynthetic` member. Use the adapters. A Java caller that needs
+  `kotlin.coroutines.*` or `kotlin.jvm.functions.*` on its classpath is a design failure to report,
+  not to work around. (`Samples/Java/ChronicleSpringBoot` does import
+  `kotlin.jvm.JvmClassMappingKt` — that is the *released Chronicle client's* Kotlin-typed API, not
+  Arc's, and it is the current known exception.)
+- The `apiValidation` block in the root `build.gradle.kts` ignores `ContractTests` and the samples,
+  so they carry no `.api` baseline. That is deliberate: they are consumers, not published surface.
+
+## Negative fixtures
+
+`ContractTests/src/negativeFixtures/java/**` is **not a Gradle source set**. It is read as plain
+text by `:CodeGeneration:KSP`'s tests through the `arc.contractNegativeFixtures` system property,
+so `-Xlint:all -Werror` never runs over it.
+
+- Every file there must be *invalid* for a stated reason, and a KSP test must assert the exact
+  `ARCKSP…` diagnostic it produces. `WildcardJavaCommand` (a `List<?>` command property),
+  `NonStaticJavaQuery` (an instance query method on a `@ReadModel`), and `RawConceptCommand` (a raw
+  `ConceptAs`) are the models.
+- Because these files are never compiled by javac, a `@SuppressWarnings` there is about IDE noise
+  only and carries none of the weight it would in a real source set.
+- Adding a file here changes the KSP negative test, not the `ContractTests` compilation. See
+  [ksp.md](./ksp.md).

--- a/engineering/sources-staged/arc-kotlin/rules/kotlin-java-interop.md
+++ b/engineering/sources-staged/arc-kotlin/rules/kotlin-java-interop.md
@@ -1,0 +1,590 @@
+# Kotlin/Java Interop — The Public Surface
+
+This file governs the shape of every public declaration in Arc.Kotlin, because that shape is
+consumed from two languages. **Kotlin implements; Java is a first-class consumer.** A Kotlin
+declaration that reads beautifully in Kotlin and compiles into a signature a Java application cannot
+call is a defect, not a trade-off. This file states what each Kotlin construct actually becomes on
+the JVM in *this* build, which interop bridges already exist here and must be reused rather than
+reinvented, how to verify a surface from Java instead of assuming it works, and where the annotations
+genuinely do not help. Kotlin style is [kotlin.md](./kotlin.md); the Java sources that prove all of
+this are [java.md](./java.md); design intent is [framework.md](./framework.md).
+
+## The core constraint
+
+- `AGENTS.md`: *"Kotlin is the implementation language; Java is a first-class consumer language.
+  Keep public APIs straightforward from Java, avoid Kotlin-only call patterns at public boundaries,
+  and verify important APIs from both languages."*
+- A Java consumer must never need `kotlin.coroutines.Continuation`,
+  `kotlin.jvm.functions.FunctionN`, `kotlinx.coroutines.flow.Flow`, or a hand-written
+  `DefaultConstructorMarker` argument to use a public Arc API.
+- The canonical proof of the constraint is `ConceptAs`:
+
+  ```kotlin
+  public interface ConceptAs<T> {
+      /** Returns the scalar value carried by this concept. */
+      public fun value(): T
+  }
+
+  /** Kotlin property view of the scalar value carried by this concept. */
+  @get:JvmSynthetic
+  public val <T> ConceptAs<T>.value: T
+      get() = value()
+  ```
+
+  The abstract member is a *method*, so `record JavaOrderId(UUID value) implements ConceptAs<UUID> {}`
+  satisfies it with zero boilerplate (`ContractTests/src/testFixtures/java/.../JavaOrderId.java`).
+  Kotlin still gets `concept.value` through a synthetic extension that Java never sees. Had this been
+  `val value: T`, Java would have needed `getValue()` and the record would not have worked.
+
+## Ground truth: how to see what Java sees
+
+Never reason about a JVM signature from the Kotlin source. Look at it.
+
+1. **The `.api` baseline** — `Source/api/Source.api`, `Integrations/<Name>/api/<Name>.api`. This is
+   the checked-in, gated view of the published surface, produced by
+   `binary-compatibility-validator`. It shows JVM descriptors, `synthetic` flags, and generated
+   overloads, but **erases generics**.
+
+   ```text
+   public abstract interface class io/cratis/arc/commands/CommandPipeline {
+       public abstract fun execute (Ljava/lang/Object;Lio/cratis/arc/commands/CommandExecutionOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+   }
+   ```
+
+2. **`javap`** on the compiled class, which keeps the generic signature and wildcards the `.api`
+   drops. This is the only way to see variance. Run it from the repository root after a build has
+   populated `Source/build/classes`:
+
+   ```bash
+   javap -cp Source/build/classes/kotlin/main io.cratis.arc.commands.DefaultCommandPipeline
+   ```
+
+   `javap` ships with the JDK. If it is not already on `PATH`, point `JAVA_HOME` at a local JDK 17
+   and prepend `$JAVA_HOME/bin` for the shell session — never hard-code a machine-specific JDK path
+   into a committed file. Add `-v` and read the `flags:` line to confirm `ACC_SYNTHETIC` on a
+   `@JvmSynthetic` member.
+
+3. **A Java fixture or test that compiles and runs.** This is the only proof that counts, because
+   Java sources here build under `-Xlint:all -Werror`. See
+   [Verifying a surface from Java](#verifying-a-surface-from-java).
+
+## What each Kotlin declaration becomes
+
+Verified with `javap` against this repository's compiled classes.
+
+| Kotlin | JVM signature Java sees | Example here |
+| --- | --- | --- |
+| `public val page: Int` | `int getPage()` | `results/PagingInfo.kt` |
+| `public val isValid: Boolean` | `boolean isValid()` | `results/CommandResult.kt` |
+| `public var x: T` | `T getX()` + `void setX(T)` | `springboot/ArcProperties.java` mirrors this shape in Java |
+| `suspend fun execute(c: Any, o: O): R` | `Object execute(Object, O, Continuation<? super R>)` | `commands/CommandPipeline.kt` |
+| `fun f(a: A = d)` | `f(A)` plus a static synthetic `f$default(..., int, Object)` | `queries/ObservableQueryPipeline.kt` |
+| `@JvmOverloads constructor(a, b = d)` | real overloads `(a)` and `(a, b)` | `results/CommandResult.kt` |
+| companion `fun` | instance method on `Foo$Companion` only | — |
+| companion `@JvmStatic fun` | `static` on `Foo` **and** instance on `Foo$Companion` | `results/CommandResult.kt` |
+| companion `@JvmField val` | `public static final` field on `Foo` | `tenancy/TenantId.kt` |
+| companion `const val` | `public static final` field on `Foo` | `tenancy/TenancyOptions.kt` |
+| top-level `fun` in `Foo.kt` | `static` on `FooKt` | `queries/JdkPublisherFlow.kt` → `JdkPublisherFlowKt` |
+| `@file:JvmName("X")` + top-level `fun` | `static` on `X` | `commands/CompletionStageAwait.kt` → `CompletionStages` |
+| `@JvmSynthetic fun` | `ACC_SYNTHETIC`; javac refuses to reference it | `results/ResultExtensions.kt` |
+| `Any` / `Any?` | `java.lang.Object` | everywhere |
+| `Class<*>` | `Class<?>` | `polymorphism/DerivedTypeRegistry.kt` |
+| `((Any) -> Any?)?` | `kotlin.jvm.functions.Function1<Object, ? extends Object>` | `queries/ObservableQueryPipeline.kt` |
+| `Flow<T>` | `kotlinx.coroutines.flow.Flow` | `queries/ObservableQueryPipeline.kt` |
+| interface member with a body (in `Source`) | real `default` method **and** a `$DefaultImpls` class | `queries/QueryPerformer.kt` |
+
+## Default arguments and `@JvmOverloads`
+
+Kotlin default arguments are invisible to Java. The compiler emits one method plus a
+`name$default(..., int mask, Object marker)` synthetic bridge that no Java caller should touch.
+
+- **Put `@JvmOverloads` on every public constructor and concrete function that has a default
+  argument and that Java is expected to call.** There are 113 uses in this repository.
+  `CommandResult`'s `@JvmOverloads constructor` produces seven real constructors in
+  `Source/api/Source.api`, from `(UUID)` up to the full seven-parameter form.
+- The Kotlin documentation states the rule precisely: *"For every parameter with a default value,
+  this generates one additional overload, which has this parameter and all parameters to the right
+  of it in the parameter list removed."* Order your parameters so that the truncated overloads are
+  the ones a caller actually wants — the most important parameters first, the rarely-overridden ones
+  last.
+- **`@JvmOverloads` cannot be used on an abstract method, including any interface method.** This is
+  the single most common interop trap here. `ObservableQueryPipeline.open` has two defaults and is
+  an interface method, so Java sees only:
+
+  ```text
+  public abstract java.lang.Object open(QueryRequest, QueryExecutionOptions, ObservableQueryTransferMode,
+      kotlin.jvm.functions.Function1<java.lang.Object, ? extends java.lang.Object>,
+      kotlin.coroutines.Continuation<? super ObservableQueryOpenResult>);
+  ```
+
+  which is unusable from Java. That is exactly why `io.cratis.arc.java.AsyncObservableQueryPipeline`
+  exists, with three real `open(...)` overloads and an `ObservableQueryKeyExtractor` fun interface in
+  place of `Function1`. **When an interface method needs defaults, add a Java-facing facade; do not
+  leave Java with the raw form.**
+- Secondary constructors are the other tool. `PagingInfo` adds one purely for Java's benefit:
+
+  ```kotlin
+  /** Java- and source-compatible convenience overload for integer totals. */
+  public constructor(page: Int, size: Int, totalItems: Int) : this(page, size, totalItems.toLong())
+  ```
+
+## Companion objects, statics, and constants
+
+- A companion member without `@JvmStatic` is reachable from Java only as
+  `Foo.Companion.member(...)`. **Annotate every companion factory a Java caller should use with
+  `@JvmStatic`.** `CommandResult.success(...)`, `QueryResult.error(...)`, `TenantId.of(...)`,
+  `ArcOneOf.of(...)`, and `JavaAsyncScope.usingExecutor(...)` all do; `javap` then shows both
+  `public static final ... success(java.util.UUID)` on the class and the instance method on
+  `Foo$Companion`.
+- **`@JvmField` for a companion `val` constant of a reference type** — the field lands directly on
+  the enclosing class:
+
+  ```kotlin
+  public companion object {
+      /** Tenant identifier used when no tenant has been selected. */
+      @JvmField
+      public val NOT_SET: TenantId = TenantId("[NotSet]")
+  }
+  ```
+
+  Java writes `TenantId.NOT_SET`, not `TenantId.Companion.getNOT_SET()`.
+- **`const val` for compile-time `String`/primitive constants** — `TenancyOptions.DEFAULT_HEADER_NAME`
+  becomes `public static final field DEFAULT_HEADER_NAME Ljava/lang/String;` and can be used in a
+  Java annotation argument or `switch` label. `@JvmField` cannot do that; `const` cannot hold an
+  object.
+- `@JvmField` is only legal on a property that has a backing field, is not `private`, and has no
+  `open`, `override`, or `const` modifier.
+
+## Top-level declarations and file classes
+
+- Top-level functions and properties compile into a class named after the file with `Kt` appended.
+  `JdkPublisherFlow.kt` → `JdkPublisherFlowKt`.
+- **Give any file whose top-level functions Java is meant to call an explicit `@file:JvmName`**, so
+  the Java-visible class name is designed rather than accidental. The five in this repository are:
+
+  | File | Java class |
+  | --- | --- |
+  | `commands/CompletionStageAwait.kt` | `CompletionStages` |
+  | `commands/ServiceResolverExtensions.kt` | `ServiceResolvers` |
+  | `identity/UsersProvider.kt` | `UsersProviders` |
+  | `identity/AsyncIdentityDetailsProviderAdapter.kt` | `IdentityDetailsProviders` |
+  | `tenancy/TenantsProvider.kt` | `TenantsProviders` |
+
+  `Integrations/Chronicle` adds `ChronicleCommandResponses` and `ChronicleCommandScenarios`, and
+  `Documentation/guides/testing.md` shows Java calling
+  `ChronicleCommandScenarios.chronicle(configured)` for what is a Kotlin extension function.
+- `@JvmMultifileClass` is not used here. If you ever need two files to share a facade name, add it
+  to *both* files.
+- Renaming a file, or adding/removing `@file:JvmName`, is a **binary-breaking change** for Java
+  callers even though nothing changed for Kotlin. It will show up in `apiCheck`.
+
+## `@JvmSynthetic` and the Kotlin-only property view
+
+`@JvmSynthetic` sets `ACC_SYNTHETIC`, so javac refuses to reference the member while Kotlin resolves
+it normally. Confirm with `javap -v`:
+
+```text
+public static final java.lang.Object getOrThrow(io.cratis.arc.results.CommandResult);
+  flags: (0x1019) ACC_PUBLIC, ACC_STATIC, ACC_FINAL, ACC_SYNTHETIC
+```
+
+Two sanctioned uses, and no others:
+
+1. **The property view over a method-shaped SPI.** The SPI member is `fun value(): T` so Java records
+   implement it for free; Kotlin gets property syntax from a synthetic extension. Used by
+   `ConceptAs.value`, `ArcEnum.wireValue`, `CommandKeyProvider.key`,
+   `DerivedTypeRegistry.baseTypes`, and `CanResolveReadModelForCommand.types` / `.ownership`.
+
+2. **A Kotlin-only ergonomic overload that has a Java-visible sibling.**
+
+   ```kotlin
+   /** Resolves [type] or throws a deterministic [MissingServiceException]. */
+   public fun <T : Any> ServiceResolver.require(type: Class<T>): T = resolve(type) ?: throw MissingServiceException(type)
+
+   /** Resolves a service using its reified Kotlin type or throws [MissingServiceException]. */
+   @JvmSynthetic
+   public inline fun <reified T : Any> ServiceResolver.require(): T = require(T::class.java)
+   ```
+
+   Also used to hide Kotlin-typed factories that would otherwise tempt Java into constructing a
+   `CoroutineScope`: `AsyncCommandPipeline.fromCoroutineScope`, `AsyncQueryPipeline.fromCoroutineScope`,
+   and `AsyncAuthentication.fromCoroutineScope` are `@JvmStatic @JvmSynthetic`, documented as
+   *"Kotlin host-integration factory; Java callers should use JavaAsyncScope."*
+
+**`@JvmSynthetic` does not remove a member from the `.api` baseline.** It appears there marked
+`synthetic`, and `apiCheck` still gates it. It is an ergonomics tool, not a way to keep a surface out
+of the published contract — use `internal` for that.
+
+## `suspend` from Java: the async adapter contract
+
+A `suspend` function is not callable from Java in any practical sense. Java sees a trailing
+`Continuation` parameter and an `Object` return; implementing one by hand is out of the question.
+
+**This repository already has a complete, consistent bridge. Reuse it. Do not invent a second one.**
+
+### Consuming Arc from Java
+
+`io.cratis.arc.java.JavaAsyncScope` is the single entry point. It is `AutoCloseable`, owns a
+`CoroutineScope(SupervisorJob() + executor.asCoroutineDispatcher())`, and hands out
+`CompletionStage`-shaped facades:
+
+```java
+try (JavaAsyncScope scope = JavaAsyncScope.owningExecutorService(Executors.newFixedThreadPool(2))) {
+    AsyncCommandPipeline commands = scope.commands(pipeline);
+    CommandResult<?> result = commands.execute(command, options).toCompletableFuture().join();
+}
+```
+
+- `usingExecutor(Executor)` — the caller keeps ownership of the executor.
+- `owningExecutorService(ExecutorService)` — the scope shuts the executor down in `close()`.
+- Facades: `commands(...)` → `AsyncCommandPipeline`, `queries(...)` → `AsyncQueryPipeline`,
+  `authentication(...)` → `AsyncAuthentication`, `observableQueries(...)` →
+  `AsyncObservableQueryPipeline`, `queryHealth(...)` → `java.util.concurrent.Flow.Publisher`.
+- `Testing` mirrors the pattern for tests: `BlockingCommandScenario`, `BlockingQueryScenario`,
+  `AsyncCommandScenario`, `AsyncQueryScenario`, `AsyncObservableQueryScenario`.
+
+### Implementing an Arc SPI from Java
+
+For every suspending SPI, `io.cratis.arc.java` publishes a matched triple: a `Blocking*` interface, an
+`Async*` interface returning `CompletionStage`, and a `*Adapter` class implementing the suspending
+contract. Register the *adapter* as the bean.
+
+| Suspending SPI | Java-facing pair | Adapters |
+| --- | --- | --- |
+| `CommandFilter` | `BlockingCommandFilter` / `AsyncCommandFilter` | `BlockingCommandFilterAdapter`, `AsyncCommandFilterAdapter` |
+| `AuthorizationCommandFilter` | `BlockingAuthorizationCommandFilter` / `Async…` | `…Adapter` pair (preserves filter ordering) |
+| `QueryFilter`, `AuthorizationQueryFilter` | `Blocking…` / `Async…` | `…Adapter` pair |
+| `CommandValidator<T>`, `QueryValidator` | `BlockingCommandValidator<T>` / `Async…` | `…Adapter` pair |
+| `AuthorizationPolicy` | `BlockingAuthorizationPolicy` / `Async…` | `…Adapter` pair |
+| `CommandExecutionScope` | `BlockingCommandExecutionScope` / `Async…` | `…Adapter` pair |
+| `CommandResponseValueHandler` | `Blocking…` / `Async…` | `…Adapter` pair |
+| `CommandHandler`, `QueryPerformer` | `BlockingCommandHandler` / `Async…`, `BlockingQueryPerformer` / `Async…` | `…Adapter` pair |
+| `TenantsProvider`, `UsersProvider`, `IdentityDetailsProvider<T>` | `AsyncTenantsProvider`, `AsyncUsersProvider`, `AsyncIdentityDetailsProvider<T>` | `…Adapter` + a Kotlin `as…Provider()` extension |
+| `AuthenticationHandler` | `AsyncAuthenticationHandler` | `AsyncAuthenticationHandlerAdapter` |
+
+Java registers one like this (`Samples/Java/SpringBoot/.../JavaSampleApplication.java`):
+
+```java
+@Bean
+public CommandValidator<CreateTask> createTaskValidator() {
+    return new BlockingCommandValidatorAdapter<>(new CreateTaskValidator());
+}
+```
+
+The adapter body is always the same three lines — delegate, and `await()` the stage:
+
+```kotlin
+public class AsyncCommandFilterAdapter(private val filter: AsyncCommandFilter) : CommandFilter {
+    override suspend fun execute(context: CommandContext): CommandResult<*> = filter.execute(context).await()
+}
+```
+
+`io.cratis.arc.commands.await` (published as `CompletionStages.await` and marked `@JvmSynthetic` for
+Java) is the **only** stage-to-coroutine bridge. It uses `suspendCancellableCoroutine`, unwraps
+`CompletionException`, and cancels the underlying `Future` from `invokeOnCancellation`. Do not write
+another.
+
+### Cancellation across the bridge
+
+Cancellation is cooperative in both directions, and every facade in this repository implements the
+same handshake — see `AsyncCommandPipeline.launch`, `AsyncQueryPipeline.perform`,
+`AsyncAuthentication.handleAuthentication`, and `AsyncObservableQueryPipeline`:
+
+```kotlin
+job = coroutineScope.launch {
+    try {
+        future.complete(operation())
+    } catch (exception: CancellationException) {
+        future.cancel(false)
+        throw exception
+    } catch (exception: Exception) {
+        future.completeExceptionally(exception)
+    }
+}
+future.whenComplete { _, _ -> if (future.isCancelled) job.cancel() }
+job.invokeOnCompletion { cause ->
+    if (cause != null && !future.isDone) {
+        if (cause is CancellationException) future.cancel(false) else future.completeExceptionally(cause)
+    }
+}
+```
+
+Any new facade must reproduce all four parts: rethrow `CancellationException`, cancel the future on
+coroutine cancellation, cancel the job when the future is cancelled, and complete exceptionally
+otherwise. The tests that hold this contract are
+`JavaObservableAdaptersTest.cancellingOpenCancelsTheJavaCompletionStage` and
+`JavaCoreAdaptersTest.closingAnOwnedScopeCancelsInFlightStagesAndShutsDownItsExecutor`, both under
+`Source/src/test/java/io/cratis/arc/conformance/`.
+
+## `Flow` versus `Flow.Publisher`
+
+`kotlinx.coroutines.flow.Flow` is Kotlin-only in practice. The repository's rule is: **Kotlin
+observable APIs speak `Flow`; the Java-facing surface speaks `java.util.concurrent.Flow.Publisher`,
+and two adapters convert between them.**
+
+- `ObservableQueryOpenResult.Stream` carries `Flow<QueryResult<*>>`;
+  `AsyncObservableQueryOpenResult.Stream` carries `JdkFlow.Publisher<QueryResult<*>>`. Both are
+  `sealed interface` hierarchies with the same two cases.
+- `CoroutineFlowPublisher` (`java/AsyncObservableQueryPipeline.kt`) turns a `Flow` into a **cold,
+  demand-aware** `Flow.Publisher`: one collection per subscriber, emission only against positive
+  demand, `IllegalArgumentException` on non-positive `request`, single terminal signal.
+- `JdkFlow.Publisher<T>.asKotlinFlow()` (`queries/JdkPublisherFlow.kt`) is the reverse, built on
+  `callbackFlow` with one-at-a-time `request(1)` and `awaitClose { subscription?.cancel() }`.
+  `BlockingQueryPerformerAdapter` and `AsyncQueryPerformerAdapter` call it automatically, so a Java
+  observable query simply returns a `Flow.Publisher` — see
+  `Samples/Java/SpringBoot/.../TaskView.java`:
+
+  ```java
+  @Path("/api/tasks/observe")
+  public static Flow.Publisher<List<TaskView>> observe(@FromServices TaskRepository repository) {
+      return repository.observe();
+  }
+  ```
+
+- Do not introduce Reactive Streams (`org.reactivestreams`) or Project Reactor types into a published
+  Arc signature. The JDK `Flow` types are already the bridge, and they cost no dependency.
+
+## Nullability across the boundary
+
+- Kotlin **does** emit `org.jetbrains.annotations.@NotNull` / `@Nullable` into the bytecode of
+  public members, and `Intrinsics.checkNotNullParameter` guards at the top of every public function.
+  `javap -v` on `io.cratis.arc.tenancy.TenantResolutionContext` shows both.
+- **javac does not enforce those annotations.** They are IDE and static-analysis signal only. The
+  Kotlin documentation is explicit: *"nobody prevents us from passing `null` as a non-nullable
+  parameter. That's why Kotlin generates runtime checks for all public functions that expect
+  non-nulls."* The consequence is a `NullPointerException` at the boundary, not a compile error and
+  not a validation result.
+- Therefore: where a `null` from Java is a *usage* error the pipeline should report, validate it
+  explicitly and return a `ValidationResult`. Where it is a programming error, the intrinsic check
+  is the right outcome.
+- Going the other way, Java types without nullability annotations arrive in Kotlin as **platform
+  types** (`T!`), which suppress Kotlin's null checks. Never let a platform type flow untested into
+  a non-null Kotlin property. Assign it to an explicitly nullable type and handle `null`.
+- This repository declares **no JSR-305, JetBrains, or JSpecify nullability annotations of its own**
+  in Kotlin or in Java main sources. The two `Nullable` annotation types under
+  `ContractTests/src/{testFixtures,negativeFixtures}/java` are local test fixtures: KSP's Java
+  metadata path recognizes any annotation whose simple name is `Nullable` or `CheckForNull`
+  (`CodeGeneration/KSP/.../JavaRecordParser.kt`, `MetadataCollector.kt`), which is how a Java record
+  component declares an optional property to the generator. That is a *code-generation* signal, not
+  a compiler one.
+
+## Generics, variance, and platform types
+
+- Kotlin's `out` variance becomes a Java wildcard **in parameter position**, and only when the type
+  argument is not final. `DefaultCommandPipeline` takes `Iterable<CommandFilter>` in Kotlin, and
+  Java sees:
+
+  ```text
+  public DefaultCommandPipeline(CommandHandlerRegistry,
+      java.lang.Iterable<? extends CommandFilter>, java.lang.Iterable<? extends CommandExecutionScope>, ...)
+  ```
+
+  which is what lets `JavaCoreAdaptersTest` pass a `List.of(...)` of mixed filter implementations.
+  By contrast `CommandResult`'s constructor takes `List<ValidationResult>` with **no** wildcard,
+  because `ValidationResult` is a final class. Do not guess which case you are in — run `javap`.
+- `@JvmSuppressWildcards` and `@JvmWildcard` are **not used anywhere in this repository**. If you
+  reach for one, that is a signal the signature is too clever; prefer changing the parameter type.
+- Return types never get wildcards, per the Kotlin documentation: *"wildcards are not generated,
+  because otherwise Java clients will have to deal with them."*
+- `Class<*>` is the house choice for a runtime type token (`DerivedTypeRegistry`,
+  `CommandValidator.commandType`, `CanResolveReadModelForCommand.readModelTypes()`), because it maps
+  to a clean `Class<?>` and avoids `KClass`, which Java can only obtain through
+  `JvmClassMappingKt.getKotlinClass(...)`.
+- **Never put `KClass`, `KType`, `KFunction`, `Pair`, `Triple`, `Unit`, or `Nothing` in a public
+  signature Java has to touch.** `Nothing` in particular is erased to a raw type. `Pair` appears in
+  a Kotlin *sample* command's return value (`Samples/Kotlin/SpringBoot/.../CreateTask.kt`) where KSP
+  unwraps it; that is generated-artifact input, not a published API.
+- Generics are not reified on either side. A cast that the surrounding code has already type-tested
+  is annotated `@Suppress("UNCHECKED_CAST")` in Kotlin and `@SuppressWarnings("unchecked")` in Java;
+  anything wider is a design problem.
+
+## Inline value classes
+
+- **Do not introduce `@JvmInline value class` into a published Arc surface.** There is not a single
+  one in this repository — the grep is empty.
+- The reason is the mangling rule: Kotlin compiles inline value classes to their unboxed
+  representation, and any public function that takes one gets a name suffix (`foo-<hash>`) that Java
+  cannot type. The Kotlin documentation states it plainly: *"By default, Kotlin compiles inline value
+  classes to use unboxed representations, which are often inaccessible from Java."*
+- `@JvmExposeBoxed` exists but is experimental (`@OptIn(ExperimentalStdlibApi::class)`) and is not
+  used here. Do not adopt it to rescue a value-class design; choose a different design.
+- The house alternative is a **`data class` implementing `ConceptAs<T>`** with a private backing
+  property, which gives Java a normal class with a normal accessor:
+
+  ```kotlin
+  public data class TenantId(private val rawValue: String) : ConceptAs<String> {
+      /** Returns the tenant identifier's wire value. */
+      override fun value(): String = rawValue
+  ```
+
+  `javap` confirms Java gets `TenantId(String)`, `String value()`, `isDefault()`, `copy`, `equals`,
+  `hashCode`, `toString`, the three `@JvmField` constants, and the `@JvmStatic of(String)` factory —
+  and, because the backing property is `private`, **no** `getRawValue()` and **no** `component1()`.
+  That is deliberate: a private constructor property keeps `componentN` out of the published API.
+- When a *dependency* exposes an inline value class, wrap it. `Integrations/Chronicle` adds a
+  `Long`-typed overload rather than re-exporting Chronicle's `EventSequenceNumber`:
+
+  ```kotlin
+  /** Adds an exact expected event-log position without exposing Chronicle's Kotlin inline value class to Java. */
+  public fun expectedSequenceNumber(eventSourceId: String, sequenceNumber: Long): EventsWithConcurrencyScopesBuilder
+  ```
+
+## Sealed types, exhaustiveness, and default methods
+
+- A `sealed interface` compiles to an ordinary Java interface. **Java gets no exhaustiveness
+  checking** — this build produces no `sealed`/`permits` Java declarations, and a Java consumer must
+  write an `instanceof` chain with a fail-closed `else`. Keep the case count small and each case's
+  payload obvious, as `ObservableQueryOpenResult` does with `Failure(result)` and `Stream(results)`.
+- Consequently, **adding a case to a public sealed hierarchy is a source-breaking change for Java
+  consumers** even though Kotlin only warns them via a non-exhaustive `when`. Treat it as a breaking
+  change and say so in the changelog.
+- `Source/build.gradle.kts` sets `compilerOptions.jvmDefault.set(JvmDefaultMode.ENABLE)`. In
+  `Source`, an interface member with a body therefore becomes a **real JVM `default` method** plus a
+  `$DefaultImpls` compatibility class:
+
+  ```text
+  public interface io.cratis.arc.queries.QueryPerformer {
+    public abstract QueryDescriptor getDescriptor();
+    public default boolean getAllowsAnonymous();
+    public default boolean getSupportsPaging();
+  }
+  ```
+
+  This is why a Java implementer of `BlockingCommandHandler` can skip `resolveCommandKey` and
+  `prepare` and only write `getCommandType`, `getMetadata`, and `invoke`.
+- Other modules inherit the compiler's default mode unless they configure it explicitly. If you
+  add a bodied interface member outside `Source`, inspect the emitted methods and compatibility
+  classes with `javap` rather than assuming either abstract or default dispatch. Compiler upgrades
+  can also add declared forwarding bridges on implementation classes; review those ABI changes.
+- `@JvmDefault` appears nowhere in this repository. The typed `jvmDefault` compiler option is the
+  mechanism this build uses; do not reach for the annotation or the deprecated `-Xjvm-default` flag.
+
+## Checked exceptions
+
+- **Kotlin has no checked exceptions, and this repository declares none.** `@Throws` is used zero
+  times. A Kotlin function that throws `IOException` is, to javac, a function that throws nothing,
+  so Java callers cannot `catch (IOException e)` on it without a compile error and cannot be forced
+  to handle it.
+- That is compatible with the design, because **Arc reports failures as results, not exceptions**:
+  `CommandResult` and `QueryResult` carry `validationResults`, `exceptionMessages`,
+  `exceptionStackTrace`, and `authorizationFailureReason`. Java handles a failure by inspecting
+  `isSuccess`, not by catching.
+- Do not add `@Throws` to make a Kotlin API feel Java-ish. Add it only if a Java caller genuinely
+  must catch a specific checked type — and then verify it from a Java test, because `@Throws` changes
+  the JVM signature and therefore the `.api` baseline.
+- A `CompletionStage` from an Arc facade completes exceptionally with the original cause (the
+  facades unwrap `CompletionException` on the way in). Java sees the wrapped form on `join()`; test
+  for the cause, not the wrapper.
+
+## Annotation use-site targets
+
+Kotlin annotations land on the *property* by default, which is often invisible where Java, Jackson,
+or Jakarta Validation looks. Always state the target.
+
+- `@get:JsonProperty("isSuccess")` on `CommandResult.isSuccess` puts the Jackson annotation on the
+  getter, which is what the serializer reads.
+- `@get:JvmName("isDefault")` on `TenantId.isDefault` names the getter explicitly. Kotlin's
+  `is`-prefix rule already yields `isDefault()` — `CommandResult.isAuthorized`, `isValid`, and
+  `isSuccess` rely on the rule with no annotation — so treat the explicit form as documentation of
+  intent, not as a fix.
+- `@get:JvmSynthetic` on an extension property hides the accessor from Java; the bare `@JvmSynthetic`
+  form applies to a function.
+- `@get:JsonInclude(JsonInclude.Include.NON_DEFAULT)` and
+  `@get:JsonProperty(access = JsonProperty.Access.WRITE_ONLY)` follow the same rule
+  (`queries/ObservableQueryProtocol.kt`, `metadata/ParameterDescriptor.kt`).
+- Arc's own annotations declare an explicit `@Target` and `AnnotationRetention.RUNTIME` so both KSP
+  and Java see them — `@Command`, `@ReadModel`, `@Path`, `@DerivedType`, `@ArcEnumValue`, `@Flags`.
+  Jakarta constraints in `validation/StandardStringConstraints.kt` additionally target
+  `AnnotationTarget.FIELD, PROPERTY_GETTER, VALUE_PARAMETER, ANNOTATION_CLASS` precisely so a Java
+  record component and a Kotlin constructor property both work.
+
+## Properties versus builders
+
+- For a small, fully-specified value, use a constructor with `@JvmOverloads`. `CommandResult`,
+  `QueryResult`, `ValidationResult`, `TenantResolutionContext`, and `TenancyOptions` are all
+  constructed directly from Java.
+- For an ordered, validated composition, publish a **fluent builder that returns `this`**, entered
+  through a `@JvmStatic` factory. `EventsWithConcurrencyScopesBuilder` is the model, and it shows the
+  right way to offer a Kotlin DSL without penalizing Java — the same operation exists as a
+  receiver-lambda overload *and* a `java.util.function.Consumer` overload:
+
+  ```kotlin
+  /** Builds a Chronicle concurrency scope with a Kotlin receiver. */
+  public fun concurrencyScope(eventSourceId: String, configure: ConcurrencyScopeBuilder.() -> Unit): EventsWithConcurrencyScopesBuilder
+
+  /** Builds a Chronicle concurrency scope with a Java [Consumer]. */
+  public fun concurrencyScope(eventSourceId: String, configure: Consumer<ConcurrencyScopeBuilder>): EventsWithConcurrencyScopesBuilder
+  ```
+
+- Never publish a receiver-lambda DSL as the only entry point. `configure: T.() -> Unit` is
+  `Function1<T, Unit>` to Java, which requires returning `kotlin.Unit` explicitly.
+- Mutable JavaBean getter/setter pairs belong only in Spring `@ConfigurationProperties` types, which
+  are written in Java for that reason (`Integrations/SpringBoot/src/main/java/.../ArcProperties.java`).
+
+## Verifying a surface from Java
+
+**"It should work from Java" is not a verification.** A public API change is not done until Java
+source that exercises it compiles under `-Xlint:all -Werror` and runs.
+
+1. Pick the right home: core surface → `Source/src/test/java/io/cratis/arc/conformance/`; a starter →
+   `Integrations/<Name>/src/test/java/`; generated artifacts → `ContractTests/src/test/java/` with
+   fixtures in `ContractTests/src/testFixtures/java/`; end-to-end → `Samples/Java/**`.
+2. Write a package-private `final class …JavaConformanceTest` / `…JavaContractTest` whose method
+   name states the claim — `resolversAndBlockingProviderBridgesAreJavaFriendly`.
+3. Call the API the way a real consumer would: no `Continuation`, no `FunctionN`, no
+   `Foo.Companion.`, no reflection. If you need any of those to make it compile, the surface is
+   wrong — fix the Kotlin, not the test.
+4. Await through `CompletionStage.toCompletableFuture().join()` and close every scope with
+   try-with-resources.
+5. Regenerate the baseline (`./gradlew apiDump`) and commit the `.api` diff in the same commit;
+   confirm the new signatures read the way you intended.
+6. Run the gates in [general.md](./general.md). `ContractTests` is mandatory when a public contract
+   moved.
+
+## Checklist for a new public declaration
+
+Run this over every public Kotlin declaration before you call it done.
+
+1. Does it have KDoc, an explicit `public`, and the standard license header?
+2. Does any parameter have a default value? If it is a constructor or concrete function, is it
+   `@JvmOverloads`? If it is an interface method, is there a Java-facing facade, since
+   `@JvmOverloads` is illegal there?
+3. Is it a companion member Java should call? Then `@JvmStatic`. A constant? `@JvmField` for a
+   reference, `const val` for a `String` or primitive.
+4. Is it a top-level function Java should call? Does the file carry an intentional `@file:JvmName`?
+5. Is it `suspend`? Then Java needs an `Async*`/`Blocking*` pair and a `*Adapter` in
+   `io.cratis.arc.java`, or a facade obtained from `JavaAsyncScope` — reusing `await()` and the
+   four-part cancellation handshake.
+6. Does any signature mention `Flow`, `Function1`, `KClass`, `Pair`, `Triple`, `Unit`, `Nothing`, or
+   an inline value class? Replace it: `Flow.Publisher`, a `fun interface`, `Class<*>`, a named type.
+7. Is it a property whose annotation must land on the accessor? Use `@get:` / `@set:`.
+8. Is it a Kotlin-only convenience? Then it is `@JvmSynthetic`, and a Java-visible sibling exists.
+9. Run `javap` on the compiled class. Do the wildcards, the nullability annotations, and the
+   generated overloads read the way a Java author would expect?
+10. Does a Java fixture, test, or sample actually call it, and does `./gradlew build` stay at zero
+    warnings?
+11. Is the `.api` diff in the same commit, and is it the diff you intended?
+
+## What annotations do not fix
+
+Be honest about the limits; do not reach for an annotation that cannot help.
+
+- **`@JvmOverloads` on an interface or abstract method** — illegal. Java gets none of your defaults.
+  Build a facade.
+- **`@JvmName` to rename an override** — not a supported use. The Kotlin reference documents
+  `@JvmName` for naming a file class, resolving signature clashes from erasure, and renaming
+  property accessors — not for changing the JVM name of a member that participates in overriding.
+  Rename on the supertype, or add a differently named member that delegates.
+- **`@JvmStatic` on a top-level function** — it buys nothing; top-level functions are already
+  compiled to `static` methods on the file class.
+- **`@JvmSynthetic` as an API-hiding mechanism** — the member remains in the `.api` baseline and in
+  the published binary. `internal` is what removes something from the surface.
+- **`@JvmField` on an `open`, `override`, `const`, `private`, or delegated property** — not
+  permitted; `@JvmField` requires a non-private property with a backing field and none of those
+  modifiers.
+- **Any annotation that makes `suspend` callable from Java** — none exists. Only an adapter does.
+- **Any annotation that gives Java exhaustiveness over a Kotlin `sealed` hierarchy** — none exists.
+- **`@Throws` as a way to document failure modes** — it changes the JVM signature and the `.api`
+  baseline while doing nothing for Kotlin callers. Use KDoc and the result envelope.
+- **`@JvmSuppressWildcards` as a shortcut past an awkward variance** — it changes a *published*
+  signature. Redesign the parameter type instead, and verify with `javap`.

--- a/engineering/sources-staged/arc-kotlin/rules/kotlin.md
+++ b/engineering/sources-staged/arc-kotlin/rules/kotlin.md
@@ -1,0 +1,331 @@
+# Kotlin Style and Conventions
+
+This file governs how Kotlin is written in Arc.Kotlin: file headers and layout, visibility and the
+published surface, KDoc, naming, immutability, type modeling, null handling, `suspend` and
+structured concurrency, collections, exceptions, and what `allWarningsAsErrors` means in practice.
+Kotlin is the implementation language for every module in this repository — `Source`,
+`CodeGeneration/KSP`, `GradlePlugin`, all six `Integrations/**`, and `Testing` are Kotlin source
+sets. Java is a first-class *consumer*, never the implementation language, so a Kotlin decision that
+reads well here but compiles into an awkward JVM signature is still wrong: see
+[kotlin-java-interop.md](./kotlin-java-interop.md), which outranks this file wherever a style
+preference and a Java-visible signature disagree.
+
+## License header
+
+Every `.kt` and `.kts` file starts with exactly these two lines, followed by a blank line:
+
+```kotlin
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+```
+
+File-level annotations go *after* the header and *before* the `package` line, separated by blank
+lines — `Source/src/main/kotlin/io/cratis/arc/commands/CompletionStageAwait.kt`:
+
+```kotlin
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+@file:JvmName("CompletionStages")
+
+package io.cratis.arc.commands
+```
+
+## Files and packages
+
+- Source lives under `<Module>/src/main/kotlin/io/cratis/arc/...`. The directory path always matches
+  the package. `Source` owns `io.cratis.arc.*`; integrations own `io.cratis.arc.<area>.*`
+  (`io.cratis.arc.springboot`, `io.cratis.arc.chronicle`, `io.cratis.arc.springdata.jpa`, …).
+- **Default: one public top-level declaration per file, named after it.** `CommandPipeline.kt`,
+  `TenantId.kt`, `QueryResult.kt`.
+- The one sanctioned deviation is a *cohesive family* of small related declarations, in a file named
+  for the family in the plural: `java/QueryAdapters.kt`, `java/CommandAdapters.kt`,
+  `tenancy/StandardTenantIdResolvers.kt`, `results/ResultExtensions.kt`,
+  `commands/CommandValueFactories.kt`, `queries/ReadModelForCommandResolvers.kt`. Do not use this to
+  park unrelated types together.
+- Private helpers used by exactly one file stay in that file as `private` top-level declarations
+  (`private object TenantHost` in `tenancy/SubdomainTenantIdResolver.kt`) rather than becoming new
+  files.
+- This is a **repository convention**, not a compiler rule.
+
+## Visibility and the published surface
+
+- **Write `public` explicitly on every public declaration.** The Kotlin `explicitApi()` mode is
+  *not* enabled in this build — the modifier is a house convention that makes an intentional export
+  visible in review. Grep any file under `Source/src/main/kotlin` and you will find it on every
+  class, interface, function, property, and companion member.
+- Use `internal` for anything the module needs but consumers must not see — `internal class
+  ConceptValidation`, `internal constructor` on `AsyncCommandPipeline`, `internal fun
+  attachExecutionToken`. `internal` is invisible to Java's `-Werror` build *and* absent from the
+  `.api` baseline, which is the machine gate.
+- The **framework contract** is the checked-in `.api` baseline (`Source/api/Source.api` and the
+  per-integration files), enforced by `./gradlew apiCheck`. Any change to a public signature must
+  land with the regenerated baseline in the same commit. See [gradle.md](./gradle.md).
+- Prefer an `internal constructor` plus a public factory over a public constructor when the type is
+  only meaningfully created by the framework — `AsyncCommandPipeline`, `AsyncQueryPipeline`,
+  `AsyncAuthentication`, and `EventsWithConcurrencyScopes` all do this.
+
+## KDoc
+
+- **Every public declaration carries KDoc**, including companion members, enum entries, and
+  properties declared in a primary constructor. One sentence, in the third person, describing
+  behavior — not restating the name.
+- Constructor properties are documented inline, above the parameter
+  (`Source/src/main/kotlin/io/cratis/arc/commands/CommandContext.kt`):
+
+  ```kotlin
+  public class CommandContext @JvmOverloads constructor(
+      /** Correlation identifier for the execution. */
+      public val correlationId: UUID,
+      /** Command instance being executed. */
+      public val command: Any,
+  ```
+
+- Use a multi-paragraph KDoc when the type carries a contract a caller can get wrong — ordering,
+  precedence, wire behavior, or an interop reason. `ConceptAs`, `ArcEnum`, `CommandResult`,
+  `TenantIdResolver`, and `CommandExecutionToken` are the models.
+- Reference other declarations with brackets (`[BlockingAuthorizationPolicy]`,
+  `[io.cratis.arc.artifacts.CommandKey]`) so the link survives.
+- American English everywhere: behavior, serialize, initialize, color, canceled/cancellation.
+
+## Naming
+
+- Types: `PascalCase`. Functions, properties, parameters: `lowerCamelCase`.
+- `const val` and `@JvmField` constants: `SCREAMING_SNAKE_CASE` — `DEFAULT_HEADER_NAME`,
+  `TenantId.NOT_SET`, `ObservableQuerySubscriptionRevision.MAX_VALUE`.
+- **Enum entries are `SCREAMING_SNAKE_CASE` by default** — `QueryTransportType.REQUEST_RESPONSE`,
+  `ArcHttpStatus.INTERNAL_SERVER_ERROR`, `ReadModelForCommandOwnership.DECLARED`.
+  The exception is an enum serialized *by name* onto the Arc wire, which keeps the wire spelling:
+  `ValidationResultSeverity` (`Unknown`, `Information`, `Warning`, `Error`) and
+  `ObservableQueryHubMessageType` (`Subscribe`, `QueryResult`, `Ping`) are the two cases, and both
+  exist because a JavaScript or .NET peer already reads those names.
+- Adapter families use a fixed prefix pair so the intent is obvious at the call site:
+  `Blocking*`/`Async*` for the Java-facing SPI, `*Adapter` for the class that bridges it to the
+  suspending contract — `BlockingCommandValidator` → `BlockingCommandValidatorAdapter`.
+- Avoid abbreviations. `configure`, not `cfg`; `repository`, not `repo`.
+
+## Immutability
+
+Immutability is the default and it is enforced by construction, not by documentation.
+
+- Public state is `val`. `var` appears only in private, synchronized, or coroutine-local scope.
+- **Defensively copy every collection that crosses a constructor.** The house idioms are
+  `java.util.List.copyOf(...)`, `java.util.Set.copyOf(...)`,
+  `Collections.unmodifiableMap(LinkedHashMap(source))`, and
+  `Collections.unmodifiableList(ArrayList(source))` — chosen deliberately over `toList()` because
+  they hand Java callers a genuinely unmodifiable view. From
+  `Source/src/main/kotlin/io/cratis/arc/results/CommandResult.kt`:
+
+  ```kotlin
+  public val validationResults: List<ValidationResult> = java.util.List.copyOf(validationResults)
+  ```
+
+- Accept the widest reasonable input type and narrow on store: take `Iterable<T>` or
+  `Collection<T>` in the constructor, expose `List<T>`.
+- Validate in `init` with `require` (argument) or `check` (state), with a message that says what the
+  caller should do — `CommandContext`, `PagingInfo`, and `QueryContext` all do this.
+
+## Type modeling
+
+- **`data class` when value equality is part of the contract** — `TenantId`, `TenantName`, `Tenant`,
+  `TenancyOptions`. Remember that `copy`, `componentN`, `equals`, `hashCode`, and `toString` all
+  become published API the moment the class is public.
+- **Plain `class` when equality is not part of the contract**, even for immutable value carriers:
+  `CommandResult`, `QueryResult`, `ValidationResult`, `PagingInfo`, and `CommandContext` are plain
+  classes with `val` properties. Prefer this. A `data class` you did not need is a `copy` overload
+  and a set of `componentN` accessors you must now keep binary-compatible forever.
+- **Do not introduce `@JvmInline value class` in a published surface.** There is not one in this
+  repository, and `Integrations/Chronicle` explicitly works around Chronicle's own inline class
+  rather than re-exposing it. See [kotlin-java-interop.md](./kotlin-java-interop.md) for why.
+- **`sealed interface` for closed result unions**, with nested `class` implementations:
+
+  ```kotlin
+  public sealed interface ObservableQueryOpenResult {
+      /** Query filters or performer creation rejected the subscription. */
+      public class Failure(public val result: QueryResult<*>) : ObservableQueryOpenResult
+
+      /** A controlled cold stream of query results. */
+      public class Stream(public val results: Flow<QueryResult<*>>) : ObservableQueryOpenResult
+  }
+  ```
+
+  Consume them with an exhaustive `when` and no `else` branch, so adding a case becomes a compile
+  error. `AuthenticationOutcome`, `CommandExecutionToken`, and `AsyncObservableQueryOpenResult`
+  follow the same shape.
+- **`fun interface` for a single-method SPI a consumer implements** — `TenantIdResolver`,
+  `CommandKeyProvider`, `BlockingAuthorizationPolicy`, `AsyncTenantsProvider`. This gives Kotlin a
+  lambda and Java a lambda in one declaration.
+- Types are final unless extension is a designed feature. `FixedTenantIdResolver` and
+  `QueryStringTenantIdResolver` are `open` precisely because `DevelopmentTenantIdResolver` and
+  `QueryTenantIdResolver` are declared subclasses of them.
+
+## Nullability
+
+- `null` is a modeled answer, never a shrug. When a function returns `null`, KDoc says what `null`
+  means: *"Returns the resolved tenant, or `null` when this resolver has no answer."*
+- **Never use `!!`.** Use `requireNotNull`, `checkNotNull`, `?:` with a fail-closed branch, or
+  `takeIf`/`let`. The one bare `!!` in `Source` main is `exception.cause!!` inside an explicit
+  `exception.cause != null` guard.
+- Prefer safe-call chains and `?.let(::Ctor)` over defensive `if` ladders:
+
+  ```kotlin
+  private fun String?.toTenantIdOrNull(): TenantId? = this?.takeIf(String::isNotBlank)?.let(::TenantId)
+  ```
+
+- At a Java-facing boundary, treat every incoming reference as possibly null even when the Kotlin
+  type is non-null — Kotlin's generated parameter null checks are what stop it, and they throw
+  `NullPointerException`, not a validation result. Where a `null` from Java is a *usage* error the
+  pipeline should report, validate it explicitly.
+
+## Coroutines and structured concurrency
+
+- **The suspending contract is the primary SPI.** `CommandPipeline.execute`, `QueryPipeline.perform`,
+  `QueryPerformer.perform`, `CommandValidator.validate`, and `AuthorizationPolicy.evaluate` are all
+  `suspend`. Java-facing variants are separate adapter types, never a second overload on the same
+  interface.
+- **Never use `ThreadLocal` for state a coroutine can observe.** This is an `AGENTS.md` rule and the
+  repository has zero occurrences. Carry state either as an explicit parameter (`CommandContext`,
+  `QueryContext`, `TenantResolutionContext`) or as a `CoroutineContext` element —
+  `Source/src/main/kotlin/io/cratis/arc/commands/CommandExecutionToken.kt`:
+
+  ```kotlin
+  internal class CommandExecutionContext(
+      val token: CommandExecutionToken
+  ) : AbstractCoroutineContextElement(Key) {
+      companion object Key : CoroutineContext.Key<CommandExecutionContext>
+  }
+  ```
+
+  installed with `withContext(CommandExecutionContext(token)) { ... }` in `DefaultCommandPipeline`.
+- **Cancellation is cooperative, and `CancellationException` must never be swallowed.** The house
+  pattern is to catch and rethrow it *before* the general handler, so a cancelled command is not
+  reported as a failed command:
+
+  ```kotlin
+  } catch (exception: CancellationException) {
+      throw exception
+  } catch (exception: Exception) {
+      return ObservableQueryOpenResult.Failure(QueryResult.exception<Any?>(options.correlationId, exception))
+  }
+  ```
+
+- Cleanup that must still run after cancellation goes in `withContext(NonCancellable) { ... }`. The
+  kotlinx.coroutines reference describes `NonCancellable` as "designed for `withContext` function to
+  prevent cancellation of code blocks that need to be executed without cancellation";
+  `DefaultCommandPipeline` uses exactly that to complete execution scopes in reverse order, each
+  under its own `withTimeout`.
+- **Do not create a `CoroutineScope` a caller cannot see or close.** A long-lived scope is either
+  owned by an `AutoCloseable` (`JavaAsyncScope`, `BlockingCommandScenario`) or supplied by the host.
+  Owned scopes are always `CoroutineScope(SupervisorJob() + dispatcher)` and are cancelled in
+  `close()`.
+- `runBlocking` is allowed **only** in a declared blocking bridge for Java or test setup —
+  `UsersProviderAggregator.provideBlocking`, `TenantsProviderAggregator.provideBlocking`,
+  `BlockingCommandScenario`, `BlockingQueryScenario`, `ChronicleCommandScenario`. It must never
+  appear on a path a request coroutine can reach.
+- Bridge a `CompletionStage` into a coroutine with the repository's own
+  `io.cratis.arc.commands.await`, which uses `suspendCancellableCoroutine` and cancels the future via
+  `invokeOnCancellation`. Do not add a second await helper.
+- Blocking I/O inside a suspending function is wrapped in `withContext(Dispatchers.IO)`; see
+  `Integrations/SpringDataMongo/src/main/kotlin/io/cratis/arc/springdata/mongodb/MongoObservation.kt`.
+
+## Collections and sequences
+
+- Return read-only `List`, `Set`, `Map` from public API. `MutableList` never appears in a published
+  signature.
+- Build with `mutableListOf` / `linkedMapOf` locally, then copy on the way out.
+- Preserve declaration order deliberately and say so in KDoc — `LinkedHashMap` and
+  `putIfAbsent`/`getOrPut` are used throughout (`TenantsProviderAggregator`,
+  `TenantResolutionContext`) because order *is* the contract.
+- Use `asSequence()` when a chain short-circuits over a possibly long input, as in
+  `CompositeTenantIdResolver`:
+
+  ```kotlin
+  override fun resolve(context: TenantResolutionContext): TenantId? = resolvers.asSequence()
+      .mapNotNull { it.resolve(context) }
+      .firstOrNull { it.value().isNotBlank() }
+  ```
+
+  For short, already-materialized lists, plain collection operators are clearer — do not convert to
+  a sequence reflexively.
+
+## Errors and exceptions
+
+- **A pipeline failure is a result, not an exception.** Command and query failures travel as
+  `CommandResult` / `QueryResult` with `validationResults`, `exceptionMessages`, and
+  `authorizationFailureReason`. Reserve throwing for programming errors and unrecoverable state.
+- Argument problems throw `IllegalArgumentException` via `require`; state problems throw
+  `IllegalStateException` via `check`. Do not construct those types by hand when the intrinsic
+  applies.
+- **A named exception type per distinguishable failure**, each carrying the data a handler needs and
+  deriving from the closest standard type:
+
+  ```kotlin
+  public class UnableToResolveReadModelFromCommandContext(public val readModelType: Class<*>) : IllegalStateException(
+      "Cannot resolve read model '${readModelType.name}' because the command context has no key."
+  )
+  ```
+
+  `DuplicateCommandHandlerException`, `MissingServiceException`, `QueryArgumentException`,
+  `InvalidTenantBaseDomainException`, and `MultipleReadModelResolversForCommandException` follow the
+  same shape. Messages name the offending type and what to do about it.
+- Never catch `Throwable` in application logic. `Exception` is the widest catch used in the
+  pipelines, and always after the `CancellationException` rethrow.
+
+## Warnings are errors
+
+`allWarningsAsErrors.set(true)` is configured for every Kotlin module in the root
+`build.gradle.kts`. This is a **framework contract**: a warning fails the build.
+
+- **Fix the cause; never suppress to go green.** Deleting an unused import, narrowing a type, or
+  handling a `when` branch is the fix.
+- `@Suppress` is admissible only where the compiler cannot see a fact you have already proved. The
+  entire repository main-source budget is 22 `@Suppress("UNCHECKED_CAST")` — each guarding a cast
+  the surrounding code has just type-tested — plus four `@Suppress("UNUSED_PARAMETER")` on
+  signature-compatibility parameters. Adding a new suppression kind needs a stated reason in review.
+- Deprecation warnings are errors too. When a dependency deprecates something, migrate; do not
+  suppress.
+
+## Kotlin conveniences and the Java surface
+
+A Kotlin-only convenience is fine when it is *additive* and hidden from Java. It is wrong when it is
+the only way to use a feature.
+
+Acceptable, because Java keeps a first-class path:
+
+- An `inline` + `reified` overload marked `@JvmSynthetic` alongside a `Class<T>` overload —
+  `ServiceResolver.resolve()` / `require()` next to `require(type: Class<T>)`.
+- A `@get:JvmSynthetic` extension property giving Kotlin `concept.value` while Java keeps
+  `concept.value()` (`ConceptAs`, `ArcEnum`, `CommandKeyProvider`, `DerivedTypeRegistry`).
+- `@JvmSynthetic` extension functions for ergonomics — `CommandResult.fold`, `getOrThrow`,
+  `onSuccess`, `validationOrNull` in `results/ResultExtensions.kt`.
+- A lambda-with-receiver DSL *paired* with a Java overload, as in
+  `Integrations/Chronicle/.../EventsWithConcurrencyScopes.kt`, which offers both
+  `concurrencyScope(id, configure: ConcurrencyScopeBuilder.() -> Unit)` and
+  `concurrencyScope(id, configure: Consumer<ConcurrencyScopeBuilder>)`.
+
+Not acceptable in a published surface:
+
+- A `suspend` function as the only way to invoke something a Java host must call.
+- A Kotlin function type (`(Any) -> Any?`) as the only parameter shape — declare a `fun interface`
+  (`ObservableQueryKeyExtractor`) and adapt.
+- `kotlinx.coroutines.flow.Flow` as the only stream type — pair it with
+  `java.util.concurrent.Flow.Publisher`.
+- Default arguments on an interface method as the only ergonomic entry point; Java gets none of them.
+- Extension functions, operator overloads, destructuring, or `Pair`/`Triple` in a signature a Java
+  consumer is expected to implement.
+
+Before adding any public declaration, run the checklist in
+[kotlin-java-interop.md](./kotlin-java-interop.md).
+
+## Formatting
+
+- No `ktlint`, `detekt`, `spotless`, or `checkstyle` is configured in this build. Formatting is
+  governed by `.editorconfig` — UTF-8, LF, four-space indent, trailing whitespace trimmed, final
+  newline — and by matching the file you are editing.
+- Keep lines within about 120 characters. A handful of main-source lines reach ~140; treat that as
+  the ceiling, not the target.
+- Imports are explicit; no star imports. Aliases are used where a name collides, always with a
+  descriptive alias — `import java.util.concurrent.Flow as JdkFlow`,
+  `import java.lang.reflect.Array as ReflectArray`.
+- Prefer expression bodies (`= ...`) for single-expression functions, and a trailing comma-free
+  parameter list broken one-per-line once it exceeds the line budget.

--- a/engineering/sources-staged/studio-issues/upstream-issues.md
+++ b/engineering/sources-staged/studio-issues/upstream-issues.md
@@ -1,0 +1,56 @@
+---
+applyTo: "**/*"
+---
+
+# Register Problems Where They Get Fixed
+
+When you hit a problem whose fix belongs in a Cratis framework repository rather than in this one, **open an issue on that repository**. Working around it here and moving on leaves the defect in place for every other application built on Cratis, and leaves the next person to rediscover it from scratch.
+
+This applies whether or not you also work around it locally. The workaround unblocks the task; the issue is what gets it fixed.
+
+## What belongs upstream
+
+A problem belongs upstream when the behavior is wrong in the framework, not in how this application uses it:
+
+- Generated output is wrong, inconsistent, or unstable across builds (proxy generator, source generators).
+- An analyzer reports something incorrect, or fails to report something it documents.
+- A public API behaves differently from what its own documentation says.
+- An alternate implementation of an interface diverges in semantics from the primary one.
+- A component renders or behaves incorrectly given documented props.
+- A runtime does something the guidance says it will not.
+
+A problem does **not** belong upstream when this application is using the framework wrongly - that is a fix here, and often a rule or skill worth updating.
+
+## Which repository
+
+| Area | Repository |
+|---|---|
+| Commands, queries, model binding, proxy generation, validation, authorization | `Cratis/Arc` |
+| Event sourcing, projections, reducers, reactors, observers, storage, compliance | `Cratis/Chronicle` |
+| `ConceptAs<T>`, type discovery, serialization, common primitives | `Cratis/Fundamentals` |
+| React components on PrimeReact | `Cratis/Components` |
+| The `Establish`/`Because`/`should_` spec base | `Cratis/Specifications` |
+| Reusable GitHub workflows | `Cratis/Workflows` |
+| Authentication proxy behavior | `Cratis/AuthProxy` |
+
+When unsure which owns it, prefer the repository whose package name appears in the failing call.
+
+## What the issue needs
+
+Enough for someone who has never seen this application to reproduce it:
+
+- What was expected, and what happened instead - both concretely.
+- The smallest reproduction you can state, with the exact source shape that triggers it.
+- The real error text, not a paraphrase.
+- Why it matters beyond the immediate annoyance: what it breaks, and what it looks like when it breaks. A defect that presents as intermittent or environment-specific is worth saying so, because that is what makes it expensive to find.
+
+State the problem rather than prescribing the fix. Suggest a direction if you have one, and leave the decision to whoever owns the code.
+
+## After filing
+
+Reference the issue from any workaround left behind, so the workaround can be removed when the fix lands and is not mistaken for a deliberate choice:
+
+```csharp
+// Worked around until Cratis/Arc#2547 - the generator emits a different module
+// layout in Debug and Release, so the committed shape has to match Release.
+```

--- a/engineering/sources-staged/studio-issues/writing-on-issues.md
+++ b/engineering/sources-staged/studio-issues/writing-on-issues.md
@@ -1,0 +1,64 @@
+---
+applyTo: "**/*"
+---
+
+# Writing on Issues, and When to Ask a Human
+
+Issues in `Cratis/StudioIssues` are read by people who did not do the work and were not in your context. What you write there is the only thing they see. Two failures matter, and the second is worse than the first.
+
+## Do not narrate your investigation
+
+An issue comment is not a log. The reader wants the current state and what happens next, not the sequence of hypotheses that produced it.
+
+Concretely, the failure looks like this: seven comments over two days, each correcting the previous one, each mentioning a person who has no action to take. The person is @-mentioned every time and asked nothing answerable. Eventually they ask *"is there any input needed from me?"* — which means every one of those notifications was a cost with no return.
+
+**Before commenting, ask what changes for the reader.** If the answer is "they now know I looked at something", do not post. Findings that change nothing yet belong in the internal plan file, not in a public comment.
+
+- **Post a comment when**: the state of the issue changed (diagnosed, fixed, blocked, withdrawn), or you need an answer.
+- **Do not post when**: you have progress but no change of state, or you are correcting a detail nobody acted on. Edit the earlier comment instead.
+- **Consolidate.** One comment that supersedes your last three is better than three that each qualify the one before.
+
+**Consolidating is retroactive, and editing is free.** Editing an existing comment sends no notification, so a thread that has already sprawled can be collapsed without costing anyone a second interruption: rewrite the first comment as the current state of play, and replace the superseded ones with a one-line pointer to it. Nothing is hidden and the history stays intact, but a reader arriving late reads one comment instead of reconstructing a narrative from ten.
+
+The measure to apply is **what a newcomer has to read to understand the state**, not how many comments exist. One issue in this repository reached **14 comments and 30,000 characters** — seven of them posted in a single day by the agent that was actively working it, each superseding the last. Consolidated afterwards, the same information was 13,000 characters and one current comment. If your recent comments would not survive that exercise, do it before posting another one.
+
+Corrections are mandatory when you were wrong and somebody may have acted on it — but state the correction and its consequence, not the journey. *"I said this was load. It is not; it fails on an idle runner too"* is complete.
+
+## Only @-mention a person for a decision that is theirs
+
+An @-mention is a claim on someone's attention. It is justified when there is a question **only they can answer**, and not otherwise.
+
+**Evidence that the reflex is real, measured on `Cratis/StudioIssues`:** of 23 issues carrying agent-written comments, **20 @-mentioned the same maintainer**. Six of those were triage questions posted on backlog issues on a single day; **none received a reply**, and all six were still open two weeks later. A mention that reliably goes unanswered is not a request — it is noise that teaches the reader to skim past the ones that matter.
+
+Before mentioning anyone, apply these in order:
+
+1. **Can I find this out?** Measure it, read the source, run it. A question you could have answered by looking is not a question. Most "should we do X or Y?" questions are really "I have not checked whether X is possible."
+2. **Is it genuinely theirs?** Product intent, priorities, money, access and credentials, and irreversible decisions are theirs. Anything decidable from the code, the measurements, or the existing rules is yours — including which of several correct implementations to use.
+3. **Is it answerable as written?** A question referring to something you redacted, or requiring the reader to reconstruct six comments of context, cannot be answered. It will be ignored, and rightly.
+4. **Does it block something now?** A decision needed only when an issue is eventually picked up is not needed today. Write it into the comment as an open call for whoever picks it up, and leave the mention off. Backlog triage almost never justifies a ping.
+
+**Replying to someone who already wrote on the issue is different, and always fine.** Answering a direct question, or thanking a reporter for a bug report, is a conversation rather than an interruption. The rule above is about *initiating* a demand for attention.
+
+### The shape of a good question
+
+When you do ask, the comment should be readable on its own, in under a minute:
+
+- **Lead with the question.** Not the background. Someone opening the notification sees the ask first.
+- **Give the options concretely**, with what each one implies. Two or three named alternatives beat an open-ended prompt.
+- **Say why you cannot decide it** — that is what justifies the interruption.
+- **Say what is not blocked.** If you can proceed on other parts meanwhile, say so, so the reply does not feel urgent when it is not.
+- **Offer an out.** "If you would rather not, say so and I will do Z instead" is often more useful than the question.
+
+Put the evidence *after* the question, or in a separate comment. Never make someone read a measurement table to find out what is being asked.
+
+## Withdraw questions that turned out not to be questions
+
+If you asked something and then discovered the answer yourself, say so explicitly and withdraw it. Leaving it open means someone is still holding an obligation you have already discharged.
+
+The same applies to a question built on a premise that turned out false. State that the premise was wrong and that nothing is needed — that is a real update and worth its notification.
+
+## A failing check is evidence about the path it exercises
+
+The reasoning error that produces most bad issue comments: treating a failing assertion as evidence about the subsystem you already suspect, rather than about the code path the assertion actually runs through.
+
+Read the path the failing check exercises — the query, the endpoint, the handler — before forming a theory about anything upstream of it. Otherwise you will produce confident, well-evidenced comments about the wrong component, ask for decisions that do not need making, and correct yourself in public repeatedly.

--- a/tooling/catalog-validation.mjs
+++ b/tooling/catalog-validation.mjs
@@ -59,6 +59,8 @@ const supportedSchemaKeywords = new Set([
     "maxItems",
     "uniqueItems",
     "items",
+    "contains",
+    "allOf",
     "minLength",
     "maxLength",
     "pattern",
@@ -88,6 +90,17 @@ export function validateSchemaVocabulary(schema, path = "$") {
             }
         } else if (keyword === "items" && value && typeof value === "object") {
             errors.push(...validateSchemaVocabulary(value, `${path}.items`));
+        } else if (keyword === "contains" && value && typeof value === "object") {
+            errors.push(...validateSchemaVocabulary(value, `${path}.contains`));
+        } else if (keyword === "allOf" && Array.isArray(value)) {
+            value.forEach((child, index) => {
+                errors.push(
+                    ...validateSchemaVocabulary(
+                        child,
+                        `${path}.allOf[${index}]`,
+                    ),
+                );
+            });
         } else if (keyword === "oneOf" && Array.isArray(value)) {
             value.forEach((child, index) => {
                 errors.push(
@@ -283,6 +296,17 @@ export function validateAgainstSchema(
             errors.push(`${path}: expected exactly one matching oneOf branch`);
     }
 
+    for (const [index, subschema] of (schema.allOf ?? []).entries()) {
+        errors.push(
+            ...validateAgainstSchema(
+                value,
+                subschema,
+                rootSchema,
+                `${path}.allOf[${index}]`,
+            ),
+        );
+    }
+
     if (Object.hasOwn(schema, "const") && value !== schema.const) {
         errors.push(
             `${path}: expected constant ${JSON.stringify(schema.const)}`,
@@ -345,6 +369,19 @@ export function validateAgainstSchema(
             errors.push(
                 `${path}: must contain at most ${schema.maxItems} items`,
             );
+        }
+        if (
+            schema.contains &&
+            !value.some((item) =>
+                validateAgainstSchema(
+                    item,
+                    schema.contains,
+                    rootSchema,
+                    path,
+                ).length === 0,
+            )
+        ) {
+            errors.push(`${path}: does not contain a matching item`);
         }
         if (schema.uniqueItems) {
             const serializedItems = value.map((item) => JSON.stringify(item));

--- a/tooling/component-catalog-validation.mjs
+++ b/tooling/component-catalog-validation.mjs
@@ -54,9 +54,9 @@ export const distributionPointerOutputs = new Set([
 const expectedComponentAnchor =
     "4d255ebf1611d9005dce55c250d4eb68bfdd9b3d53e0078be23b12bcb19a6247";
 const expectedProjectionAnchor =
-    "b896dcb363e9b52ae5a20985cd2706e730d7569ce93d0ee1755f5c59dadb24b9";
+    "4091d3a75e9acf5490a6b38585c7c870945bd8f58ba006ce9ad1852a7e79b4e9";
 const expectedProjectionHostAnchor =
-    "9735e6fd6a1b15e92086df6fda6cb4a988094c37c26e11bddf0518d5d3fdeba2";
+    "8bb30c43bdcbbd51d4568a8c9aa5828f57555a144833336f46e77b6f4dc56c7f";
 
 export const componentKinds = Object.freeze([
     "skill",
@@ -1389,15 +1389,19 @@ export function validateComponentProjections(
     );
     if (
         projections.hosts.length !== 9 ||
-        // 399 rather than 402 since Cratis/AI#175 and #177: `add-business-rule`
-        // was one directory projected into three host adapters, but both halves
-        // of its pending split modeled the same three, so every adapter was
-        // counted twice. Executing the split leaves the three on the retained
-        // legacy twin exactly once.
-        projections.projections.length !== 399 ||
+        // 398 rather than 399 since Cratis/AI#256: the fleet adoption retired
+        // the root `AGENTS.md` symlink adapter. `AGENTS.md` is now the
+        // project-owned minimal bootstrap pointing at `.cratis/PROJECT.md`
+        // (see Documentation/project-context-bootstrap.md), not a projection
+        // of `cratis-instruction-general`, so its codex projection entry is
+        // gone. The earlier 399-rather-than-402 note was Cratis/AI#175 and
+        // #177: `add-business-rule` was one directory projected into three
+        // host adapters, but both halves of its pending split modeled the same
+        // three, so every adapter was counted twice.
+        projections.projections.length !== 398 ||
         projections.projections.filter(
             (projection) => projection.state === "existing",
-        ).length !== 329 ||
+        ).length !== 328 ||
         generatedStatic.length !== 70 ||
         generatedCounts["jetbrains-ai-assistant"] !== 34 ||
         generatedCounts.tabnine !== 34 ||

--- a/tooling/generate-repository-inventory.mjs
+++ b/tooling/generate-repository-inventory.mjs
@@ -115,6 +115,10 @@ function readPathUniverse() {
                 path === ".github/workflows/distribution-npm-stage.yml" ||
                 path === ".github/workflows/package-passive-candidate-assets.yml" ||
                 /^AI-REPOSITORY-REDESIGN-[A-Z0-9-]+\.md$/.test(path) ||
+                path === ".cratis/PROJECT.md" ||
+                path === ".cratis/ai.json" ||
+                path === "CLAUDE.md" ||
+                path === "GEMINI.md" ||
                 path === "Documentation/.markdownlint.json" ||
                 /^Documentation\/(?:adopting-cratis-ai|adopting-cratis-ai-for-maintainers|ai-distribution-and-subscriptions|capability-catalog-v2|phase-0-verification|private-repository-overlays|portable-compliance|profile-reference|public-product-architecture|skill-authoring-contract|skill-classification-audit|project-context-bootstrap|redesign-foundation-validation|releasing-cratis-ai|source-evidence-contract)\.md$/.test(
                     path,
@@ -230,19 +234,49 @@ const inventoryDefinitions = () => [
         evidenceIds: ["repo-main-b795d53"],
     },
     {
-        id: "root-instruction-adapter",
-        sourcePathPatterns: ["AGENTS.md"],
-        artifactType: "adapter",
+        id: "root-context-bootstrap",
+        sourcePathPatterns: ["AGENTS.md", "CLAUDE.md", "GEMINI.md"],
+        artifactType: "instruction",
         currentOwner: engineeringOwner,
-        targetOwner: obsoleteOwner,
+        targetOwner: engineeringOwner,
         runtimeEligibility: "forbidden",
-        generatedStatus: "derived",
-        adapterStatus: "symlink-adapter",
-        dependencies: [".ai/rules/general.md"],
-        risk: "high",
-        migrationState: "retire-after-evidence",
-        evidenceIds: ["workflows-68", "reevaluation-authority"],
-        generator: "legacy-manual-adapter-model",
+        generatedStatus: "source",
+        adapterStatus: "none",
+        dependencies: [".cratis/PROJECT.md"],
+        risk: "low",
+        migrationState: "retain",
+        evidenceIds: ["workflows-68", "ai-256"],
+    },
+    {
+        id: "project-context",
+        sourcePathPatterns: [".cratis/PROJECT.md"],
+        artifactType: "instruction",
+        currentOwner: engineeringOwner,
+        targetOwner: engineeringOwner,
+        runtimeEligibility: "forbidden",
+        generatedStatus: "source",
+        adapterStatus: "none",
+        dependencies: ["Documentation/project-context-bootstrap.md"],
+        risk: "low",
+        migrationState: "retain",
+        evidenceIds: ["workflows-68", "ai-256"],
+    },
+    {
+        id: "project-context-subscription",
+        sourcePathPatterns: [".cratis/ai.json"],
+        artifactType: "repository-metadata",
+        currentOwner: engineeringOwner,
+        targetOwner: engineeringOwner,
+        runtimeEligibility: "forbidden",
+        generatedStatus: "source",
+        adapterStatus: "none",
+        dependencies: [
+            "distribution/profile-subscription.schema.json",
+            "Documentation/project-context-bootstrap.md",
+        ],
+        risk: "low",
+        migrationState: "retain",
+        evidenceIds: ["workflows-68", "ai-256"],
     },
     {
         id: "root-skill-adapter",
@@ -478,6 +512,20 @@ const inventoryDefinitions = () => [
         risk: "high",
         migrationState: "retain",
         evidenceIds: ["option-a-plus-authority", "reevaluation-authority"],
+    },
+    {
+        id: "engineering-staged-migrated-sources",
+        sourcePathPatterns: ["engineering/sources-staged/**"],
+        artifactType: "documentation",
+        currentOwner: engineeringOwner,
+        targetOwner: engineeringOwner,
+        runtimeEligibility: "forbidden",
+        generatedStatus: "source",
+        adapterStatus: "none",
+        dependencies: ["Documentation/corpus-generations.md"],
+        risk: "medium",
+        migrationState: "classify-in-place",
+        evidenceIds: ["ai-256"],
     },
     {
         id: "skill-evaluations",

--- a/tooling/profile-subscription-validation.mjs
+++ b/tooling/profile-subscription-validation.mjs
@@ -34,7 +34,11 @@ function readJson(path, errors) {
  * `cratis` namespace: the whole `cratis/engineering` subtree (the umbrella,
  * its core, and every language cell) derives the engineering channel, every
  * other `cratis` id derives the public channel, and mixing the two resolves
- * to no channel at all. A declared channel must agree with the derived one.
+ * to no single channel. A mixed selection is a valid subscription — a
+ * repository may combine public profiles such as `cratis/documentation` with
+ * maintainer engineering cells — it simply derives no `channel` value, so a
+ * declared channel must agree with the derived one on single-channel
+ * selections and must be absent on mixed ones.
  */
 export function deriveSubscriptionChannel(profiles) {
     if (profiles.length === 0) return null;
@@ -251,12 +255,22 @@ export function validateProfileSubscriptions(
         errors.push(
             ...validateAgainstSchema(example, schema, schema, relativePath),
         );
-        const derivedChannel = deriveSubscriptionChannel(
-            example.profiles ?? [],
-        );
-        if (!derivedChannel)
+        const profiles = example.profiles ?? [];
+        const derivedChannel = deriveSubscriptionChannel(profiles);
+        const engineeringCount = profiles.filter(
+            (profile) =>
+                profile === "cratis/engineering" ||
+                profile.startsWith("cratis/engineering/"),
+        ).length;
+        const mixedSelection =
+            engineeringCount > 0 && engineeringCount < profiles.length;
+        if (!derivedChannel && !mixedSelection)
             errors.push(
                 `${relativePath}: profile selection does not resolve to one channel`,
+            );
+        if (mixedSelection && Object.hasOwn(example, "channel"))
+            errors.push(
+                `${relativePath}: a mixed public and engineering selection derives no single channel; leave channel unset`,
             );
         if (
             Object.hasOwn(example, "channel") &&
@@ -266,14 +280,8 @@ export function validateProfileSubscriptions(
             errors.push(
                 `${relativePath}: declared channel ${example.channel} contradicts the derived channel ${derivedChannel}`,
             );
-        const allowedProfiles = new Set(
-            (derivedChannel === "cratis-engineering"
-                ? profileCatalog.engineeringProfiles
-                : profileCatalog.publicProfiles
-            ).map((profile) => profile.id),
-        );
-        for (const profile of example.profiles)
-            if (!allowedProfiles.has(profile))
+        for (const profile of profiles)
+            if (!knownProfiles.has(profile))
                 errors.push(`${relativePath}: unknown profile ${profile}`);
         for (const harness of example.harnesses) {
             try {

--- a/tooling/specs/catalog-v2-validation.spec.mjs
+++ b/tooling/specs/catalog-v2-validation.spec.mjs
@@ -815,10 +815,10 @@ test("unknown properties fail the closed catalog v2 schema", () => {
 
 test("unsupported JSON Schema vocabulary fails explicitly", () => {
     const unsupported = clone(schema);
-    unsupported.$defs.target.allOf = [];
+    unsupported.$defs.target.anyOf = [];
     assert(
         validateSchemaVocabulary(unsupported).some((error) =>
-            error.includes("unsupported JSON Schema keyword allOf"),
+            error.includes("unsupported JSON Schema keyword anyOf"),
         ),
     );
 });

--- a/tooling/specs/component-catalog.spec.mjs
+++ b/tooling/specs/component-catalog.spec.mjs
@@ -299,12 +299,14 @@ test("S8 adds exactly 70 passive generated-static non-skill projections", () => 
         (projection) => projection.state === "generated-static",
     );
     assert.equal(catalogs.projections.hosts.length, 9);
-    assert.equal(catalogs.projections.projections.length, 399);
+    // 398/328 since Cratis/AI#256: the root AGENTS.md codex symlink adapter
+    // was retired; AGENTS.md is the project-owned bootstrap now.
+    assert.equal(catalogs.projections.projections.length, 398);
     assert.equal(
         catalogs.projections.projections.filter(
             (projection) => projection.state === "existing",
         ).length,
-        329,
+        328,
     );
     assert.equal(generated.length, 70);
     assert.equal(

--- a/tooling/specs/profile-subscription.spec.mjs
+++ b/tooling/specs/profile-subscription.spec.mjs
@@ -195,26 +195,35 @@ test("subscription schema enforces exact SemVer pins", () => {
     });
 });
 
-test("subscription schema rejects cross-audience profiles", () => {
+test("subscription schema accepts mixed public and engineering selections", () => {
     withFixture((root) => {
         const path = join(
             root,
             "Documentation/examples/ai-subscriptions/cratis-application.cratis-ai.json",
         );
         const example = readJson(path);
-        example.profiles = ["cratis/engineering"];
+        example.profiles = [
+            "cratis/documentation",
+            "cratis/engineering/csharp",
+        ];
+        delete example.channel;
         writeJson(path, example);
         const errors = validateProfileSubscriptions(root);
         assert(
-            errors.some((error) =>
-                error.includes("expected exactly one matching oneOf branch"),
-            ),
+            errors.every((error) => !error.includes("channel")),
+            `mixed selection must not produce channel errors: ${errors.join("; ")}`,
         );
         assert(
-            errors.some((error) =>
-                error.includes(
-                    "declared channel public contradicts the derived channel cratis-engineering",
-                ),
+            errors.every(
+                (error) => !error.includes("oneOf branch"),
+            ),
+            `mixed selection must satisfy the schema: ${errors.join("; ")}`,
+        );
+        example.channel = "public";
+        writeJson(path, example);
+        assert(
+            validateProfileSubscriptions(root).some((error) =>
+                error.includes("leave channel unset"),
             ),
         );
     });
@@ -240,6 +249,22 @@ test("cratis namespace subscribes without hand-declaring a channel", () => {
         deriveSubscriptionChannel(["cratis/arc", "cratis/engineering"]),
         null,
     );
+});
+
+test("mixed subscriptions validate against the committed example", () => {
+    const example = readJson(
+        join(
+            repositoryRoot,
+            "Documentation/examples/ai-subscriptions/mixed-documentation-and-engineering.cratis-ai.json",
+        ),
+    );
+    assert.deepEqual(example.profiles, [
+        "cratis/documentation",
+        "cratis/engineering/csharp",
+        "cratis/application/csharp",
+    ]);
+    assert.equal(Object.hasOwn(example, "channel"), false);
+    assert.deepEqual(validateProfileSubscriptions(repositoryRoot), []);
 });
 
 test("cratis namespace subscription still rejects a floating version", () => {

--- a/tooling/specs/support-validation.spec.mjs
+++ b/tooling/specs/support-validation.spec.mjs
@@ -151,9 +151,11 @@ test("all authored evidence and support policy schemas reject unknown properties
     }
 });
 
-test("all 178 observations, 172 fact IDs, 11 legacy gaps, 108 official sources, and 24 distribution evidence files are accounted exactly", () => {
+test("all 183 observations, 172 fact IDs, 11 legacy gaps, 108 official sources, and 24 distribution evidence files are accounted exactly", () => {
     const catalogs = loadSupportCatalogs();
-    assert.equal(catalogs.evidence.observations.length, 178);
+    // 183 since Cratis/AI#256 added the corpus-retirement authority observation
+    // ai-256; the previous 178 was already stale on main (the file carried 182).
+    assert.equal(catalogs.evidence.observations.length, 183);
     assert.equal(catalogs.evidence.legacyFacts.length, 172);
     assert.equal(catalogs.evidence.legacyGaps.length, 11);
     assert.equal(

--- a/tooling/specs/work-record-containment.spec.mjs
+++ b/tooling/specs/work-record-containment.spec.mjs
@@ -10,7 +10,7 @@ function read(path) {
 }
 
 const general = read(".ai/rules/general.md");
-const agents = read("AGENTS.md");
+const agentsBootstrap = read("AGENTS.md");
 const claude = read(".claude/CLAUDE.md");
 const pullRequests = read(".ai/rules/pull-requests.md");
 const shipSkill = read(".ai/skills/ship-changes/SKILL.md");
@@ -33,9 +33,13 @@ function assertNoIssueMutationInstruction(path, content) {
 }
 
 test("repository intake is transient and no-effect in every always-on adapter", () => {
-    assert.equal(agents, general);
+    // The root AGENTS.md is the project-owned bootstrap (Cratis/Workflows#68):
+    // it points at .cratis/PROJECT.md and carries no corpus bytes. The corpus
+    // general rules stay served through the always-on .claude adapter here.
+    assert.match(agentsBootstrap, /\.cratis\/PROJECT\.md/);
+    assert.equal(agentsBootstrap.includes("# Cratis — Project Instructions"), false);
     assert.equal(claude, general);
-    for (const content of [general, agents, claude]) {
+    for (const content of [general, claude]) {
         assert.match(content, /## New Repository Strategy Intake/);
         assert.match(
             content,


### PR DESCRIPTION
Part of the Cratis/AI#256 corpus retirement and the team-repository AI adoption ([scenario](https://www.cratis.io/ai/scenarios/team-repository/)).

## What changes

- Commits the Cratis AI contract: `.cratis/PROJECT.md` (canonical project context), `.cratis/ai.json` (subscription: `cratis/documentation`, `cratis/engineering/typescript`), and the minimal `AGENTS.md` / `CLAUDE.md` / `GEMINI.md` bootstraps.
- Removes the synchronized `.ai/` corpus, the `.claude/` and `.github` Copilot adapters, and the generated `.pi` adapters. Nothing unique was lost: general content lives in `Cratis/AI` (staged for authoring where it had no home yet), and repository-specific content moved into `.cratis/PROJECT.md` / `.agents/`.
- Removes the `sync-copilot-instructions` and `propagate-copilot-instructions` workflows; the synchronization system is retired from `Cratis/Workflows` as well.
- The subscription contract itself evolves here: mixed public+engineering selections are valid (a third schema branch), the mini JSON-Schema validator learns `contains`/`allOf`, staged migrated sources live under `engineering/sources-staged/`, and this repository adopts its own `.cratis/` contract.

## For contributors

Install the Cratis plugin for your harness once (Claude Code, Codex, GitHub Copilot, Cursor, and Pi are installable today — see the [harness guide](https://www.cratis.io/ai/harnesses/)) and this repository's subscribed profiles load automatically. General improvements are proposed in `Cratis/AI`; repository facts belong in `.cratis/PROJECT.md`; AI session work records stay in the untracked `.ai-work/` folder.

Rollback is reverting this pull request.