### PR TITLE
Filter Pi rules by profile and language

### DIFF
--- a/Source/Pi.Plugin/src/index.ts
+++ b/Source/Pi.Plugin/src/index.ts
@@ -59,12 +59,47 @@ function isManagedInstallation(cwd: string): boolean {
     return existsSync(join(cwd, '.cratis', 'ai.manifest.json'));
 }
 
-function rules(): string {
+function frontmatterValue(content: string, name: string): string | undefined {
+    if (!content.startsWith('---\n')) return undefined;
+    const end = content.indexOf('\n---\n', 4);
+    if (end < 0) return undefined;
+    const prefix = `${name}:`;
+    const line = content.slice(4, end).split('\n').find(candidate => candidate.startsWith(prefix));
+    return line?.slice(prefix.length).trim().replace(/^"|"$/g, '');
+}
+
+function ruleMatchesConfiguration(path: string, content: string, configuration: AiConfiguration): boolean {
+    const selectedProfiles = configuration.profiles ?? [];
+    const profile = frontmatterValue(content, 'profile');
+    const hasApplicationProfile = selectedProfiles.some(candidate => candidate.startsWith('cratis/application'));
+    const hasEngineeringProfile = selectedProfiles.some(candidate => candidate.startsWith('cratis/engineering'));
+    if (profile === 'application' && !hasApplicationProfile) return false;
+    if (profile === 'framework' && !hasEngineeringProfile) return false;
+
+    const languages = configuration.languages ?? [];
+    if (languages.length === 0) return true;
+    const applyTo = frontmatterValue(content, 'applyTo') ?? '';
+    const needsCSharp = applyTo.includes('.cs');
+    const needsTypeScript = applyTo.includes('.ts') || path.endsWith('/rtk.md');
+    const needsDocumentation = applyTo.includes('md');
+    if (!needsCSharp && !needsTypeScript && !needsDocumentation) return true;
+    return (needsCSharp && languages.includes('csharp')) ||
+        (needsTypeScript && languages.includes('typescript')) ||
+        (needsDocumentation && selectedProfiles.includes('cratis/documentation'));
+}
+
+function rules(cwd: string): string {
     const root = join(corpusRoot, 'rules');
+    const configurationPath = join(cwd, '.cratis', 'ai.json');
+    const configuration = existsSync(configurationPath)
+        ? JSON.parse(readFileSync(configurationPath, 'utf8')) as AiConfiguration
+        : undefined;
     return readdirSync(root, { recursive: true, encoding: 'utf8' })
         .filter((entry): entry is string => entry.endsWith('.md'))
         .sort()
-        .map(entry => readFileSync(join(root, entry), 'utf8'))
+        .map(entry => ({ path: join(root, entry), content: readFileSync(join(root, entry), 'utf8') }))
+        .filter(rule => !configuration || ruleMatchesConfiguration(rule.path, rule.content, configuration))
+        .map(rule => rule.content)
         .join('\n\n');
 }
 
@@ -76,5 +111,5 @@ export default function (pi: ExtensionAPI): void {
     }));
     pi.on('before_agent_start', (event, context) => isManagedInstallation(context.cwd)
         ? undefined
-        : ({ systemPrompt: `${event.systemPrompt}\n\n${rules()}` }));
+        : ({ systemPrompt: `${event.systemPrompt}\n\n${rules(context.cwd)}` }));
 }

--- a/Source/Verification/pi-plugin.spec.ts
+++ b/Source/Verification/pi-plugin.spec.ts
@@ -57,6 +57,26 @@ test('the Pi package yields to a managed CLI installation', () => {
     }
 });
 
+test('the Pi package filters rules for framework CSharp documentation repositories', () => {
+    const project = mkdtempSync(join(tmpdir(), 'cratis-pi-'));
+    try {
+        mkdirSync(join(project, '.cratis'));
+        writeFileSync(join(project, '.cratis', 'ai.json'), JSON.stringify({
+            profiles: ['cratis/engineering/csharp', 'cratis/documentation'],
+            languages: ['csharp'],
+        }));
+        const handlers = pluginHandlers();
+        const result = handlers.get('before_agent_start')?.({ cwd: project, systemPrompt: 'base' }, { cwd: project }) as { systemPrompt: string };
+        assert.match(result.systemPrompt, /# Framework Profile/);
+        assert.match(result.systemPrompt, /# C# Conventions/);
+        assert.match(result.systemPrompt, /# How to write documentation/);
+        assert.doesNotMatch(result.systemPrompt, /# Vertical Slice Architecture/);
+        assert.doesNotMatch(result.systemPrompt, /# TypeScript Conventions/);
+    } finally {
+        rmSync(project, { recursive: true, force: true });
+    }
+});
+
 test('Pi resolves configured profile composition through selected languages', () => {
     const project = mkdtempSync(join(tmpdir(), 'cratis-pi-'));
     try {


### PR DESCRIPTION
## Fixed
- Apply `.cratis/ai.json` profile and language selections to native Pi package rules as well as skills.
- Framework C# and documentation repositories receive framework, C#, documentation, and universal rules without application vertical-slice or TypeScript guidance.
- Preserve the all-rules fallback when no configuration exists.

## Verification
- Pi and verification TypeScript checks pass.
- Five Pi behavior specifications pass, including explicit framework C# rule inclusion and application/TypeScript exclusion.
- Corpus verification passes.