### PR TITLE
Fix Pi package provenance metadata

### DIFF
--- a/Source/Pi.Plugin/package.json
+++ b/Source/Pi.Plugin/package.json
@@ -10,6 +10,13 @@
     "postpack": "node prepare-package.mjs --clean"
   },
   "keywords": ["cratis", "pi-package", "ai", "skills"],
+  "homepage": "https://github.com/Cratis/AI",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Cratis/AI",
+    "directory": "Source/Pi.Plugin"
+  },
+  "bugs": "https://github.com/Cratis/AI/issues",
   "license": "MIT",
   "devDependencies": {
     "typescript": "^5.8.0"

--- a/Source/Verification/verify.ts
+++ b/Source/Verification/verify.ts
@@ -77,6 +77,7 @@ for (const extension of requiredPiExtensions) {
     if (!await exists(join(corpus, 'harnesses', 'pi', 'extensions', extension, 'index.ts'))) failures.push(`Pi extension '${extension}' is missing.`);
 }
 const piPackage = JSON.parse(await readFile(join(root, 'Source', 'Pi.Plugin', 'package.json'), 'utf8'));
+if (piPackage.repository?.url !== 'https://github.com/Cratis/AI') failures.push('@cratis/pi repository.url must match its GitHub provenance repository.');
 const packagedExtensions: string[] = piPackage.pi?.extensions ?? [];
 for (const extension of [
     './src/index.ts',


### PR DESCRIPTION
## Fixed
- Declare the canonical Cratis/AI repository URL and package directory in `@cratis/pi`.
- Verify that package metadata remains compatible with npm trusted-publishing provenance.

## Verification
- Pi package and verification TypeScript checks pass.
- Corpus verification and npm pack dry run pass.
- `actionlint` and `git diff --check` pass.

This fixes the npm E422 that blocked publishing `@cratis/pi` 2.0.0.