### PR TITLE
Expose all available AI languages

### DIFF
--- a/.cratis/ai/manifest.json
+++ b/.cratis/ai/manifest.json
@@ -79,9 +79,15 @@
   ],
   "languages": [
     "csharp",
-    "typescript",
+    "elixir",
+    "java",
     "kotlin",
-    "elixir"
+    "language-agnostic",
+    "markdown",
+    "python",
+    "react",
+    "shell",
+    "typescript"
   ],
   "profileCatalog": "profile-catalog.json"
 }

--- a/Source/Verification/verify.ts
+++ b/Source/Verification/verify.ts
@@ -98,6 +98,9 @@ const profileIds = new Set(profiles.map(profile => profile.id));
 const declaredProfiles: string[] = manifest.profiles ?? [];
 const catalogProfiles = [...profileIds].sort();
 if (JSON.stringify(declaredProfiles) !== JSON.stringify(catalogProfiles)) failures.push('Manifest profiles must list every catalog profile in sorted order.');
+const declaredLanguages: string[] = manifest.languages ?? [];
+const catalogLanguages = [...new Set(profiles.flatMap(profile => profile.languages ?? []))].sort();
+if (JSON.stringify(declaredLanguages) !== JSON.stringify(catalogLanguages)) failures.push('Manifest languages must list every catalog language in sorted order.');
 for (const profile of profiles) {
     for (const composed of profile.composes ?? []) {
         if (!profileIds.has(composed)) failures.push(`Profile '${profile.id}' composes missing profile '${composed}'.`);


### PR DESCRIPTION
## Fixed
- Publish every language represented by the profile catalog through `.cratis/ai/manifest.json`.
- Verify exact profile-catalog and installation-manifest language parity.

This enables language-agnostic, Markdown, Python, Java, React, and shell repositories to select honest language values during managed installation.

## Verification
- Verification and Pi TypeScript checks pass.
- Corpus verification reports 53 skills and 66 profiles.