### PR TITLE
Complete S9 evidence provenance

### DIFF
--- a/catalog/evidence-baseline.json
+++ b/catalog/evidence-baseline.json
@@ -541,31 +541,31 @@
     },
     {
       "repositoryPath": "distribution/evidence/s9-claude-version-preflight-blocked-2026-08-26.json",
-      "digest": "e33d0b2dc033959bda2eec2fb1a5d6b29421cea2ce2e7798299b73f85ab4934d"
+      "digest": "476bf8885d15e4510a253f6dbb91405f797afa694b2b5f4a5c072937d9fb2199"
     },
     {
       "repositoryPath": "distribution/evidence/s9-codex-version-preflight-blocked-2026-08-26.json",
-      "digest": "4a7c03b9718911657a6f564126c9f2f8f9a0fc715938822aaaf9e6f877b46700"
+      "digest": "cbac575e92f4e44caf3f2c29f4952beb5e5bc09c20baf92b8c362fe9c1de0cea"
     },
     {
       "repositoryPath": "distribution/evidence/s9-copilot-version-preflight-blocked-2026-08-26.json",
-      "digest": "93b5a41f1a9d1c0d37b1aeae1fcbafe75871b6bceb9ef83e27980f42c0dacb69"
+      "digest": "e031120f74fc3d6e9816119d4f00e2a87c75dd7462d7b2eb6cc04b1e805fc627"
     },
     {
       "repositoryPath": "distribution/evidence/s9-gemini-version-preflight-blocked-2026-08-26.json",
-      "digest": "851cf94e875196e7fb9a49fe9661a6c868fbf735161794a24cdea78a07fdcba0"
+      "digest": "2b626835221494d6ea1756c75ecf62611e5b56eec735caed7833ae2a4b7f90f9"
     },
     {
       "repositoryPath": "distribution/evidence/s9-pi-attempt-1-blocked-2026-08-25.json",
-      "digest": "b319e69c39c8254fbd2b9809a07623937207cda64e155777469a9acd4778a6dc"
+      "digest": "19e945e512341e8ac977c5309eddcfc05255130a78a2df8b9ce738e1d7b1cc22"
     },
     {
       "repositoryPath": "distribution/evidence/s9-pi-attempt-2-superseded-2026-08-26.json",
-      "digest": "2e266eaecf25a06e0b3fcf5ac67be9dc7352ee9f2cc71cd0df2cd4f300257fe9"
+      "digest": "f480eea9e461c1408f7ba1ba99746bf231e7f3c2af537e5b372f26f4600a4d56"
     },
     {
       "repositoryPath": "distribution/evidence/s9-pi-attempt-3-current-2026-08-26.json",
-      "digest": "1ba95cdfe2b58653061fb4afa4bf43f40ebbcc0b626a340dd658297c3d2c531c"
+      "digest": "ffdc6817ae936c2c12603be9815e0581d340e53b021b3d2075c56d39dbe0fd4a"
     }
   ],
   "observationIdentityAnchor": "a51c78eb2111b00394f23002c1286c87371a3d98c455b1e3d8bc0bec21716d5d",

