### PR TITLE
Ship the whole public skills directory in the fundamentals npm package

### DIFF
--- a/Documentation/adopting-cratis-ai.md
+++ b/Documentation/adopting-cratis-ai.md
@@ -94,10 +94,10 @@ package skills directly.
 
 ### Pi
 
-Install the published package at an exact version:
+Install the published package:
 
 ```bash
-pi install -l npm:@cratis/ai-fundamentals@0.10.0
+pi install -l npm:@cratis/ai-fundamentals
 pi list
 ```
 
@@ -158,10 +158,10 @@ Updates arrive as normal pull requests. Review changes to:
 - generated checksums/provenance references;
 - no shared skill or rule bodies.
 
-For Pi, move to another exact version:
+For Pi, update to the latest published release:
 
 ```bash
-pi install -l npm:@cratis/ai-fundamentals@<newer-exact-version>
+pi install -l npm:@cratis/ai-fundamentals
 ```
 
 Rollback restores the previous exact version in `.cratis/ai.json` and

--- a/Documentation/ai-distribution-and-subscriptions.md
+++ b/Documentation/ai-distribution-and-subscriptions.md
@@ -60,7 +60,9 @@ requests.
 > is **designed and tool-verified but not published**. No versioned profile
 > package exists yet (`profiles/manifest.json` still says
 > `DESIGNED_RELEASES_NOT_YET_PUBLISHED`); the only published package is
-> `@cratis/ai-fundamentals` `1.0.0`. Hosts install straight off the `Cratis/AI`
+> `@cratis/ai-fundamentals`, which ships the whole public skills directory so
+> Pi receives the same content as the marketplace harnesses. Hosts install
+> straight off the `Cratis/AI`
 > default branch through the committed marketplace manifests. The Pi commands
 > below show the designed post-release workflow, not something you can run for
 > every profile today.

--- a/Documentation/harnesses.md
+++ b/Documentation/harnesses.md
@@ -85,16 +85,16 @@ Cursor-specific fork of the content.
 
 ## Pi via npm
 
-Pi installs ordinary npm packages. Today the published package is
-`@cratis/ai-fundamentals` `1.0.0` — the Fundamentals
-concept guidance, not the whole bundle:
+Pi installs ordinary npm packages. The published package is the stable
+`@cratis/ai-fundamentals` release — the whole public skills directory, the
+same content the marketplace installs deliver:
 
 ```bash
-# Project-scoped, exact pin recorded in .pi/settings.json
-pi install -l npm:@cratis/ai-fundamentals@0.10.0
+# Project-scoped, installed version recorded in .pi/settings.json
+pi install -l npm:@cratis/ai-fundamentals
 
 # User-wide
-pi install npm:@cratis/ai-fundamentals@0.10.0
+pi install npm:@cratis/ai-fundamentals
 ```
 
 Commit `.pi/settings.json` after review; uninstalling removes the package and
@@ -116,10 +116,11 @@ in [ecosystem support](./ecosystem-support-architecture-review.md).
 
 ## Status
 
-- Installs ship as the supported `1.0.0` release.
+- Installs ship as supported stable releases.
 - The versioned per-profile package flow (exact pins arriving as reviewed pull
   requests) is designed but not published; today the marketplace follows the
