### PR TITLE
Rename the whole-bundle npm package to @cratis/pi

### DIFF
--- a/.github/workflows/release-passive-previews.yml
+++ b/.github/workflows/release-passive-previews.yml
@@ -81,7 +81,7 @@ jobs:
           test "$(node -p "require('$manifest').distTag")" = "latest"
           test "$(node -p "require('$manifest').supportGranted")" = "true"
           node tooling/smoke-fundamentals-preview-npm.mjs \
-            "$RUNNER_TEMP/fundamentals-npm/cratis-ai-fundamentals-$VERSION.tgz" \
+            "$RUNNER_TEMP/fundamentals-npm/cratis-pi-$VERSION.tgz" \
             "$VERSION"
 
       - name: Publish through npm trusted OIDC
@@ -89,5 +89,5 @@ jobs:
           VERSION: ${{ needs.release.outputs.version }}
         run: |
           set -euo pipefail
-          archive="$RUNNER_TEMP/fundamentals-npm/cratis-ai-fundamentals-$VERSION.tgz"
+          archive="$RUNNER_TEMP/fundamentals-npm/cratis-pi-$VERSION.tgz"
           npm publish --provenance --access public --tag latest "$archive"

--- a/Documentation/adopting-cratis-ai.md
+++ b/Documentation/adopting-cratis-ai.md
@@ -12,7 +12,7 @@ There are two ways to bring Cratis AI into a repository, and they compose:
   `.cratis/ai.json`, pinned to exact versions, with updates arriving as reviewed
   pull requests.
 
-Per-profile packages beyond `@cratis/ai-fundamentals` release as each profile
+Per-profile packages beyond `@cratis/pi` release as each profile
 passes its preview gates; until then, the marketplace plugin delivers the
 skills and the subscription records the intended scope.
 
@@ -97,7 +97,7 @@ package skills directly.
 Install the published package:
 
 ```bash
-pi install -l npm:@cratis/ai-fundamentals
+pi install -l npm:@cratis/pi
 pi list
 ```
 
@@ -161,7 +161,7 @@ Updates arrive as normal pull requests. Review changes to:
 For Pi, update to the latest published release:
 
 ```bash
-pi install -l npm:@cratis/ai-fundamentals
+pi install -l npm:@cratis/pi
 ```
 
 Rollback restores the previous exact version in `.cratis/ai.json` and

--- a/Documentation/ai-distribution-and-subscriptions.md
+++ b/Documentation/ai-distribution-and-subscriptions.md
@@ -60,7 +60,7 @@ requests.
 > is **designed and tool-verified but not published**. No versioned profile
 > package exists yet (`profiles/manifest.json` still says
 > `DESIGNED_RELEASES_NOT_YET_PUBLISHED`); the only published package is
-> `@cratis/ai-fundamentals`, which ships the whole public skills directory so
+> `@cratis/pi`, which ships the whole public skills directory so
 > Pi receives the same content as the marketplace harnesses. Hosts install
 > straight off the `Cratis/AI`
 > default branch through the committed marketplace manifests. The Pi commands

--- a/Documentation/harnesses.md
+++ b/Documentation/harnesses.md
@@ -86,19 +86,20 @@ Cursor-specific fork of the content.
 ## Pi via npm
 
 Pi installs ordinary npm packages. The published package is the stable
-`@cratis/ai-fundamentals` release — the whole public skills directory, the
+`@cratis/pi` release — the whole public skills directory, the
 same content the marketplace installs deliver:
 
 ```bash
 # Project-scoped, installed version recorded in .pi/settings.json
-pi install -l npm:@cratis/ai-fundamentals
+pi install -l npm:@cratis/pi
 
 # User-wide
-pi install npm:@cratis/ai-fundamentals
+pi install npm:@cratis/pi
 ```
 
 Commit `.pi/settings.json` after review; uninstalling removes the package and
-touches nothing else.
+touches nothing else. The package was previously published as
+`@cratis/ai-fundamentals`; that name is deprecated in favor of `@cratis/pi`.
 
 ## Pending: Kiro, Junie, Gemini CLI
 
@@ -120,7 +121,7 @@ in [ecosystem support](./ecosystem-support-architecture-review.md).
 - The versioned per-profile package flow (exact pins arriving as reviewed pull
   requests) is designed but not published; today the marketplace follows the
   `Cratis/AI` default branch, and npm carries the whole-bundle
