### PR TITLE
Skip quality follow-ups in noninteractive Pi

### DIFF
--- a/.cratis/ai/harnesses/pi/extensions/cratis-hooks/index.ts
+++ b/.cratis/ai/harnesses/pi/extensions/cratis-hooks/index.ts
@@ -186,6 +186,7 @@ export default function (pi: ExtensionAPI) {
 
 	// ── Stop → quality gate (re-runs the gates the change touched; keeps the model going on failure) ──
 	pi.on("agent_settled", async (_event, ctx) => {
+		if (ctx.mode === "print" || ctx.mode === "json") return;
 		if (!isInstalled(qualityGate)) return;
 		const payload = JSON.stringify({
 			session_id: ctx.sessionManager.getSessionId?.() ?? "nosession",

--- a/Source/Verification/pi-plugin.spec.ts
+++ b/Source/Verification/pi-plugin.spec.ts
@@ -8,6 +8,7 @@ import { join, resolve } from 'node:path';
 import test from 'node:test';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import registerPiPlugin, { selectedSkillPaths } from '../Pi.Plugin/src/index.ts';
+import registerCratisHooks from '../../.cratis/ai/harnesses/pi/extensions/cratis-hooks/index.ts';
 import { managedRules } from '../../.cratis/ai/harnesses/pi/extensions/cratis-rules/index.ts';
 
 const repositoryRoot = resolve(import.meta.dirname, '..', '..');
@@ -55,6 +56,17 @@ test('the Pi package yields to a managed CLI installation', () => {
     } finally {
         rmSync(project, { recursive: true, force: true });
     }
+});
+
+test('Cratis quality hooks do not continue a completed noninteractive session', async () => {
+    let settled: ((event: unknown, context: { mode: string }) => Promise<void>) | undefined;
+    registerCratisHooks({
+        on(name: string, handler: unknown) {
+            if (name === 'agent_settled') settled = handler as typeof settled;
+        },
+    } as unknown as ExtensionAPI);
+    assert.ok(settled);
+    await assert.doesNotReject(() => settled!({}, { mode: 'print' }));
 });
 
 test('the Pi package filters rules for framework CSharp documentation repositories', () => {


### PR DESCRIPTION
## Fixed
- Do not queue quality-gate follow-up turns after Pi print or JSON sessions have completed.
- Prevent stale extension-context errors from masking the original noninteractive result.

## Verification
- Pi and verification TypeScript checks pass.
- Six Pi behavior specifications pass, including the noninteractive session lifecycle.