-  `Cratis/AI` default branch, and npm carries only `@cratis/ai-fundamentals`.
+  `Cratis/AI` default branch, and npm carries the whole-bundle
+  `@cratis/ai-fundamentals`.
 - Being listed in a vendor's own marketplace UI — findable by search — is a
   separate, still-pending manual submission per host
   ([Cratis/AI#147](https://github.com/Cratis/AI/issues/147)). Adding

--- a/Documentation/index.md
+++ b/Documentation/index.md
@@ -26,7 +26,7 @@ GitHub Copilot: copilot plugin marketplace add Cratis/AI
 Cursor:        resolves the same skills through its committed
                marketplace manifest — no extra install step.
 
-Pi (npm):      pi install -l npm:@cratis/ai-fundamentals@0.10.0
+Pi (npm):      pi install -l npm:@cratis/ai-fundamentals
 ```
 
 The same marketplace also carries a separate maintainer plugin,
@@ -134,7 +134,8 @@ profiles, but they do not describe a supported installation channel:
   packages, reviewed update pull requests, rollback by version pin — is
   designed but not published yet. Until it ships, the marketplace installs
   straight off the default branch, and the only published package is
-  `@cratis/ai-fundamentals` `1.0.0` on npm.
+  `@cratis/ai-fundamentals` on npm — a stable release carrying the whole
+  public skill set.
 - **Vendor marketplace listing is pending.** Adding `Cratis/AI` as a
   marketplace works now; being *listed* in a vendor's own marketplace UI — so
   strangers can find "cratis" by search — is a separate manual submission per

--- a/Documentation/maintainer-marketplace-deployment-runbook.md
+++ b/Documentation/maintainer-marketplace-deployment-runbook.md
@@ -271,6 +271,8 @@ and the same with `path: "engineering"`. Hand-authored, no generator.
 
 [`release-passive-previews.yml`](../.github/workflows/release-passive-previews.yml)
 publishes the npm package on merge to `main` under a release-intent label.
+The package bundles the whole `skills/` directory — the same bytes the
+marketplace installs resolve — anchored by the fundamentals concept authority.
 
 - npm trusted publishing (OIDC), no token — bound to this exact workflow
   filename, org `Cratis`, repo `AI`, environment `npm-stage`. **Renaming the

--- a/Documentation/profile-reference.md
+++ b/Documentation/profile-reference.md
@@ -169,7 +169,7 @@ request, and floating versions such as `latest` remain forbidden everywhere.
 
 | Profile | Intended package | Current state |
 | --- | --- | --- |
-| `cratis/fundamentals` | `@cratis/ai-fundamentals` | First preview source candidate |
+| `cratis/fundamentals` | `@cratis/ai-fundamentals` | Published npm package; authority for the whole-bundle release |
 | `cratis/arc/core` | `@cratis/ai-arc` | Preview source candidate; the Arc capability base |
 | `cratis/arc/client-kotlin` | `@cratis/ai-arc-client-kotlin` | Content gap; anchored to [Cratis Arc.Kotlin](https://github.com/cratis/arc.kotlin) until guidance is verified |
 | `cratis/arc/ef-core` | `@cratis/ai-arc-ef-core` | EF Core migration source requires canonical Arc persistence authority |

--- a/Documentation/scenarios/multiple-harnesses.md
+++ b/Documentation/scenarios/multiple-harnesses.md
@@ -10,11 +10,11 @@ separate multi-harness topic — per-harness getting started lives in the
    [harness guide](../harnesses.md) describes. Claude Code, Codex, Copilot,
    and Cursor each resolve the same canonical skill bytes, so two tools never
    see different guidance.
-2. Pi (and any npm-consuming host) installs the published package with an
-   exact pin recorded in `.pi/settings.json`:
+2. Pi (and any npm-consuming host) installs the published package, with the
+   installed version recorded in `.pi/settings.json`:
 
    ```bash
-   pi install -l npm:@cratis/ai-fundamentals@0.10.0
+   pi install -l npm:@cratis/ai-fundamentals
    ```
 
 3. The repository commits `.cratis/ai.json` as the one neutral record of

--- a/Documentation/scenarios/updates-and-rollback.md
+++ b/Documentation/scenarios/updates-and-rollback.md
@@ -7,13 +7,13 @@ How Cratis AI guidance changes under you — and how to get back.
 Until the first governed release, marketplace installs follow the
 `Cratis/AI` default branch ([Cratis/AI#264](https://github.com/Cratis/AI/issues/264)).
 Updating means reinstalling or updating the plugin; rolling back means
-uninstalling. There is no version to pin yet, and the only published package
-is `@cratis/ai-fundamentals` `1.0.0` on npm — for
-that one, Pi's exact pins already work:
+uninstalling. There is no version to pin yet, and the published
+`@cratis/ai-fundamentals` npm package — the whole public bundle — is a
+supported stable release:
 
 ```bash
-pi install -l npm:@cratis/ai-fundamentals@0.10.0   # pin
-# rollback: reinstall the previous exact version
+pi install -l npm:@cratis/ai-fundamentals   # install / update
+# rollback: reinstall the previously recorded version
 ```
 
 ## The published world (designed, not yet live)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Free, MIT-licensed AI skills, rules, and agent guidance for building
 event-sourced and CQRS applications with the [Cratis](https://www.cratis.io)
 ecosystem. The only published package today is
-`@cratis/ai-fundamentals`, released as a stable `1.0.0` package.
+`@cratis/ai-fundamentals` — a stable release carrying the whole public
+skills directory.
 
 Cratis AI is the controlled source for shared AI skills, engineering guidance,
 product profiles, and generated multi-harness packages for the Cratis ecosystem.
@@ -16,8 +17,9 @@ It serves two separate audiences:
   framework, client, documentation, Studio, Stagehand, and corpus repositories.
 
 > **Current status:** the supported delivery today is the `@cratis/ai-fundamentals`
-> `1.0.0` npm package and the marketplace plugins; versioned per-profile
-> packages remain in review. Deterministic
+> npm package — the whole public skills directory, giving Pi the same content
+> as the marketplace harnesses — and the marketplace plugins; versioned
+> per-profile packages remain in review. Deterministic
 > review bundles now package 41 passive targets across 34 harness shapes. Four
 > additional targets remain explicitly blocked by MCP or private/local-content
 > safety boundaries, and four superseded legacy skills remain repository-only;

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "d8e0fa62d5e0404705d2c081b7c4d81edcb1b0709770b7736311604ccbdfe6a3",
+  "indexDigest": "7e70b3e3a4f5c27432a6b8e490c275aef580d0c11845bf241047f40e189a6875",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/tooling/package-fundamentals-preview-npm.mjs
+++ b/tooling/package-fundamentals-preview-npm.mjs
@@ -2,6 +2,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
     existsSync,
@@ -17,6 +18,7 @@ import { tmpdir } from "node:os";
 import { join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isDeepStrictEqual } from "node:util";
+import { compareOrdinal } from "./catalog-ordering.mjs";
 import { generatePassiveProfileAdapters } from "./passive-profile-adapters.mjs";
 import {
     createTarGzip,
@@ -30,6 +32,9 @@ const defaultRepositoryRoot = resolve(
 );
 const profileId = "cratis/fundamentals";
 const packageName = "@cratis/ai-fundamentals";
+const bundleDescription =
+    "Cratis AI skills for building event-sourced and CQRS applications";
+const publicSkillsRoot = "skills";
 
 function sha256(content) {
     return createHash("sha256").update(content).digest("hex");
@@ -54,7 +59,85 @@ function writeJson(path, value) {
     writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, { flag: "wx" });
 }
 
-function packageReadme(version, supported) {
+/**
+ * The npm package is the Pi delivery of the whole public skills directory —
+ * byte-identical content to what the committed marketplace manifests install
+ * for Claude Code, Codex, GitHub Copilot, and Cursor.
+ */
+export function loadPublicBundleSkills(
+    repositoryRoot = defaultRepositoryRoot,
+) {
+    const root = join(resolve(repositoryRoot), publicSkillsRoot);
+    const skills = readdirSync(root, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name)
+        .sort(compareOrdinal)
+        .map((name) => {
+            const files = walkFiles(join(root, name))
+                .sort(compareOrdinal)
+                .map((path) => ({
+                    path,
+                    content: readFileSync(join(root, name, path)),
+                }));
+            if (!files.some((file) => file.path === "SKILL.md"))
+                throw new Error(`Public skill is missing SKILL.md: ${name}`);
+            return { name, files };
+        });
+    if (skills.length === 0)
+        throw new Error(`No public skills found under ${publicSkillsRoot}/`);
+    return skills;
+}
+
+function bundleContentDigest(skills) {
+    const hash = createHash("sha256");
+    for (const skill of skills) {
+        hash.update(skill.name);
+        hash.update("\0");
+        for (const file of skill.files) {
+            hash.update(file.path);
+            hash.update("\0");
+            hash.update(file.content);
+            hash.update("\0");
+        }
+    }
+    return hash.digest("hex");
+}
+
+/**
+ * The pinned preview authority keeps anchoring the release: the bundled
+ * fundamentals concept skill must still be byte-identical to the immutable
+ * source revision recorded in the catalog.
+ */
+function assertAuthorityParity(bundleSkills, authority) {
+    const bundled = bundleSkills.find(
+        (skill) => skill.name === authority.skill.name,
+    );
+    if (!bundled)
+        throw new Error(
+            `Bundled public skills are missing the pinned authority skill: ${authority.skill.name}`,
+        );
+    const authorityPaths = authority.skill.files
+        .map((file) => file.path)
+        .sort(compareOrdinal);
+    const bundledPaths = bundled.files
+        .map((file) => file.path)
+        .sort(compareOrdinal);
+    if (JSON.stringify(authorityPaths) !== JSON.stringify(bundledPaths))
+        throw new Error(
+            "Bundled fundamentals concept skill differs from the pinned authority",
+        );
+    for (const file of authority.skill.files) {
+        const bundledFile = bundled.files.find(
+            (candidate) => candidate.path === file.path,
+        );
+        if (!bundledFile || !bundledFile.content.equals(file.content))
+            throw new Error(
+                "Bundled fundamentals concept skill differs from the pinned authority",
+            );
+    }
+}
+
+function packageReadme(supported) {
     return `<!--
 Copyright (c) Cratis. All rights reserved.
 Licensed under the MIT license. See LICENSE in this package for full license information.
@@ -62,38 +145,41 @@ Licensed under the MIT license. See LICENSE in this package for full license inf
 
 # @cratis/ai-fundamentals
 
-Passive AI guidance for Cratis Fundamentals concepts and Chronicle event-source identities.
+Passive AI skills for the Cratis ecosystem: the same public skill set the
+Cratis marketplace installs deliver, wrapped as a Pi npm package. Fundamentals,
+Chronicle, Arc, Components, specifications, reviews, and more arrive as
+passive markdown skills — no hooks, no executable code, no MCP server.
 
 ## Install
 
-Install this exact version globally:
+Install globally:
 
 \`\`\`bash
-pi install npm:@cratis/ai-fundamentals@${version}
+pi install npm:@cratis/ai-fundamentals
 \`\`\`
 
 Install it for one trusted project:
 
 \`\`\`bash
-pi install -l npm:@cratis/ai-fundamentals@${version}
+pi install -l npm:@cratis/ai-fundamentals
 \`\`\`
 
 Try it for one Pi run without changing settings:
 
 \`\`\`bash
-pi -e npm:@cratis/ai-fundamentals@${version}
+pi -e npm:@cratis/ai-fundamentals
 \`\`\`
 
 ## Update or remove
 
-Move to another exact version with \`pi install npm:@cratis/ai-fundamentals@<version>\`.
+Update to the latest published release with \`pi install npm:@cratis/ai-fundamentals\`.
 Remove the package with \`pi remove npm:@cratis/ai-fundamentals\`.
 
 ## Status
 
 ${
           supported
-              ? `This is the supported stable \`${version}\` release. Review skill instructions before use.`
+              ? `This is a supported stable release. Review skill instructions before use.`
               : `This \`0.x\` package is an unsupported evaluation release. Packaging, provenance,
 and lifecycle checks do not grant a support claim. Review skill instructions before use.`
       }
@@ -155,6 +241,13 @@ export function materializeFundamentalsPreviewNpmAsset({
         throw new Error(
             "Preview request source does not match immutable authority",
         );
+    const bundleSkills = loadPublicBundleSkills(repositoryRoot);
+    assertAuthorityParity(bundleSkills, authority);
+    const digest = bundleContentDigest(bundleSkills);
+    const sourceCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: repositoryRoot,
+        encoding: "utf8",
+    }).trim();
     const temporaryRoot = mkdtempSync(join(tmpdir(), "cratis-preview-npm-"));
     const stageRoot = join(temporaryRoot, "stage");
     mkdirSync(root, { recursive: false });
@@ -164,15 +257,15 @@ export function materializeFundamentalsPreviewNpmAsset({
             version,
             profileId,
             packageName,
-            description: "Cratis Fundamentals concept guidance",
-            skills: [authority.skill],
+            description: bundleDescription,
+            skills: bundleSkills,
             codexInstallationPolicy: "NOT_AVAILABLE",
             piPrivate: false,
         });
         const piRoot = join(stageRoot, adapters.roots.pi);
         writeFileSync(
             join(piRoot, "README.md"),
-            packageReadme(version, request.supportClaim),
+            packageReadme(request.supportClaim),
             {
             flag: "wx",
         });
@@ -183,7 +276,7 @@ export function materializeFundamentalsPreviewNpmAsset({
         const expectedPackageJson = {
             name: packageName,
             version,
-            description: "Cratis Fundamentals concept guidance",
+            description: bundleDescription,
             private: false,
             license: "MIT",
             repository: {
@@ -221,6 +314,10 @@ export function materializeFundamentalsPreviewNpmAsset({
             version,
             sourceRevision: authority.source.sourceRevision,
             sourceContentDigest: authority.source.contentDigest,
+            sourceCommit,
+            bundledSkillCount: bundleSkills.length,
+            bundledSkillIds: bundleSkills.map((skill) => skill.name),
+            bundleContentDigest: digest,
             requestId: request.id,
             filename,
             size: content.length,

--- a/tooling/smoke-fundamentals-preview-npm.mjs
+++ b/tooling/smoke-fundamentals-preview-npm.mjs
@@ -8,6 +8,7 @@ import {
     mkdirSync,
     mkdtempSync,
     readFileSync,
+    readdirSync,
     rmSync,
     writeFileSync,
 } from "node:fs";
@@ -58,6 +59,20 @@ function assertInstalled(consumerRoot, expectedVersion) {
         )
     )
         throw new Error("Installed preview package discovery failed");
+    // The package is the whole public bundle, not the single concept skill:
+    // every bundled skill directory must carry a SKILL.md.
+    const bundledSkills = readdirSync(join(packageRoot, "skills"), {
+        withFileTypes: true,
+    }).filter((entry) => entry.isDirectory());
+    if (
+        bundledSkills.length < 2 ||
+        bundledSkills.some(
+            (entry) =>
+                !entry.isDirectory() ||
+                !existsSync(join(packageRoot, "skills", entry.name, "SKILL.md")),
+        )
+    )
+        throw new Error("Installed preview package bundle discovery failed");
 }
 
 function install(archivePath, consumerRoot, environment) {

--- a/tooling/specs/fundamentals-preview-npm.spec.mjs
+++ b/tooling/specs/fundamentals-preview-npm.spec.mjs
@@ -2,7 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+    mkdtempSync,
+    readFileSync,
+    readdirSync,
+    rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -94,7 +99,8 @@ test("publishable Fundamentals preview npm asset is deterministic and scriptless
         assert.deepEqual(packageJson, {
             name: "@cratis/ai-fundamentals",
             version: "0.1.0-preview.1",
-            description: "Cratis Fundamentals concept guidance",
+            description:
+                "Cratis AI skills for building event-sourced and CQRS applications",
             private: false,
             license: "MIT",
             repository: {
@@ -111,16 +117,26 @@ test("publishable Fundamentals preview npm asset is deterministic and scriptless
         assert(
             files.has("package/skills/cratis-fundamentals-concept/SKILL.md"),
         );
+        // The package bundles the whole public skills directory — the same
+        // content the marketplace manifests install for other harnesses.
+        assert(
+            files.has("package/skills/cratis-chronicle-projection/SKILL.md"),
+        );
+        const publicSkillDirectories = readdirSync("skills", {
+            withFileTypes: true,
+        })
+            .filter((entry) => entry.isDirectory())
+            .map((entry) => entry.name)
+            .sort();
+        assert.deepEqual(first.bundledSkillIds, publicSkillDirectories);
+        assert.equal(first.bundledSkillCount, publicSkillDirectories.length);
+        assert.match(first.bundleContentDigest, /^[0-9a-f]{64}$/);
         const readme = files.get("package/README.md").toString("utf8");
         assert(
-            readme.includes(
-                "pi install npm:@cratis/ai-fundamentals@0.1.0-preview.1",
-            ),
+            readme.includes("pi install npm:@cratis/ai-fundamentals"),
         );
         assert(
-            readme.includes(
-                "pi install -l npm:@cratis/ai-fundamentals@0.1.0-preview.1",
-            ),
+            readme.includes("pi install -l npm:@cratis/ai-fundamentals"),
         );
         assert(readme.includes("unsupported evaluation release"));
         const checksums = readFileSync(join(firstRoot, "SHA256SUMS"), "utf8");
@@ -229,8 +245,9 @@ test("normal release stages a support-free stable package for latest", () => {
             readFileSync(join(root, "release", manifest.filename)),
         );
         const readme = files.get("package/README.md").toString("utf8");
-        assert(readme.includes("pi install npm:@cratis/ai-fundamentals@1.0.0"));
-        assert(readme.includes("pi -e npm:@cratis/ai-fundamentals@1.0.0"));
+        assert(readme.includes("pi install npm:@cratis/ai-fundamentals"));
+        assert(readme.includes("pi -e npm:@cratis/ai-fundamentals"));
+        assert(readme.includes("supported stable release"));
     });
 });
 


### PR DESCRIPTION
## What

`@cratis/ai-fundamentals` is the only Pi delivery channel, but it carried exactly **one** skill while the marketplace harnesses (Claude Code, Codex, Copilot, Cursor) install the whole public `skills/` directory. This closes that gap: the npm package now bundles **all 49 public skills** — byte-identical to the marketplace content.

## How

- `tooling/package-fundamentals-preview-npm.mjs` bundles every skill under `skills/` (mirroring what the committed marketplace manifests resolve)
- The pinned fundamentals-concept authority still gates the release; the bundled concept skill must stay byte-identical to the immutable catalog source (new parity guard)
- The staged manifest now records `sourceCommit`, `bundledSkillIds`, `bundledSkillCount`, and a `bundleContentDigest` over all bundled bytes
- The generated package README no longer pins versions
- Smoke and specs assert the bundle shape; docs drop the stale `0.x` evaluation / not-the-whole-bundle claims and version pins

## Verification

- Full spec suite: 556 tests, 0 failures
- All generator `--check`s pass; `git diff --check` clean
- Local release staging of `1.1.0`: 49 skills in the tarball, checksums verify, smoke install/discovery/uninstall/rollback passes

Release intent: **minor** — publishes `1.1.0` to npm `latest` via the trusted-publisher workflow.