### PR TITLE
Load general Pi rules with project instructions

### DIFF
--- a/.cratis/ai/harnesses/pi/extensions/cratis-rules/index.ts
+++ b/.cratis/ai/harnesses/pi/extensions/cratis-rules/index.ts
@@ -8,18 +8,18 @@ import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 
 const corpusRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
 
-/** Loads task-specific rules from the managed corpus. AGENTS.md already supplies general.md. */
+/** Loads every rule from the managed corpus, including general guidance when AGENTS.md is project-owned. */
 export function managedRules(cwd: string): string {
     const managedRoot = join(cwd, '.cratis', 'ai', 'rules');
     const rulesRoot = existsSync(managedRoot) ? managedRoot : join(corpusRoot, 'rules');
     return readdirSync(rulesRoot, { recursive: true, encoding: 'utf8' })
-        .filter((entry): entry is string => entry.endsWith('.md') && entry !== 'general.md')
+        .filter((entry): entry is string => entry.endsWith('.md'))
         .sort()
         .map(entry => readFileSync(join(rulesRoot, entry), 'utf8'))
         .join('\n\n');
 }
 
-/** Adds every task-specific managed Cratis rule to Pi without requiring the @cratis/pi package. */
+/** Adds every managed Cratis rule to Pi without requiring the @cratis/pi package. */
 export default function (pi: ExtensionAPI): void {
     pi.on('before_agent_start', (event, context) => ({
         systemPrompt: `${event.systemPrompt}\n\n${managedRules(context.cwd)}`,

--- a/Source/Verification/pi-plugin.spec.ts
+++ b/Source/Verification/pi-plugin.spec.ts
@@ -36,10 +36,10 @@ test('Pi exposes every catalog skill when configuration is absent', () => {
     }
 });
 
-test('managed Pi loads every task-specific rule from the canonical corpus', () => {
+test('managed Pi loads general and task-specific rules from the canonical corpus', () => {
     const rules = managedRules(repositoryRoot);
+    assert.match(rules, /# Cratis — Project Instructions/);
     assert.match(rules, /# C# Conventions/);
-    assert.doesNotMatch(rules, /# Cratis — Project Instructions/);
 });
 
 test('the Pi package yields to a managed CLI installation', () => {


### PR DESCRIPTION
## Fixed
- Load `general.md` through the managed Pi rules extension as well as task-specific rules.
- Keep managed Cratis guidance active when a repository preserves its own `AGENTS.md` and project instructions.

## Verification
- Pi package and verification TypeScript checks pass.
- Pi behavior specifications verify both general and task-specific managed rules.
- Corpus verification passes.