-  `@cratis/ai-fundamentals`.
+  `@cratis/pi`.
 - Being listed in a vendor's own marketplace UI — findable by search — is a
   separate, still-pending manual submission per host
   ([Cratis/AI#147](https://github.com/Cratis/AI/issues/147)). Adding

--- a/Documentation/index.md
+++ b/Documentation/index.md
@@ -26,7 +26,7 @@ GitHub Copilot: copilot plugin marketplace add Cratis/AI
 Cursor:        resolves the same skills through its committed
                marketplace manifest — no extra install step.
 
-Pi (npm):      pi install -l npm:@cratis/ai-fundamentals
+Pi (npm):      pi install -l npm:@cratis/pi
 ```
 
 The same marketplace also carries a separate maintainer plugin,
@@ -134,7 +134,7 @@ profiles, but they do not describe a supported installation channel:
   packages, reviewed update pull requests, rollback by version pin — is
   designed but not published yet. Until it ships, the marketplace installs
   straight off the default branch, and the only published package is
-  `@cratis/ai-fundamentals` on npm — a stable release carrying the whole
+  `@cratis/pi` on npm — a stable release carrying the whole
   public skill set.
 - **Vendor marketplace listing is pending.** Adding `Cratis/AI` as a
   marketplace works now; being *listed* in a vendor's own marketplace UI — so

--- a/Documentation/maintainer-marketplace-deployment-runbook.md
+++ b/Documentation/maintainer-marketplace-deployment-runbook.md
@@ -267,7 +267,7 @@ and the same with `path: "engineering"`. Hand-authored, no generator.
 - Install evidence under `distribution/evidence/s9-*` was recorded against
   the deleted `distribution` branch and needs re-running per host.
 
-## What actually publishes: `@cratis/ai-fundamentals`
+## What actually publishes: `@cratis/pi`
 
 [`release-passive-previews.yml`](../.github/workflows/release-passive-previews.yml)
 publishes the npm package on merge to `main` under a release-intent label.

--- a/Documentation/profile-reference.md
+++ b/Documentation/profile-reference.md
@@ -169,7 +169,7 @@ request, and floating versions such as `latest` remain forbidden everywhere.
 
 | Profile | Intended package | Current state |
 | --- | --- | --- |
-| `cratis/fundamentals` | `@cratis/ai-fundamentals` | Published npm package; authority for the whole-bundle release |
+| `cratis/fundamentals` | `@cratis/pi` | Published npm package; authority for the whole-bundle release |
 | `cratis/arc/core` | `@cratis/ai-arc` | Preview source candidate; the Arc capability base |
 | `cratis/arc/client-kotlin` | `@cratis/ai-arc-client-kotlin` | Content gap; anchored to [Cratis Arc.Kotlin](https://github.com/cratis/arc.kotlin) until guidance is verified |
 | `cratis/arc/ef-core` | `@cratis/ai-arc-ef-core` | EF Core migration source requires canonical Arc persistence authority |

--- a/Documentation/scenarios/multiple-harnesses.md
+++ b/Documentation/scenarios/multiple-harnesses.md
@@ -14,7 +14,7 @@ separate multi-harness topic — per-harness getting started lives in the
    installed version recorded in `.pi/settings.json`:
 
    ```bash
-   pi install -l npm:@cratis/ai-fundamentals
+   pi install -l npm:@cratis/pi
    ```
 
 3. The repository commits `.cratis/ai.json` as the one neutral record of
@@ -44,7 +44,7 @@ enough.
 ## Status
 
 - Per-host package availability differs today: marketplace hosts follow
-  `Cratis/AI` `main`; npm/Pi carries `@cratis/ai-fundamentals` `1.0.0`;
+  `Cratis/AI` `main`; npm/Pi carries `@cratis/pi` `1.0.0`;
   Kiro, Junie, and Gemini CLI are
   pending (see the harness guide).
 - The versioned flow that would pin every harness to one reviewed release is

--- a/Documentation/scenarios/updates-and-rollback.md
+++ b/Documentation/scenarios/updates-and-rollback.md
@@ -8,11 +8,11 @@ Until the first governed release, marketplace installs follow the
 `Cratis/AI` default branch ([Cratis/AI#264](https://github.com/Cratis/AI/issues/264)).
 Updating means reinstalling or updating the plugin; rolling back means
 uninstalling. There is no version to pin yet, and the published
-`@cratis/ai-fundamentals` npm package — the whole public bundle — is a
+`@cratis/pi` npm package — the whole public bundle — is a
 supported stable release:
 
 ```bash
-pi install -l npm:@cratis/ai-fundamentals   # install / update
+pi install -l npm:@cratis/pi   # install / update
 # rollback: reinstall the previously recorded version
 ```
 
@@ -40,7 +40,7 @@ If you installed the plugin as a solo developer and never pinned anything,
 ## Status
 
 - Versioned releases: **designed, not published**. Install from `main` today.
-- The `@cratis/ai-fundamentals` npm package ships as the supported
+- The `@cratis/pi` npm package ships as the supported
   `1.0.0` release.
 - See [distribution and subscriptions](../ai-distribution-and-subscriptions.md)
   for the complete versioning and authority model.

--- a/Documentation/skill-classification-audit.md
+++ b/Documentation/skill-classification-audit.md
@@ -31,7 +31,7 @@ The eight engineering classifications are:
 
 The engineering source remains public under `engineering/`, but none of these
 skills enters a public product-profile package such as
-`@cratis/ai-fundamentals` or its Agent Plugin artifact.
+`@cratis/pi` or its Agent Plugin artifact.
 
 ## Audit of all current skills
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Free, MIT-licensed AI skills, rules, and agent guidance for building
 event-sourced and CQRS applications with the [Cratis](https://www.cratis.io)
 ecosystem. The only published package today is
-`@cratis/ai-fundamentals` — a stable release carrying the whole public
+`@cratis/pi` — a stable release carrying the whole public
 skills directory.
 
 Cratis AI is the controlled source for shared AI skills, engineering guidance,
@@ -16,7 +16,7 @@ It serves two separate audiences:
 - **Cratis maintainers** receive separate engineering profiles for application,
   framework, client, documentation, Studio, Stagehand, and corpus repositories.
 
-> **Current status:** the supported delivery today is the `@cratis/ai-fundamentals`
+> **Current status:** the supported delivery today is the `@cratis/pi`
 > npm package — the whole public skills directory, giving Pi the same content
 > as the marketplace harnesses — and the marketplace plugins; versioned
 > per-profile packages remain in review. Deterministic
@@ -261,7 +261,7 @@ node tooling/generate-repository-inventory.mjs --check
 
 ## Current release state
 
-`@cratis/ai-fundamentals` uses the normal Cratis release flow: exactly one
+`@cratis/pi` uses the normal Cratis release flow: exactly one
 `major`, `minor`, `patch`, or `no-release` pull-request label, followed by an
 automatic release from protected `main`. Releases publish supported stable
 versions (`1.0.0` and newer) to npm `latest` through trusted OIDC.

--- a/catalog/generated/human-catalog/CATALOG.md
+++ b/catalog/generated/human-catalog/CATALOG.md
@@ -1698,7 +1698,7 @@ Combined AI guidance for developers using Cratis Chronicle, Cratis Specification
 
 - **Profile ID:** `cratis/fundamentals`
 - **Audience:** public
-- **Package:** `@cratis/ai-fundamentals`
+- **Package:** `@cratis/pi`
 - **State:** preview-source-candidate
 - **Installable:** no
 - **Materialization:** candidate-package

--- a/catalog/generated/human-catalog/catalog.json
+++ b/catalog/generated/human-catalog/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractVersion": 1,
   "disclaimer": "Catalog inclusion, evaluation evidence, component modeling, planned projection, bundle generation, or publication does not grant runtime permission, emitted bytes, support, or approval.",
-  "inputDigest": "317b21534de97ee0795fbcb4e801085b86032b1d7de3cdba6210806b8e5a1c96",
+  "inputDigest": "871489abeb25ca6d8257ca762f91957243a66fa65372f377611e23b089caeec9",
   "componentSummary": {
     "disclaimer": "Modeled or planned components and projections are catalog metadata only; they are not emitted, supported, installable, published, promoted, or runtime eligible.",
     "total": 193,
@@ -1788,7 +1788,7 @@
       "description": "Strongly typed Cratis Fundamentals concepts and Chronicle event-source identities for C# projects.",
       "intendedFor": "Developers who use Cratis Fundamentals and Cratis Chronicle.",
       "audience": "public",
-      "packageName": "@cratis/ai-fundamentals",
+      "packageName": "@cratis/pi",
       "state": "preview-source-candidate",
       "installable": false,
       "materialization": "candidate-package",

--- a/catalog/generated/human-catalog/manifest.json
+++ b/catalog/generated/human-catalog/manifest.json
@@ -1,17 +1,17 @@
 {
   "schemaVersion": 2,
   "contractVersion": 1,
-  "inputDigest": "317b21534de97ee0795fbcb4e801085b86032b1d7de3cdba6210806b8e5a1c96",
+  "inputDigest": "871489abeb25ca6d8257ca762f91957243a66fa65372f377611e23b089caeec9",
   "files": [
     {
       "path": "CATALOG.md",
-      "size": 188571,
-      "sha256": "37494291ef57d7f47d6ea4d74a29c48b41f373c9759f77f36c702f8e4893b675"
+      "size": 188558,
+      "sha256": "6f060caa394fe301a91bebc70c0fc7ab0d45e12fee63b86508a47ba3dd9c18ae"
     },
     {
       "path": "catalog.json",
-      "size": 246278,
-      "sha256": "1e5bafbf35450cc4f3956f9a2bd99dbd8bae51ac05c0ef35fe91328e6a5e15ad"
+      "size": 246265,
+      "sha256": "f1d27a1abb1172477b7c009e0d42024e069d7475fc96d9b813f1ffd5565842ba"
     }
   ]
 }

--- a/catalog/v2/repository-inventory.json
+++ b/catalog/v2/repository-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "baseRevision": "b795d5307e20f7f7458a67708b4f26975e223796",
-  "indexDigest": "7e70b3e3a4f5c27432a6b8e490c275aef580d0c11845bf241047f40e189a6875",
+  "indexDigest": "99fe14a1c74c072e6f30a381333c197d77feb03bbabe2d95822481df4c877d87",
   "indexDigestExcludedPaths": [
     "catalog/v2/repository-inventory.json"
   ],

--- a/distribution/assurance-lanes.json
+++ b/distribution/assurance-lanes.json
@@ -59,7 +59,7 @@
   ],
   "selectedPreview": {
     "profileId": "cratis/fundamentals",
-    "packageName": "@cratis/ai-fundamentals",
+    "packageName": "@cratis/pi",
     "requiredStatusContext": "release-intent / verify",
     "protectedEnvironment": "npm-stage"
   },

--- a/distribution/assurance-lanes.schema.json
+++ b/distribution/assurance-lanes.schema.json
@@ -36,7 +36,7 @@
       "required": ["profileId", "packageName", "requiredStatusContext", "protectedEnvironment"],
       "properties": {
         "profileId": { "const": "cratis/fundamentals" },
-        "packageName": { "const": "@cratis/ai-fundamentals" },
+        "packageName": { "const": "@cratis/pi" },
         "requiredStatusContext": { "const": "release-intent / verify" },
         "protectedEnvironment": { "const": "npm-stage" }
       }

--- a/distribution/npm-stage-contract.json
+++ b/distribution/npm-stage-contract.json
@@ -4,7 +4,7 @@
   "trackingIssue": "https://github.com/Cratis/Workflows/issues/70",
   "package": {
     "fixtureName": "@cratis/ai",
-    "productionName": "@cratis/ai-fundamentals",
+    "productionName": "@cratis/pi",
     "fixturePrivate": true,
     "lifecycleScriptsAllowed": false,
     "dependenciesAllowed": false,

--- a/distribution/preview-readiness.json
+++ b/distribution/preview-readiness.json
@@ -5,7 +5,7 @@
   "lane": "passive-preview",
   "assuranceMode": "basic",
   "profileId": "cratis/fundamentals",
-  "packageName": "@cratis/ai-fundamentals",
+  "packageName": "@cratis/pi",
   "targetIds": [
     "cratis-fundamentals-concept"
   ],

--- a/distribution/preview-readiness.schema.json
+++ b/distribution/preview-readiness.schema.json
@@ -12,7 +12,7 @@
     "lane": { "const": "passive-preview" },
     "assuranceMode": { "const": "basic" },
     "profileId": { "const": "cratis/fundamentals" },
-    "packageName": { "const": "@cratis/ai-fundamentals" },
+    "packageName": { "const": "@cratis/pi" },
     "targetIds": { "type": "array", "minItems": 1, "maxItems": 1, "uniqueItems": true, "items": { "const": "cratis-fundamentals-concept" } },
     "staticCandidateReady": { "const": true },
     "blockers": {

--- a/distribution/preview-requests.json
+++ b/distribution/preview-requests.json
@@ -1,1 +1,30 @@
-{"schemaVersion":1,"defaultPolicy":"deny","requests":[{"id":"cratis-fundamentals-0-1-0-preview-1","state":"preview-on-merge","profileId":"cratis/fundamentals","packageName":"@cratis/ai-fundamentals","version":"0.1.0-preview.1","sourceRevision":"b53caa555b9a3f05ba1462b86202fe3ccb8a9470","sourceContentDigest":"9e537c48a95c414709008c69ebfb616354d60992578ddd9da3d7dc7308c42caa","assuranceMode":"basic","supportClaim":false,"releaseNotes":"First unsupported public preview of passive Cratis Fundamentals concept and Chronicle event-source identity guidance."}]}
+{
+  "schemaVersion": 1,
+  "defaultPolicy": "deny",
+  "requests": [
+    {
+      "id": "cratis-fundamentals-0-1-0-preview-1",
+      "state": "preview-on-merge",
+      "profileId": "cratis/fundamentals",
+      "packageName": "@cratis/ai-fundamentals",
+      "version": "0.1.0-preview.1",
+      "sourceRevision": "b53caa555b9a3f05ba1462b86202fe3ccb8a9470",
+      "sourceContentDigest": "9e537c48a95c414709008c69ebfb616354d60992578ddd9da3d7dc7308c42caa",
+      "assuranceMode": "basic",
+      "supportClaim": false,
+      "releaseNotes": "First unsupported public preview of passive Cratis Fundamentals concept and Chronicle event-source identity guidance."
+    },
+    {
+      "id": "cratis-fundamentals-0-1-0-preview-2",
+      "state": "preview-on-merge",
+      "profileId": "cratis/fundamentals",
+      "packageName": "@cratis/pi",
+      "version": "0.1.0-preview.2",
+      "sourceRevision": "b53caa555b9a3f05ba1462b86202fe3ccb8a9470",
+      "sourceContentDigest": "9e537c48a95c414709008c69ebfb616354d60992578ddd9da3d7dc7308c42caa",
+      "assuranceMode": "basic",
+      "supportClaim": false,
+      "releaseNotes": "Rename the published whole-bundle package to @cratis/pi; the previous name @cratis/ai-fundamentals is deprecated."
+    }
+  ]
+}

--- a/distribution/preview-requests.schema.json
+++ b/distribution/preview-requests.schema.json
@@ -19,7 +19,7 @@
           "id": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" },
           "state": { "const": "preview-on-merge" },
           "profileId": { "const": "cratis/fundamentals" },
-          "packageName": { "const": "@cratis/ai-fundamentals" },
+          "packageName": { "enum": ["@cratis/ai-fundamentals", "@cratis/pi"] },
           "version": { "type": "string", "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$" },
           "sourceRevision": { "type": "string", "pattern": "^[a-f0-9]{40}$" },
           "sourceContentDigest": { "type": "string", "pattern": "^[a-f0-9]{64}$" },

--- a/distribution/profile-catalog.json
+++ b/distribution/profile-catalog.json
@@ -993,7 +993,7 @@
     },
     {
       "id": "cratis/fundamentals",
-      "packageName": "@cratis/ai-fundamentals",
+      "packageName": "@cratis/pi",
       "version": "0.0.0",
       "products": [
         "fundamentals",
@@ -1006,7 +1006,7 @@
       "availableTargets": [
         "cratis-fundamentals-concept"
       ],
-      "gapSummary": "The first candidate combines Fundamentals value concepts with Chronicle stream identities at exact verified versions. Convention-based implementation discovery now ships as cratis/fundamentals/type-discovery rather than here, because this profile is the pinned passive-preview package and its authority requires exactly one target; serialization and the remaining Fundamentals primitives are gaps."
+      "gapSummary": "The first candidate combines Fundamentals value concepts with Chronicle stream identities at exact verified versions. Convention-based implementation discovery now ships as cratis/fundamentals/type-discovery rather than here, because this profile is the pinned passive-preview package and its authority requires exactly one target; serialization and the remaining Fundamentals primitives are gaps. Since the whole-bundle release the profile's package also delivers every public skill to Pi; the name changed from @cratis/ai-fundamentals to @cratis/pi to match."
     },
     {
       "id": "cratis/fundamentals/type-discovery",

--- a/distribution/remote-repository-state.json
+++ b/distribution/remote-repository-state.json
@@ -22,7 +22,7 @@
       "appliedOn": "2026-09-06",
       "note": "The distribution branch and the dist/* tag ruleset that had been created on 2026-09-06 were deleted the same day by the repository admin through the GitHub API, before any release ran against them. Neither exists now: GET /repos/Cratis/AI/branches lists no distribution branch and GET /repos/Cratis/AI/rulesets is empty.",
       "protectedEnvironmentsStillLive": {
-        "npm-stage": "Used by release-passive-previews.yml, the real npm trusted publish for @cratis/ai-fundamentals. Branch policy only; no required reviewer, matching npm-stage-contract.json's environmentApprovalRequired: false.",
+        "npm-stage": "Used by release-passive-previews.yml, the real npm trusted publish for @cratis/pi. Branch policy only; no required reviewer, matching npm-stage-contract.json's environmentApprovalRequired: false.",
         "distribution-canary": "Still configured with woksin as required reviewer, but no remaining workflow declares it. Whether to delete it is a separate decision."
       }
     },

--- a/profiles/public/cratis/fundamentals.json
+++ b/profiles/public/cratis/fundamentals.json
@@ -1,6 +1,6 @@
 {
     "id": "cratis/fundamentals",
-    "packageName": "@cratis/ai-fundamentals",
+    "packageName": "@cratis/pi",
     "version": "0.0.0",
     "products": [
         "fundamentals",
@@ -13,5 +13,5 @@
     "availableTargets": [
         "cratis-fundamentals-concept"
     ],
-    "gapSummary": "The first candidate combines Fundamentals value concepts with Chronicle stream identities at exact verified versions. Convention-based implementation discovery now ships as cratis/fundamentals/type-discovery rather than here, because this profile is the pinned passive-preview package and its authority requires exactly one target; serialization and the remaining Fundamentals primitives are gaps."
+    "gapSummary": "The first candidate combines Fundamentals value concepts with Chronicle stream identities at exact verified versions. Convention-based implementation discovery now ships as cratis/fundamentals/type-discovery rather than here, because this profile is the pinned passive-preview package and its authority requires exactly one target; serialization and the remaining Fundamentals primitives are gaps. Since the whole-bundle release the profile's package also delivers every public skill to Pi; the name changed from @cratis/ai-fundamentals to @cratis/pi to match."
 }

--- a/tooling/benchmarks/release-generation.mjs
+++ b/tooling/benchmarks/release-generation.mjs
@@ -41,7 +41,7 @@ export function benchmarkReleaseGeneration({ concurrency = 1 } = {}) {
             outputRoot,
             version: "0.0.0-benchmark",
             profileId: "cratis/fundamentals",
-            packageName: "@cratis/ai-fundamentals",
+            packageName: "@cratis/pi",
             description: "Deterministic release generation benchmark",
             skills: [
                 { name: "cratis-fundamentals-concept", files: sourceFiles },

--- a/tooling/package-fundamentals-preview-assets.mjs
+++ b/tooling/package-fundamentals-preview-assets.mjs
@@ -31,7 +31,7 @@ const profileId = "cratis/fundamentals";
 const targetId = "cratis-fundamentals-concept";
 const sourceId = "add-concept";
 const artifactId = "cratis-fundamentals-concept-preview";
-const packageName = "@cratis/ai-fundamentals";
+const packageName = "@cratis/pi";
 const requiredSourceRevision = "b53caa555b9a3f05ba1462b86202fe3ccb8a9470";
 const requiredSourceContentDigest =
     "9e537c48a95c414709008c69ebfb616354d60992578ddd9da3d7dc7308c42caa";

--- a/tooling/package-fundamentals-preview-npm.mjs
+++ b/tooling/package-fundamentals-preview-npm.mjs
@@ -31,9 +31,9 @@ const defaultRepositoryRoot = resolve(
     fileURLToPath(new URL("..", import.meta.url)),
 );
 const profileId = "cratis/fundamentals";
-const packageName = "@cratis/ai-fundamentals";
+const packageName = "@cratis/pi";
 const bundleDescription =
-    "Cratis AI skills for building event-sourced and CQRS applications";
+    "The whole public Cratis AI skill set for building event-sourced and CQRS applications, delivered as a passive Pi package";
 const publicSkillsRoot = "skills";
 
 function sha256(content) {
@@ -143,37 +143,40 @@ Copyright (c) Cratis. All rights reserved.
 Licensed under the MIT license. See LICENSE in this package for full license information.
 -->
 
-# @cratis/ai-fundamentals
+# @cratis/pi
 
-Passive AI skills for the Cratis ecosystem: the same public skill set the
+Passive AI skills for the Cratis ecosystem: the whole public skill set the
 Cratis marketplace installs deliver, wrapped as a Pi npm package. Fundamentals,
 Chronicle, Arc, Components, specifications, reviews, and more arrive as
 passive markdown skills — no hooks, no executable code, no MCP server.
+
+This package was previously published as \`@cratis/ai-fundamentals\`; that name
+is deprecated in favor of \`@cratis/pi\`.
 
 ## Install
 
 Install globally:
 
 \`\`\`bash
-pi install npm:@cratis/ai-fundamentals
+pi install npm:@cratis/pi
 \`\`\`
 
 Install it for one trusted project:
 
 \`\`\`bash
-pi install -l npm:@cratis/ai-fundamentals
+pi install -l npm:@cratis/pi
 \`\`\`
 
 Try it for one Pi run without changing settings:
 
 \`\`\`bash
-pi -e npm:@cratis/ai-fundamentals
+pi -e npm:@cratis/pi
 \`\`\`
 
 ## Update or remove
 
-Update to the latest published release with \`pi install npm:@cratis/ai-fundamentals\`.
-Remove the package with \`pi remove npm:@cratis/ai-fundamentals\`.
+Update to the latest published release with \`pi install npm:@cratis/pi\`.
+Remove the package with \`pi remove npm:@cratis/pi\`.
 
 ## Status
 
@@ -292,7 +295,7 @@ export function materializeFundamentalsPreviewNpmAsset({
         };
         if (!isDeepStrictEqual(packageJson, expectedPackageJson))
             throw new Error("Generated npm package metadata is unsafe");
-        const filename = `cratis-ai-fundamentals-${version}.tgz`;
+        const filename = `cratis-pi-${version}.tgz`;
         const content = createTarGzip(piRoot, paths, "package");
         const archive = readTarGzip(content);
         for (const path of paths) {

--- a/tooling/profile-subscription-validation.mjs
+++ b/tooling/profile-subscription-validation.mjs
@@ -175,7 +175,14 @@ export function validateProfileSubscriptions(
             (profile.availableTargets?.length ?? 0) === 0
         )
             errors.push(`${profile.id}: approved profile has no targets`);
-        if (!/^@cratis\/ai-[a-z0-9]+(?:-[a-z0-9]+)*$/.test(profile.packageName))
+        // Profile packages share the `@cratis/ai-*` family. `@cratis/pi` is the
+        // one carve-out: the whole-bundle Pi delivery package (formerly
+        // `@cratis/ai-fundamentals`).
+        if (
+            !/^@cratis\/(?:ai-[a-z0-9]+(?:-[a-z0-9]+)*|pi)$/.test(
+                profile.packageName,
+            )
+        )
             errors.push(`${profile.id}: invalid package name`);
         // `cratis` is the one bare id: the root of the namespace, and the
         // maximal public bundle. Everything else stays namespaced under

--- a/tooling/smoke-fundamentals-preview-npm.mjs
+++ b/tooling/smoke-fundamentals-preview-npm.mjs
@@ -16,7 +16,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const packageName = "@cratis/ai-fundamentals";
+const packageName = "@cratis/pi";
 
 function npm(arguments_, cwd, environment) {
     return execFileSync("npm", arguments_, {
@@ -28,7 +28,7 @@ function npm(arguments_, cwd, environment) {
 }
 
 function installedPackageRoot(consumerRoot) {
-    return join(consumerRoot, "node_modules", "@cratis", "ai-fundamentals");
+    return join(consumerRoot, "node_modules", "@cratis", "pi");
 }
 
 function assertInstalled(consumerRoot, expectedVersion) {

--- a/tooling/specs/approved-profile-release.spec.mjs
+++ b/tooling/specs/approved-profile-release.spec.mjs
@@ -149,7 +149,7 @@ test("approved plan requires every authority security and evidence gate", () => 
     assert.equal(plan.state, "READY_FOR_BOT_MATERIALIZATION");
     assert.deepEqual(plan.blockers, []);
     assert.deepEqual(plan.targetIds, ["cratis-fundamentals-concept"]);
-    assert.equal(plan.packageName, "@cratis/ai-fundamentals");
+    assert.equal(plan.packageName, "@cratis/pi");
     assert.equal(plan.displayName, "Cratis Fundamentals");
     assert.equal(
         plan.description,
@@ -175,7 +175,7 @@ test("approved plan requires every authority security and evidence gate", () => 
     const instructions = buildReleaseInstructions(plan, passiveHarnesses);
     assert.match(
         instructions,
-        /pi install -l npm:@cratis\/ai-fundamentals@1\.0\.0-preview\.1\+build\.7/,
+        /pi install -l npm:@cratis\/pi@1\.0\.0-preview\.1\+build\.7/,
     );
     assert.match(instructions, /sha256sum -c SHA256SUMS/);
     assert.match(instructions, /support-matrix\.json/);

--- a/tooling/specs/assurance-lanes.spec.mjs
+++ b/tooling/specs/assurance-lanes.spec.mjs
@@ -99,7 +99,7 @@ test("basic owner setup can enable normal 0.x releases without granting support"
         const lanes = readJson(root, "distribution/assurance-lanes.json");
         writeJson(root, "distribution/assurance-lanes.json", lanes);
         const npm = readJson(root, "distribution/npm-stage-contract.json");
-        npm.package.productionName = "@cratis/ai-fundamentals";
+        npm.package.productionName = "@cratis/pi";
         npm.package.publicOwnershipConfirmed = true;
         npm.package.latestTagSafe = true;
         npm.workflow.trustedPublisherConfigured = true;

--- a/tooling/specs/distribution-npm-stage.spec.mjs
+++ b/tooling/specs/distribution-npm-stage.spec.mjs
@@ -25,7 +25,7 @@ const workflow = readFileSync(
 test("npm stage contract enables normal support-free stable releases", () => {
     assert.equal(contract.state, "NORMAL_STABLE_RELEASES_ENABLED");
     assert.equal(contract.package.fixtureName, "@cratis/ai");
-    assert.equal(contract.package.productionName, "@cratis/ai-fundamentals");
+    assert.equal(contract.package.productionName, "@cratis/pi");
     assert.equal(contract.package.fixturePrivate, true);
     assert.equal(contract.package.publicOwnershipConfirmed, true);
     assert.equal(contract.package.bootstrapVersion, "0.0.0-bootstrap.0");

--- a/tooling/specs/fundamentals-preview-assets.spec.mjs
+++ b/tooling/specs/fundamentals-preview-assets.spec.mjs
@@ -45,7 +45,7 @@ function packageVersion(consumerRoot) {
         readFileSync(
             join(
                 consumerRoot,
-                "node_modules/@cratis/ai-fundamentals/package.json",
+                "node_modules/@cratis/pi/package.json",
             ),
             "utf8",
         ),
@@ -279,7 +279,7 @@ test("Fundamentals preview assets are deterministic and non-publishable", () => 
         const piPackage = JSON.parse(
             piFiles.get("package/package.json").toString("utf8"),
         );
-        assert.equal(piPackage.name, "@cratis/ai-fundamentals");
+        assert.equal(piPackage.name, "@cratis/pi");
         assert.equal(piPackage.private, true);
         assert.equal(piPackage.scripts, undefined);
         assert.equal(piPackage.dependencies, undefined);
@@ -392,7 +392,7 @@ test("Pi npm preview asset updates rolls back uninstalls and preserves context",
             "npm",
             [
                 "uninstall",
-                "@cratis/ai-fundamentals",
+                "@cratis/pi",
                 "--ignore-scripts",
                 "--no-audit",
                 "--no-fund",
@@ -400,7 +400,7 @@ test("Pi npm preview asset updates rolls back uninstalls and preserves context",
             { cwd: consumer, stdio: "pipe" },
         );
         assert.equal(
-            existsSync(join(consumer, "node_modules/@cratis/ai-fundamentals")),
+            existsSync(join(consumer, "node_modules/@cratis/pi")),
             false,
         );
         for (const [path, content] of Object.entries(context))

--- a/tooling/specs/fundamentals-preview-npm.spec.mjs
+++ b/tooling/specs/fundamentals-preview-npm.spec.mjs
@@ -37,7 +37,7 @@ const request = Object.freeze({
     id: "cratis-fundamentals-0-1-0-preview-1",
     state: "preview-on-merge",
     profileId: "cratis/fundamentals",
-    packageName: "@cratis/ai-fundamentals",
+    packageName: "@cratis/pi",
     version: "0.1.0-preview.1",
     sourceRevision: "b53caa555b9a3f05ba1462b86202fe3ccb8a9470",
     sourceContentDigest:
@@ -51,7 +51,7 @@ const ready = Object.freeze({
     state: "READY_FOR_PREVIEW_REQUEST",
     assuranceMode: "basic",
     profileId: "cratis/fundamentals",
-    packageName: "@cratis/ai-fundamentals",
+    packageName: "@cratis/pi",
     previewRequestEligible: true,
     supportGranted: true,
 });
@@ -80,7 +80,7 @@ test("publishable Fundamentals preview npm asset is deterministic and scriptless
         });
         assert.deepEqual(second, first);
         assert.equal(first.state, "PASSIVE_NPM_STAGED");
-        assert.equal(first.packageName, "@cratis/ai-fundamentals");
+        assert.equal(first.packageName, "@cratis/pi");
         assert.equal(first.distTag, "preview");
         assert.equal(first.publicationEligible, true);
         assert.equal(first.previewPublicationEligible, true);
@@ -97,10 +97,10 @@ test("publishable Fundamentals preview npm asset is deterministic and scriptless
             files.get("package/package.json").toString("utf8"),
         );
         assert.deepEqual(packageJson, {
-            name: "@cratis/ai-fundamentals",
+            name: "@cratis/pi",
             version: "0.1.0-preview.1",
             description:
-                "Cratis AI skills for building event-sourced and CQRS applications",
+                "The whole public Cratis AI skill set for building event-sourced and CQRS applications, delivered as a passive Pi package",
             private: false,
             license: "MIT",
             repository: {
@@ -133,10 +133,10 @@ test("publishable Fundamentals preview npm asset is deterministic and scriptless
         assert.match(first.bundleContentDigest, /^[0-9a-f]{64}$/);
         const readme = files.get("package/README.md").toString("utf8");
         assert(
-            readme.includes("pi install npm:@cratis/ai-fundamentals"),
+            readme.includes("pi install npm:@cratis/pi"),
         );
         assert(
-            readme.includes("pi install -l npm:@cratis/ai-fundamentals"),
+            readme.includes("pi install -l npm:@cratis/pi"),
         );
         assert(readme.includes("unsupported evaluation release"));
         const checksums = readFileSync(join(firstRoot, "SHA256SUMS"), "utf8");
@@ -245,8 +245,8 @@ test("normal release stages a support-free stable package for latest", () => {
             readFileSync(join(root, "release", manifest.filename)),
         );
         const readme = files.get("package/README.md").toString("utf8");
-        assert(readme.includes("pi install npm:@cratis/ai-fundamentals"));
-        assert(readme.includes("pi -e npm:@cratis/ai-fundamentals"));
+        assert(readme.includes("pi install npm:@cratis/pi"));
+        assert(readme.includes("pi -e npm:@cratis/pi"));
         assert(readme.includes("supported stable release"));
     });
 });

--- a/tooling/specs/preview-request-validation.spec.mjs
+++ b/tooling/specs/preview-request-validation.spec.mjs
@@ -32,7 +32,7 @@ test("preview request schema rejects support claims unknown fields and multiple 
         id: "public-fundamentals-0-1-0-preview-1",
         state: "preview-on-merge",
         profileId: "public-fundamentals",
-        packageName: "@cratis/ai-fundamentals",
+        packageName: "@cratis/pi",
         version: "0.1.0-preview.1",
         sourceRevision: "a".repeat(40),
         sourceContentDigest: "b".repeat(64),

--- a/tooling/specs/profile-presentation.spec.mjs
+++ b/tooling/specs/profile-presentation.spec.mjs
@@ -12,7 +12,7 @@ import {
 
 const fundamentals = {
     id: "cratis/fundamentals",
-    packageName: "@cratis/ai-fundamentals",
+    packageName: "@cratis/pi",
     products: ["fundamentals", "chronicle"],
     languages: ["csharp"],
     state: "preview-source-candidate",

--- a/tooling/specs/s10-release-gate.spec.mjs
+++ b/tooling/specs/s10-release-gate.spec.mjs
@@ -170,7 +170,7 @@ test("production lifecycle requires complete non-synthetic A-to-B-to-A evidence"
         sourceRevision: "c".repeat(40),
         artifactId: "release-artifact",
         artifactDigest: digestA,
-        packageName: "@cratis/ai-fundamentals",
+        packageName: "@cratis/pi",
         versionA: "1.0.0",
         versionB: "1.1.0",
         profileId: "public-fundamentals",


### PR DESCRIPTION
## What

Companion decision to #299: the published package now carries the whole public skill set, so the `@cratis/ai-fundamentals` name no longer describes it. This renames it to **`@cratis/pi`** — the Pi delivery vehicle for the public Cratis AI bundle — publishing as `1.2.0` (version lineage continues from `1.1.0`).

## Changes

- Package name, tarball filename (`cratis-pi-<version>.tgz`), and a fuller description: *"The whole public Cratis AI skill set for building event-sourced and CQRS applications, delivered as a passive Pi package"*
- Generated README notes the rename; `@cratis/ai-fundamentals` is deprecated with a pointer (manual `npm deprecate` after this publishes)
- Package-name convention gains a documented `@cratis/pi` carve-out beside the `@cratis/ai-*` profile family (`profile-subscription-validation`)
- Preview request history **appends** the rename record (`0.1.0-preview.2`) instead of mutating the append-only ledger; schema accepts both names
- Workflows, npm-stage contract, readiness/lanes/schemas, specs, generated catalogs, and all documentation follow

## Verification

- Full suite: 556 tests, 0 failures; all generator `--check`s pass
- Local release staging of `1.2.0`: correct name/description/README, 49 skills, checksums verify

## Prerequisite

npm trusted-publisher registration for `@cratis/pi` (repo `Cratis/AI`, workflow `release-passive-previews.yml`, environment `npm-stage`) must exist before the publish job can release `1.2.0`.

Release intent: **minor**.