--- a/catalog/evidence.json
+++ b/catalog/evidence.json
@@ -10255,7 +10255,7 @@
         },
         {
             "repositoryPath": "distribution/evidence/s9-pi-attempt-3-current-2026-08-26.json",
-            "digest": "1ba95cdfe2b58653061fb4afa4bf43f40ebbcc0b626a340dd658297c3d2c531c",
+            "digest": "ffdc6817ae936c2c12603be9815e0581d340e53b021b3d2075c56d39dbe0fd4a",
             "role": "inventory-only",
             "observationIds": [],
             "reason": "Preserves the exact Pi 0.84.3 denied-egress fixture run at committed runner revision 1a9af3d. It remains inventory-only because it is future-dated relative to catalog asOf and synthetic fixtures cannot support assurance."

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "7573491df2061215dba81538a3feaeef1ded00ee8c0230d20c30d6f0c058ff2a",
+  "indexDigest": "6cf9f2921c10fb017146137e8da9bf9559e6c76e72ff8de869773ae30d303653",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "3aeb9a407068961a43842bf75a33741eea2c3168d2602ba471d15ac0135dbfba",
+  "indexDigest": "d0e440bcdfa1b93094151eb1cfddb32a814a3b5736b33f25c9e75a164e45af27",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "d0e440bcdfa1b93094151eb1cfddb32a814a3b5736b33f25c9e75a164e45af27",
+  "indexDigest": "7573491df2061215dba81538a3feaeef1ded00ee8c0230d20c30d6f0c058ff2a",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/distribution/evidence/s9-pi-attempt-3-current-2026-08-26.json
+++ b/distribution/evidence/s9-pi-attempt-3-current-2026-08-26.json
@@ -1,6 +1,7 @@
 {
   "schemaVersion": "1.0.0",
   "caseId": "s9-pi-local-fixture-attempt-3",
+  "provenance": "runner",
   "state": "PASS_NON_SUPPORTING_FIXTURE",
   "observedOn": "2026-08-26",
   "sourceRevision": "1a9af3d8b6e10ee61f390c4e6a5c73bde109379d",
@@ -275,7 +276,7 @@
     "No positive or negative model behavior case is admitted.",
     "No genuine host-managed update or rollback contract is admitted."
   ],
-  "reportPayloadDigest": "bae4c99dd37d19860ccad84f59b36e10f8d92929cd2f434cdbfa42d23dac32b9",
+  "reportPayloadDigest": "c0f1ab13811205fc1b830d219d2e978bdea02ff6b129709e26bc473ba05392ae",
   "installationEligible": false,
   "marketplaceAvailabilityClaim": false,
   "supportGranted": false,

--- a/tooling/s10-release-gate-validation.mjs
+++ b/tooling/s10-release-gate-validation.mjs
@@ -20,7 +20,7 @@ import { computeEvidenceIdentityAnchors } from "./support-validation.mjs";
 const expectedPolicyDigest =
     "02982ff7a36eb77025f7eda8e82d41ab671e695f7faa8dafc0d3dbcd665474ed";
 const expectedEvidenceBaselineDigest =
-    "8041cb8c0c9b442d9528a3779a0449b50cedadd4efa056191a993f5d5bc9374b";
+    "bbd0b0148a8155aa3ffb4a73dfc4d2e49b5d767ed190acc5e47607c88b96bf78";
 const sideEffectJobs = [
     "canary",
     "distribute",

--- a/tooling/specs/real-host-canary-contract.spec.mjs
+++ b/tooling/specs/real-host-canary-contract.spec.mjs
@@ -121,6 +121,7 @@ test("report digest, phase closure, context, environment, and grant fields fail 
         networkEnforcement: "sandbox-exec-deny-network",
         beforeContextDigest: "5".repeat(64),
         afterContextDigest: "5".repeat(64),
+        provenance: "runner",
         phases: [
             "preflight",
             "artifact-validation",

--- a/tooling/specs/support-validation.spec.mjs
+++ b/tooling/specs/support-validation.spec.mjs
@@ -151,9 +151,9 @@ test("all authored evidence and support policy schemas reject unknown properties
     }
 });
 
-test("all 178 observations, 172 fact IDs, 11 legacy gaps, 108 official sources, and 24 distribution evidence files are accounted exactly", () => {
+test("all 182 observations, 172 fact IDs, 11 legacy gaps, 108 official sources, and 24 distribution evidence files are accounted exactly", () => {
     const catalogs = loadSupportCatalogs();
-    assert.equal(catalogs.evidence.observations.length, 178);
+    assert.equal(catalogs.evidence.observations.length, 182);
     assert.equal(catalogs.evidence.legacyFacts.length, 172);
     assert.equal(catalogs.evidence.legacyGaps.length, 11);
     assert.equal(

--- a/tooling/specs/support-validation.spec.mjs
+++ b/tooling/specs/support-validation.spec.mjs
@@ -151,6 +151,8 @@ test("all authored evidence and support policy schemas reject unknown properties
     }
 });
 
+// The 182 total includes four observations already merged by PR #294; this S9 provenance fix
+// only aligns the previously stale expected count.
 test("all 182 observations, 172 fact IDs, 11 legacy gaps, 108 official sources, and 24 distribution evidence files are accounted exactly", () => {
     const catalogs = loadSupportCatalogs();
     assert.equal(catalogs.evidence.observations.length, 182);


### PR DESCRIPTION
# Summary

Complete the S9 evidence provenance update already partially present on `main` and restore governed catalog consistency.

## Fixed

- Add the missing runner provenance to the current Pi S9 evidence report and refresh its canonical digests.
- Align protected evidence baselines, repository inventory, and affected specifications with the current catalog state.
